### PR TITLE
fix: authorize plane CRs created after agent connects

### DIFF
--- a/internal/cluster-gateway/connection_manager.go
+++ b/internal/cluster-gateway/connection_manager.go
@@ -31,6 +31,7 @@ type AgentConnection struct {
 	LastSeen        time.Time
 	ValidCRs        []string          // List of CRs (namespace/name) this connection is authorized for
 	clientCert      *x509.Certificate // Client certificate for re-validation on CR updates
+	intermediates   *x509.CertPool    // Handshake intermediate CAs, used to chain the client cert on re-validation
 	mu              sync.Mutex
 }
 
@@ -105,10 +106,15 @@ func (ac *AgentConnection) UpdateCRValidity(crKey string, certPool *x509.CertPoo
 
 	wasValid := slices.Contains(ac.ValidCRs, crKey)
 
-	// Verify connection's client cert against CA pool
+	// Verify against the CA pool, including the handshake intermediates so a cert
+	// issued by an intermediate can still chain to the CR's CA (mirrors connect-time
+	// verification; without it, CRs created after connect are never authorized).
 	opts := x509.VerifyOptions{
 		Roots:     certPool,
 		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	if ac.intermediates != nil {
+		opts.Intermediates = ac.intermediates
 	}
 
 	_, verifyErr := ac.clientCert.Verify(opts)
@@ -161,6 +167,7 @@ func (cm *ConnectionManager) Register(
 	conn Connection,
 	validCRs []string,
 	clientCert *x509.Certificate,
+	intermediates *x509.CertPool,
 ) (string, error) {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
@@ -179,6 +186,7 @@ func (cm *ConnectionManager) Register(
 		LastSeen:        now,
 		ValidCRs:        validCRs,
 		clientCert:      clientCert,
+		intermediates:   intermediates,
 	}
 
 	// Store by planeIdentifier (supports HA - multiple replicas)

--- a/internal/cluster-gateway/connection_manager_test.go
+++ b/internal/cluster-gateway/connection_manager_test.go
@@ -236,6 +236,95 @@ func TestAgentConnection_UpdateCRValidity(t *testing.T) {
 	})
 }
 
+// Regression test: when the client cert is issued by an intermediate CA and the CR's CA
+// is the root only, incremental re-validation must use the handshake intermediates to
+// chain to the root, otherwise CRs created after the agent connects are never authorized.
+func TestAgentConnection_UpdateCRValidity_WithIntermediates(t *testing.T) {
+	// root CA -> intermediate CA -> client cert
+	rootCA, rootKey := generateTestCA(t)
+
+	intermediateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	intermediateTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(20),
+		Subject:               pkix.Name{CommonName: "Intermediate CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	intermediateDER, err := x509.CreateCertificate(rand.Reader, intermediateTemplate, rootCA, &intermediateKey.PublicKey, rootKey)
+	require.NoError(t, err)
+	intermediateCert, err := x509.ParseCertificate(intermediateDER)
+	require.NoError(t, err)
+
+	clientCert := generateTestClientCert(t, intermediateCert, intermediateKey)
+
+	// The CR's CA pool contains only the root (single cert, no chain).
+	rootPool := x509.NewCertPool()
+	rootPool.AddCert(rootCA)
+
+	t.Run("without intermediates - cannot chain, not granted (the bug)", func(t *testing.T) {
+		ac := &AgentConnection{
+			ValidCRs:   []string{},
+			clientCert: clientCert,
+			// intermediates deliberately nil
+		}
+
+		granted, revoked, err := ac.UpdateCRValidity("ns/dp1", rootPool)
+		assert.False(t, granted)
+		assert.False(t, revoked)
+		assert.NoError(t, err)
+		assert.NotContains(t, ac.GetValidCRs(), "ns/dp1")
+	})
+
+	t.Run("with intermediates - chains to root, authorization granted (the fix)", func(t *testing.T) {
+		ac := &AgentConnection{
+			ValidCRs:      []string{},
+			clientCert:    clientCert,
+			intermediates: buildIntermediatePool([]*x509.Certificate{intermediateCert}),
+		}
+
+		granted, revoked, err := ac.UpdateCRValidity("ns/dp1", rootPool)
+		assert.True(t, granted)
+		assert.False(t, revoked)
+		assert.NoError(t, err)
+		assert.Contains(t, ac.GetValidCRs(), "ns/dp1")
+	})
+
+	t.Run("no intermediates - client signed directly by CR CA, still granted", func(t *testing.T) {
+		// Common case: client cert issued directly by the CR's CA, no handshake
+		// intermediates. Behavior must be unchanged by the fix.
+		directCA, directKey := generateTestCA(t)
+		directClient := generateTestClientCert(t, directCA, directKey)
+
+		directPool := x509.NewCertPool()
+		directPool.AddCert(directCA)
+
+		ac := &AgentConnection{
+			ValidCRs:      []string{},
+			clientCert:    directClient,
+			intermediates: buildIntermediatePool(nil), // nil - no handshake intermediates
+		}
+		require.Nil(t, ac.intermediates)
+
+		granted, revoked, err := ac.UpdateCRValidity("ns/dp1", directPool)
+		assert.True(t, granted)
+		assert.False(t, revoked)
+		assert.NoError(t, err)
+		assert.Contains(t, ac.GetValidCRs(), "ns/dp1")
+	})
+}
+
+func TestBuildIntermediatePool(t *testing.T) {
+	assert.Nil(t, buildIntermediatePool(nil), "nil slice should yield a nil pool")
+	assert.Nil(t, buildIntermediatePool([]*x509.Certificate{}), "empty slice should yield a nil pool")
+
+	caCert, _ := generateTestCA(t)
+	assert.NotNil(t, buildIntermediatePool([]*x509.Certificate{caCert}), "non-empty slice should yield a non-nil pool")
+}
+
 // --- ConnectionManager Tests ---
 
 func TestConnectionManager_Register(t *testing.T) {
@@ -243,7 +332,7 @@ func TestConnectionManager_Register(t *testing.T) {
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
 
-	connID, err := cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil)
+	connID, err := cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil, nil)
 	require.NoError(t, err)
 	assert.NotEmpty(t, connID)
 	assert.Equal(t, 1, cm.Count())
@@ -257,9 +346,9 @@ func TestConnectionManager_Register_HA(t *testing.T) {
 	conn2, cleanup2 := newTestWSConn(t)
 	defer cleanup2()
 
-	id1, err := cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil)
+	id1, err := cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil, nil)
 	require.NoError(t, err)
-	id2, err := cm.Register("dataplane", "prod", conn2, []string{"ns/dp1"}, nil)
+	id2, err := cm.Register("dataplane", "prod", conn2, []string{"ns/dp1"}, nil, nil)
 	require.NoError(t, err)
 
 	assert.NotEqual(t, id1, id2)
@@ -271,7 +360,7 @@ func TestConnectionManager_Unregister(t *testing.T) {
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
 
-	connID, err := cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil)
+	connID, err := cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, cm.Count())
 
@@ -295,8 +384,8 @@ func TestConnectionManager_Get_RoundRobin(t *testing.T) {
 	conn2, cleanup2 := newTestWSConn(t)
 	defer cleanup2()
 
-	id1, _ := cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil)
-	id2, _ := cm.Register("dataplane", "prod", conn2, []string{"ns/dp1"}, nil)
+	id1, _ := cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil, nil)
+	id2, _ := cm.Register("dataplane", "prod", conn2, []string{"ns/dp1"}, nil, nil)
 
 	// Round-robin should alternate between connections
 	got1, err := cm.Get("dataplane/prod")
@@ -328,8 +417,8 @@ func TestConnectionManager_GetForCR(t *testing.T) {
 	defer cleanup2()
 
 	// conn1 is authorized for ns/dp1, conn2 for ns/dp2
-	_, _ = cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil)
-	id2, _ := cm.Register("dataplane", "prod", conn2, []string{"ns/dp2"}, nil)
+	_, _ = cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil, nil)
+	id2, _ := cm.Register("dataplane", "prod", conn2, []string{"ns/dp2"}, nil, nil)
 
 	got, err := cm.GetForCR("dataplane/prod", "ns/dp2")
 	require.NoError(t, err)
@@ -342,7 +431,7 @@ func TestConnectionManager_GetForCR_NoneAuthorized(t *testing.T) {
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
 
-	_, _ = cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil)
+	_, _ = cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil, nil)
 
 	_, err := cm.GetForCR("dataplane/prod", "ns/dp99")
 	assert.Error(t, err)
@@ -357,8 +446,8 @@ func TestConnectionManager_GetAll(t *testing.T) {
 	conn2, cleanup2 := newTestWSConn(t)
 	defer cleanup2()
 
-	_, _ = cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil)
-	_, _ = cm.Register("workflowplane", "ci", conn2, []string{"ns/wp1"}, nil)
+	_, _ = cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil, nil)
+	_, _ = cm.Register("workflowplane", "ci", conn2, []string{"ns/wp1"}, nil, nil)
 
 	all := cm.GetAll()
 	assert.Len(t, all, 2)
@@ -373,10 +462,10 @@ func TestConnectionManager_Count(t *testing.T) {
 	conn2, cleanup2 := newTestWSConn(t)
 	defer cleanup2()
 
-	_, _ = cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil)
+	_, _ = cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil, nil)
 	assert.Equal(t, 1, cm.Count())
 
-	_, _ = cm.Register("workflowplane", "ci", conn2, []string{"ns/wp1"}, nil)
+	_, _ = cm.Register("workflowplane", "ci", conn2, []string{"ns/wp1"}, nil, nil)
 	assert.Equal(t, 2, cm.Count())
 }
 
@@ -386,7 +475,7 @@ func TestConnectionManager_UpdateConnectionLastSeen(t *testing.T) {
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
 
-	connID, _ := cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil)
+	connID, _ := cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil, nil)
 
 	beforeUpdate, err := cm.Get("dataplane/prod")
 	require.NoError(t, err)
@@ -412,9 +501,9 @@ func TestConnectionManager_DisconnectAllForPlane(t *testing.T) {
 	conn3, cleanup3 := newTestWSConn(t)
 	defer cleanup3()
 
-	_, _ = cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil)
-	_, _ = cm.Register("dataplane", "prod", conn2, []string{"ns/dp2"}, nil)
-	_, _ = cm.Register("workflowplane", "ci", conn3, []string{"ns/wp1"}, nil)
+	_, _ = cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil, nil)
+	_, _ = cm.Register("dataplane", "prod", conn2, []string{"ns/dp2"}, nil, nil)
+	_, _ = cm.Register("workflowplane", "ci", conn3, []string{"ns/wp1"}, nil, nil)
 
 	disconnected := cm.DisconnectAllForPlane("dataplane", "prod")
 	assert.Equal(t, 2, disconnected)
@@ -431,7 +520,7 @@ func TestConnectionManager_GetPlaneStatus(t *testing.T) {
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
 
-	_, _ = cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil)
+	_, _ = cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil, nil)
 
 	status := cm.GetPlaneStatus("dataplane", "prod")
 	assert.True(t, status.Connected)
@@ -458,8 +547,8 @@ func TestConnectionManager_GetCRAuthorizationStatus(t *testing.T) {
 	defer cleanup2()
 
 	// conn1 authorized for ns/dp1, conn2 authorized for ns/dp2
-	_, _ = cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil)
-	_, _ = cm.Register("dataplane", "prod", conn2, []string{"ns/dp2"}, nil)
+	_, _ = cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil, nil)
+	_, _ = cm.Register("dataplane", "prod", conn2, []string{"ns/dp2"}, nil, nil)
 
 	// Check authorization for ns/dp1 - only 1 agent authorized
 	status := cm.GetCRAuthorizationStatus("dataplane", "prod", "ns", "dp1")
@@ -480,8 +569,8 @@ func TestConnectionManager_GetAllPlaneStatuses(t *testing.T) {
 	conn2, cleanup2 := newTestWSConn(t)
 	defer cleanup2()
 
-	_, _ = cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil)
-	_, _ = cm.Register("workflowplane", "ci", conn2, []string{"ns/wp1"}, nil)
+	_, _ = cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil, nil)
+	_, _ = cm.Register("workflowplane", "ci", conn2, []string{"ns/wp1"}, nil, nil)
 
 	statuses := cm.GetAllPlaneStatuses()
 	assert.Len(t, statuses, 2)
@@ -525,7 +614,7 @@ func TestConnectionManager_RevalidateCR(t *testing.T) {
 		defer cleanup()
 
 		// Register with no valid CRs, but with a client cert signed by the CA
-		_, _ = cm.Register("dataplane", "prod", conn, []string{}, clientCert)
+		_, _ = cm.Register("dataplane", "prod", conn, []string{}, clientCert, nil)
 
 		updated, removed, err := cm.RevalidateCR("dataplane", "prod", "ns", "dp1", caPEM)
 		require.NoError(t, err)
@@ -539,7 +628,7 @@ func TestConnectionManager_RevalidateCR(t *testing.T) {
 		defer cleanup()
 
 		// Register with valid CR
-		_, _ = cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, clientCert)
+		_, _ = cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, clientCert, nil)
 
 		// Generate a different CA
 		otherCACert, _ := generateTestCA(t)
@@ -565,7 +654,7 @@ func TestConnectionManager_RevalidateCR(t *testing.T) {
 		conn, cleanup := newTestWSConn(t)
 		defer cleanup()
 
-		_, _ = cm.Register("dataplane", "prod", conn, []string{}, clientCert)
+		_, _ = cm.Register("dataplane", "prod", conn, []string{}, clientCert, nil)
 
 		_, _, err := cm.RevalidateCR("dataplane", "prod", "ns", "dp1", []byte("not-valid-pem"))
 		assert.Error(t, err)
@@ -594,8 +683,8 @@ func TestConnectionManager_CleanupOrphanedCRKeys(t *testing.T) {
 	defer cleanup2()
 
 	// Register two connections: conn1 for dp1+dp2, conn2 for dp2 only
-	_, _ = cm.Register("dataplane", "prod", conn1, []string{"ns/dp1", "ns/dp2"}, nil)
-	id2, _ := cm.Register("dataplane", "prod", conn2, []string{"ns/dp2"}, nil)
+	_, _ = cm.Register("dataplane", "prod", conn1, []string{"ns/dp1", "ns/dp2"}, nil, nil)
+	id2, _ := cm.Register("dataplane", "prod", conn2, []string{"ns/dp2"}, nil, nil)
 
 	// Do a GetForCR to create per-CR round-robin keys
 	_, _ = cm.GetForCR("dataplane/prod", "ns/dp1")
@@ -619,8 +708,8 @@ func TestConnectionManager_Unregister_PartialCleanup(t *testing.T) {
 	defer cleanup2()
 
 	// conn1 authorized for dp1 only, conn2 authorized for dp1 + dp2
-	id1, _ := cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil)
-	_, _ = cm.Register("dataplane", "prod", conn2, []string{"ns/dp1", "ns/dp2"}, nil)
+	id1, _ := cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil, nil)
+	_, _ = cm.Register("dataplane", "prod", conn2, []string{"ns/dp1", "ns/dp2"}, nil, nil)
 
 	// Access dp1 via GetForCR to create round-robin key
 	_, _ = cm.GetForCR("dataplane/prod", "ns/dp1")
@@ -649,11 +738,11 @@ func TestConnectionManager_GetPlaneStatus_MultipleConnections(t *testing.T) {
 	conn2, cleanup2 := newTestWSConn(t)
 	defer cleanup2()
 
-	_, _ = cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil)
+	_, _ = cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil, nil)
 
 	// Small delay so conn2 has a later LastSeen
 	time.Sleep(10 * time.Millisecond)
-	connID2, _ := cm.Register("dataplane", "prod", conn2, []string{"ns/dp1"}, nil)
+	connID2, _ := cm.Register("dataplane", "prod", conn2, []string{"ns/dp1"}, nil, nil)
 
 	// Update conn2 LastSeen to be newer
 	time.Sleep(10 * time.Millisecond)
@@ -673,10 +762,10 @@ func TestConnectionManager_GetAllPlaneStatuses_MultipleConnsPerPlane(t *testing.
 	conn2, cleanup2 := newTestWSConn(t)
 	defer cleanup2()
 
-	_, _ = cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil)
+	_, _ = cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil, nil)
 
 	time.Sleep(10 * time.Millisecond)
-	connID2, _ := cm.Register("dataplane", "prod", conn2, []string{"ns/dp2"}, nil)
+	connID2, _ := cm.Register("dataplane", "prod", conn2, []string{"ns/dp2"}, nil, nil)
 	time.Sleep(10 * time.Millisecond)
 	cm.UpdateConnectionLastSeen("dataplane/prod", connID2)
 
@@ -707,8 +796,8 @@ func TestConnectionManager_Unregister_CleansUpOrphanedCRKeys(t *testing.T) {
 	defer cleanup2()
 
 	// conn1 has unique CR "ns/dp-unique", conn2 has shared CR "ns/dp-shared"
-	id1, _ := cm.Register("dataplane", "prod", conn1, []string{"ns/dp-unique", "ns/dp-shared"}, nil)
-	_, _ = cm.Register("dataplane", "prod", conn2, []string{"ns/dp-shared"}, nil)
+	id1, _ := cm.Register("dataplane", "prod", conn1, []string{"ns/dp-unique", "ns/dp-shared"}, nil, nil)
+	_, _ = cm.Register("dataplane", "prod", conn2, []string{"ns/dp-shared"}, nil, nil)
 
 	// Access both CRs to create round-robin keys
 	_, _ = cm.GetForCR("dataplane/prod", "ns/dp-unique")
@@ -736,8 +825,8 @@ func TestConnectionManager_GetForCR_RoundRobin(t *testing.T) {
 	defer cleanup2()
 
 	// Both connections authorized for the same CR
-	id1, _ := cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil)
-	id2, _ := cm.Register("dataplane", "prod", conn2, []string{"ns/dp1"}, nil)
+	id1, _ := cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil, nil)
+	id2, _ := cm.Register("dataplane", "prod", conn2, []string{"ns/dp1"}, nil, nil)
 
 	got1, err := cm.GetForCR("dataplane/prod", "ns/dp1")
 	require.NoError(t, err)
@@ -756,7 +845,7 @@ func TestConnectionManager_Unregister_LastConnection_CleansRRKeys(t *testing.T) 
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
 
-	connID, _ := cm.Register("dataplane", "prod", conn, []string{"ns/dp1", "ns/dp2"}, nil)
+	connID, _ := cm.Register("dataplane", "prod", conn, []string{"ns/dp1", "ns/dp2"}, nil, nil)
 
 	// Access CRs to create per-CR round-robin keys
 	_, _ = cm.GetForCR("dataplane/prod", "ns/dp1")
@@ -778,7 +867,7 @@ func TestConnectionManager_DisconnectAllForPlane_CleansRRKeys(t *testing.T) {
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
 
-	_, _ = cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil)
+	_, _ = cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil, nil)
 
 	// Create per-CR round-robin key
 	_, _ = cm.GetForCR("dataplane/prod", "ns/dp1")
@@ -799,7 +888,7 @@ func TestConnectionManager_RevalidateCR_UnchangedStatus(t *testing.T) {
 	defer cleanup()
 
 	// Register with CR already valid
-	_, _ = cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, clientCert)
+	_, _ = cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, clientCert, nil)
 
 	// Revalidate with same CA — should be unchanged (still valid)
 	updated, removed, err := cm.RevalidateCR("dataplane", "prod", "ns", "dp1", caPEM)

--- a/internal/cluster-gateway/plane_api_test.go
+++ b/internal/cluster-gateway/plane_api_test.go
@@ -46,7 +46,7 @@ func TestHandlePlaneNotification_Deleted(t *testing.T) {
 	// Register a connection so there's something to disconnect
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
-	_, err := cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil)
+	_, err := cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil, nil)
 	require.NoError(t, err)
 
 	notification := PlaneNotification{
@@ -218,7 +218,7 @@ func TestHandleReconnect(t *testing.T) {
 
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
-	_, err := cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil)
+	_, err := cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil, nil)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/planes/dataplane/prod/reconnect", nil)
@@ -238,7 +238,7 @@ func TestHandleGetPlaneStatus(t *testing.T) {
 
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
-	_, err := cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil)
+	_, err := cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil, nil)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/planes/dataplane/prod/status", nil)
@@ -260,7 +260,7 @@ func TestHandleGetPlaneStatus_CRSpecific(t *testing.T) {
 
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
-	_, err := cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil)
+	_, err := cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil, nil)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/planes/dataplane/prod/status?namespace=ns&name=dp1", nil)
@@ -281,7 +281,7 @@ func TestHandleGetPlaneStatus_ClusterScoped(t *testing.T) {
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
 	// Cluster-scoped CR key format: "/name"
-	_, err := cm.Register("dataplane", "prod", conn, []string{"/global-dp"}, nil)
+	_, err := cm.Register("dataplane", "prod", conn, []string{"/global-dp"}, nil, nil)
 	require.NoError(t, err)
 
 	// Cluster-scoped: name only, no namespace
@@ -305,9 +305,9 @@ func TestHandleGetAllPlaneStatus(t *testing.T) {
 	conn2, cleanup2 := newTestWSConn(t)
 	defer cleanup2()
 
-	_, err := cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil)
+	_, err := cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil, nil)
 	require.NoError(t, err)
-	_, err = cm.Register("workflowplane", "ci", conn2, []string{"ns/wp1"}, nil)
+	_, err = cm.Register("workflowplane", "ci", conn2, []string{"ns/wp1"}, nil, nil)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/planes/status", nil)
@@ -441,7 +441,7 @@ func TestHandlePlaneNotification_RevalidationError(t *testing.T) {
 	// Register a connection so RevalidateCR is actually called (with no client cert → will fail)
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
-	_, err := cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil)
+	_, err := cm.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil, nil)
 	require.NoError(t, err)
 
 	notification := PlaneNotification{

--- a/internal/cluster-gateway/server.go
+++ b/internal/cluster-gateway/server.go
@@ -336,9 +336,13 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	clientCert := peerCerts[0]
 	intermediates := peerCerts[1:]
 
+	// Build the handshake intermediate pool once; reused for connect-time validation
+	// and later incremental re-validation (see AgentConnection.UpdateCRValidity).
+	intermediatePool := buildIntermediatePool(intermediates)
+
 	// Per-CR certificate validation enforces security boundaries
 	// Each CR is validated independently to prevent cross-tenant access
-	validCRs, err := s.verifyClientCertificatePerCR(clientCert, intermediates, planeType, planeID)
+	validCRs, err := s.verifyClientCertificatePerCR(clientCert, intermediatePool, planeType, planeID)
 	if err != nil {
 		s.logger.Warn("per-CR certificate verification failed",
 			"planeType", planeType,
@@ -359,7 +363,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	// Register the connection with validated CR list and client certificate
 	// Multiple agent replicas for the same plane will share the same identifier for HA
-	connID, err := s.connMgr.Register(planeType, planeID, conn, validCRs, clientCert)
+	connID, err := s.connMgr.Register(planeType, planeID, conn, validCRs, clientCert, intermediatePool)
 	if err != nil {
 		s.logger.Error("failed to register connection", "error", err)
 		conn.Close()
@@ -747,12 +751,25 @@ func (s *Server) GetConnectionManager() *ConnectionManager {
 	return s.connMgr
 }
 
+// buildIntermediatePool builds an x509 cert pool from the intermediate certificates
+// presented during the TLS handshake. Returns nil when there are no intermediates.
+func buildIntermediatePool(intermediates []*x509.Certificate) *x509.CertPool {
+	if len(intermediates) == 0 {
+		return nil
+	}
+	pool := x509.NewCertPool()
+	for _, ic := range intermediates {
+		pool.AddCert(ic)
+	}
+	return pool
+}
+
 // verifyClientCertificatePerCR validates the client certificate against EACH CR individually
 // and returns a list of CRs (namespace/name) that the certificate is valid for.
 // This enforces per-CR security boundaries in multi-tenant scenarios.
 func (s *Server) verifyClientCertificatePerCR(
 	clientCert *x509.Certificate,
-	intermediates []*x509.Certificate,
+	intermediatePool *x509.CertPool,
 	planeType, planeID string,
 ) (validCRs []string, err error) {
 	clientCN := clientCert.Subject.CommonName
@@ -777,14 +794,6 @@ func (s *Server) verifyClientCertificatePerCR(
 			"planeID", planeID,
 		)
 		return nil, fmt.Errorf("no %s CRs found with planeID '%s'", planeType, planeID)
-	}
-
-	var intermediatePool *x509.CertPool
-	if len(intermediates) > 0 {
-		intermediatePool = x509.NewCertPool()
-		for _, ic := range intermediates {
-			intermediatePool.AddCert(ic)
-		}
 	}
 
 	validCRs = []string{}

--- a/internal/cluster-gateway/server_test.go
+++ b/internal/cluster-gateway/server_test.go
@@ -267,7 +267,7 @@ func TestSendHTTPTunnelRequest_Timeout(t *testing.T) {
 	// Register a connection
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
-	_, _ = s.connMgr.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil)
+	_, _ = s.connMgr.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil, nil)
 
 	req := &messaging.HTTPTunnelRequest{
 		Target: "k8s",
@@ -311,7 +311,7 @@ func TestSendHTTPTunnelRequestForCR_NoAuthorizedAgent(t *testing.T) {
 
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
-	_, _ = s.connMgr.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil)
+	_, _ = s.connMgr.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil, nil)
 
 	req := &messaging.HTTPTunnelRequest{
 		Target: "k8s",
@@ -332,7 +332,7 @@ func TestSendHTTPTunnelRequestForCR_Success(t *testing.T) {
 
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
-	_, _ = s.connMgr.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil)
+	_, _ = s.connMgr.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil, nil)
 
 	req := &messaging.HTTPTunnelRequest{
 		Target: "k8s",
@@ -556,7 +556,7 @@ func TestVerifyClientCertificatePerCR_WithIntermediates(t *testing.T) {
 	s := &Server{k8sClient: fakeClient, logger: testLogger()}
 
 	// Pass intermediate cert chain
-	validCRs, err := s.verifyClientCertificatePerCR(clientCert, []*x509.Certificate{intermediateCert}, "dataplane", "prod")
+	validCRs, err := s.verifyClientCertificatePerCR(clientCert, buildIntermediatePool([]*x509.Certificate{intermediateCert}), "dataplane", "prod")
 	require.NoError(t, err)
 	assert.Contains(t, validCRs, "ns/dp1")
 }
@@ -586,7 +586,7 @@ func TestHandleHTTPProxy_CRAuthorizationFailed(t *testing.T) {
 	// Register agent but only for ns/dp1
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
-	_, _ = s.connMgr.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil)
+	_, _ = s.connMgr.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil, nil)
 
 	// Request for a different CR
 	req := httptest.NewRequest(http.MethodGet, "/api/proxy/dataplane/prod/ns/dp-other/k8s/api/v1/pods", nil)
@@ -606,7 +606,7 @@ func TestHandleHTTPProxy_ClusterScopedCRNamespace(t *testing.T) {
 	// Register agent for cluster-scoped CR only (key format: "/crName")
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
-	_, _ = s.connMgr.Register("dataplane", "prod", conn, []string{"/global-dp"}, nil)
+	_, _ = s.connMgr.Register("dataplane", "prod", conn, []string{"/global-dp"}, nil, nil)
 
 	// Request with _cluster namespace but a different CR name → should get 403 (not found)
 	// This verifies _cluster is mapped to empty namespace forming key "/wrong-dp"
@@ -627,7 +627,7 @@ func TestHandleHTTPProxy_Success(t *testing.T) {
 
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
-	_, _ = s.connMgr.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil)
+	_, _ = s.connMgr.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil, nil)
 
 	// Run proxy request in goroutine (it blocks waiting for tunnel response)
 	req := httptest.NewRequest(http.MethodGet, "/api/proxy/dataplane/prod/ns/dp1/k8s/api/v1/pods", nil)
@@ -678,7 +678,7 @@ func TestSendHTTPTunnelRequestForCR_Timeout(t *testing.T) {
 
 	conn, cleanup := newTestWSConn(t)
 	defer cleanup()
-	_, _ = s.connMgr.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil)
+	_, _ = s.connMgr.Register("dataplane", "prod", conn, []string{"ns/dp1"}, nil, nil)
 
 	req := &messaging.HTTPTunnelRequest{
 		Target: "k8s",
@@ -786,7 +786,7 @@ func TestHandleConnection_ProcessesMessages(t *testing.T) {
 	s.requestsMu.Unlock()
 
 	// Register the mock connection in connMgr
-	connID, err := s.connMgr.Register("dataplane", "prod", mock, []string{"ns/dp1"}, nil)
+	connID, err := s.connMgr.Register("dataplane", "prod", mock, []string{"ns/dp1"}, nil, nil)
 	require.NoError(t, err)
 
 	s.handleConnection("dataplane/prod", connID, mock)
@@ -810,7 +810,7 @@ func TestHandleConnection_InvalidMessage(t *testing.T) {
 		readMessages: [][]byte{[]byte("not json")},
 	}
 
-	connID, err := s.connMgr.Register("dataplane", "prod", mock, []string{"ns/dp1"}, nil)
+	connID, err := s.connMgr.Register("dataplane", "prod", mock, []string{"ns/dp1"}, nil, nil)
 	require.NoError(t, err)
 
 	// Should not panic — skips invalid message and exits when no more messages
@@ -833,7 +833,7 @@ func TestHandleConnection_MissingRequestID(t *testing.T) {
 		readMessages: [][]byte{data},
 	}
 
-	connID, err := s.connMgr.Register("dataplane", "prod", mock, []string{"ns/dp1"}, nil)
+	connID, err := s.connMgr.Register("dataplane", "prod", mock, []string{"ns/dp1"}, nil, nil)
 	require.NoError(t, err)
 
 	// Should skip message and exit
@@ -853,7 +853,7 @@ func TestHandleConnection_UnexpectedClose(t *testing.T) {
 		},
 	}
 
-	connID, err := s.connMgr.Register("dataplane", "prod", mock, []string{"ns/dp1"}, nil)
+	connID, err := s.connMgr.Register("dataplane", "prod", mock, []string{"ns/dp1"}, nil, nil)
 	require.NoError(t, err)
 
 	// Should log "websocket error" and return
@@ -873,7 +873,7 @@ func TestHandleConnection_NormalClose(t *testing.T) {
 		},
 	}
 
-	connID, err := s.connMgr.Register("dataplane", "prod", mock, []string{"ns/dp1"}, nil)
+	connID, err := s.connMgr.Register("dataplane", "prod", mock, []string{"ns/dp1"}, nil, nil)
 	require.NoError(t, err)
 
 	// Should log "agent disconnected" and return


### PR DESCRIPTION
## Purpose
> Briefly describe the problem or need driving this PR and how it resolves the issue.

A plane CR (e.g. a `DataPlane`) that is **created after** an agent's WebSocket connection to `cluster-gateway` is already established never gets authorized on that existing connection. It stays permanently at `status.agentConnection.connected: false` / `"No agents connected"`, even though the agent is healthy and serves every CR that existed at connect time. The only recovery is restarting `cluster-gateway` to force the agent to reconnect.

Root cause is an asymmetry in certificate verification between the connect-time path and the incremental re-validation path:

- **Connect path** — `verifyClientCertificatePerCR` verifies the agent's client cert against each CR's CA **with `opts.Intermediates`** set from the TLS handshake chain.
- **Incremental path** — `POST /api/v1/planes/notify` (`created`/`updated`) → `RevalidateCR` → `UpdateCRValidity` verified the cert **without** setting `opts.Intermediates`, building the pool from only the CR's own `ca.crt`.

When the agent's client cert is issued by an intermediate CA and the CR's CA holds only the root (no chain), the intermediate-less verify cannot build a chain, so the newly-created CR is never added to the connection's authorized set.

Resolves #4411.

## Approach
> Summarize the solution and implementation details.

Capture the handshake intermediates on the connection at register time and reuse them during incremental re-validation, mirroring the connect-time path:

- `AgentConnection` gains an unexported `intermediates *x509.CertPool` field.
- `UpdateCRValidity` sets `opts.Intermediates = ac.intermediates` when present (nil-guarded — no behavior change when there are no intermediates).
- `Register` accepts and stores the intermediates pool.
- `server.go` adds a `buildIntermediatePool(...)` helper; `handleWebSocket` builds the pool once and passes it to both `verifyClientCertificatePerCR` and `Register` (the previous inline pool-building in `verifyClientCertificatePerCR` is folded into the helper).

The common case — client cert issued directly by the CR's CA with no intermediates — is unchanged: `buildIntermediatePool` returns `nil` and the verify options are identical to before.

## Related Issues
> Include any related issues that are resolved by this PR.

- Fixes #4411

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.

New/updated tests in `internal/cluster-gateway`:

- `TestAgentConnection_UpdateCRValidity_WithIntermediates` — covers three cases: intermediate-issued cert **without** stored intermediates (reproduces the bug → not granted), **with** stored intermediates (the fix → granted), and a directly-signed cert with no intermediates (unchanged → granted).
- `TestBuildIntermediatePool` — nil/empty input yields a nil pool; non-empty yields a non-nil pool.
- Existing `Register` / `verifyClientCertificatePerCR` call sites updated for the new signatures.

The verification asymmetry affects all planes that use intermediate-issued agent certificates, so a `backport/*` label may be warranted for maintained release branches.
