### PR TITLE
feat(api): list namespace Events for a ReleaseBinding

### DIFF
--- a/internal/openchoreo-api/api/gen/client.gen.go
+++ b/internal/openchoreo-api/api/gen/client.gen.go
@@ -625,6 +625,9 @@ type ClientInterface interface {
 	// GetReleaseBindingK8sResourceLogs request
 	GetReleaseBindingK8sResourceLogs(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params *GetReleaseBindingK8sResourceLogsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetReleaseBindingNamespaceEvents request
+	GetReleaseBindingNamespaceEvents(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params *GetReleaseBindingNamespaceEventsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// GetReleaseBindingK8sResourceTree request
 	GetReleaseBindingK8sResourceTree(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -3224,6 +3227,18 @@ func (c *Client) GetReleaseBindingK8sResourceEvents(ctx context.Context, namespa
 
 func (c *Client) GetReleaseBindingK8sResourceLogs(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params *GetReleaseBindingK8sResourceLogsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetReleaseBindingK8sResourceLogsRequest(c.Server, namespaceName, releaseBindingName, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetReleaseBindingNamespaceEvents(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params *GetReleaseBindingNamespaceEventsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetReleaseBindingNamespaceEventsRequest(c.Server, namespaceName, releaseBindingName, params)
 	if err != nil {
 		return nil, err
 	}
@@ -11738,6 +11753,85 @@ func NewGetReleaseBindingK8sResourceLogsRequest(server string, namespaceName Nam
 	return req, nil
 }
 
+// NewGetReleaseBindingNamespaceEventsRequest generates requests for GetReleaseBindingNamespaceEvents
+func NewGetReleaseBindingNamespaceEventsRequest(server string, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params *GetReleaseBindingNamespaceEventsParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "namespaceName", runtime.ParamLocationPath, namespaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "releaseBindingName", runtime.ParamLocationPath, releaseBindingName)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/namespaces/%s/releasebindings/%s/k8sresources/namespace-events", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Type != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "type", runtime.ParamLocationQuery, *params.Type); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetReleaseBindingK8sResourceTreeRequest generates requests for GetReleaseBindingK8sResourceTree
 func NewGetReleaseBindingK8sResourceTreeRequest(server string, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam) (*http.Request, error) {
 	var err error
@@ -16014,6 +16108,9 @@ type ClientWithResponsesInterface interface {
 	// GetReleaseBindingK8sResourceLogsWithResponse request
 	GetReleaseBindingK8sResourceLogsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params *GetReleaseBindingK8sResourceLogsParams, reqEditors ...RequestEditorFn) (*GetReleaseBindingK8sResourceLogsResp, error)
 
+	// GetReleaseBindingNamespaceEventsWithResponse request
+	GetReleaseBindingNamespaceEventsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params *GetReleaseBindingNamespaceEventsParams, reqEditors ...RequestEditorFn) (*GetReleaseBindingNamespaceEventsResp, error)
+
 	// GetReleaseBindingK8sResourceTreeWithResponse request
 	GetReleaseBindingK8sResourceTreeWithResponse(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, reqEditors ...RequestEditorFn) (*GetReleaseBindingK8sResourceTreeResp, error)
 
@@ -20104,6 +20201,33 @@ func (r GetReleaseBindingK8sResourceLogsResp) StatusCode() int {
 	return 0
 }
 
+type GetReleaseBindingNamespaceEventsResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ResourceEventsResponse
+	JSON400      *BadRequest
+	JSON401      *Unauthorized
+	JSON403      *Forbidden
+	JSON404      *NotFound
+	JSON500      *InternalError
+}
+
+// Status returns HTTPResponse.Status
+func (r GetReleaseBindingNamespaceEventsResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetReleaseBindingNamespaceEventsResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetReleaseBindingK8sResourceTreeResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -23654,6 +23778,15 @@ func (c *ClientWithResponses) GetReleaseBindingK8sResourceLogsWithResponse(ctx c
 		return nil, err
 	}
 	return ParseGetReleaseBindingK8sResourceLogsResp(rsp)
+}
+
+// GetReleaseBindingNamespaceEventsWithResponse request returning *GetReleaseBindingNamespaceEventsResp
+func (c *ClientWithResponses) GetReleaseBindingNamespaceEventsWithResponse(ctx context.Context, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params *GetReleaseBindingNamespaceEventsParams, reqEditors ...RequestEditorFn) (*GetReleaseBindingNamespaceEventsResp, error) {
+	rsp, err := c.GetReleaseBindingNamespaceEvents(ctx, namespaceName, releaseBindingName, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetReleaseBindingNamespaceEventsResp(rsp)
 }
 
 // GetReleaseBindingK8sResourceTreeWithResponse request returning *GetReleaseBindingK8sResourceTreeResp
@@ -32824,6 +32957,67 @@ func ParseGetReleaseBindingK8sResourceLogsResp(rsp *http.Response) (*GetReleaseB
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest ResourcePodLogsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest BadRequest
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest Unauthorized
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest Forbidden
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFound
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetReleaseBindingNamespaceEventsResp parses an HTTP response from a GetReleaseBindingNamespaceEventsWithResponse call
+func ParseGetReleaseBindingNamespaceEventsResp(rsp *http.Response) (*GetReleaseBindingNamespaceEventsResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetReleaseBindingNamespaceEventsResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ResourceEventsResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/openchoreo-api/api/gen/models.gen.go
+++ b/internal/openchoreo-api/api/gen/models.gen.go
@@ -452,6 +452,12 @@ const (
 	WorkloadEndpointVisibilityProject   WorkloadEndpointVisibility = "project"
 )
 
+// Defines values for GetReleaseBindingNamespaceEventsParamsType.
+const (
+	Normal  GetReleaseBindingNamespaceEventsParamsType = "Normal"
+	Warning GetReleaseBindingNamespaceEventsParamsType = "Warning"
+)
+
 // ActionCapability Capabilities for a specific action
 type ActionCapability struct {
 	// Allowed Resources where action is allowed
@@ -5190,6 +5196,18 @@ type GetReleaseBindingK8sResourceLogsParams struct {
 	// SinceSeconds Number of seconds since which to show logs
 	SinceSeconds *int64 `form:"sinceSeconds,omitempty" json:"sinceSeconds,omitempty"`
 }
+
+// GetReleaseBindingNamespaceEventsParams defines parameters for GetReleaseBindingNamespaceEvents.
+type GetReleaseBindingNamespaceEventsParams struct {
+	// Type Filter by event type (Warning or Normal). Omit for all types.
+	Type *GetReleaseBindingNamespaceEventsParamsType `form:"type,omitempty" json:"type,omitempty"`
+
+	// Limit Maximum number of events to return (default 200, max 500)
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+}
+
+// GetReleaseBindingNamespaceEventsParamsType defines parameters for GetReleaseBindingNamespaceEvents.
+type GetReleaseBindingNamespaceEventsParamsType string
 
 // ListResourceReleaseBindingsParams defines parameters for ListResourceReleaseBindings.
 type ListResourceReleaseBindingsParams struct {

--- a/internal/openchoreo-api/api/gen/server.gen.go
+++ b/internal/openchoreo-api/api/gen/server.gen.go
@@ -456,6 +456,9 @@ type ServerInterface interface {
 	// Get pod logs for a release binding
 	// (GET /api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/logs)
 	GetReleaseBindingK8sResourceLogs(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params GetReleaseBindingK8sResourceLogsParams)
+	// List Kubernetes events in the release binding workload namespace
+	// (GET /api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/namespace-events)
+	GetReleaseBindingNamespaceEvents(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params GetReleaseBindingNamespaceEventsParams)
 	// Get K8s resource tree for a release binding
 	// (GET /api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/tree)
 	GetReleaseBindingK8sResourceTree(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam)
@@ -6170,6 +6173,65 @@ func (siw *ServerInterfaceWrapper) GetReleaseBindingK8sResourceLogs(w http.Respo
 	handler.ServeHTTP(w, r)
 }
 
+// GetReleaseBindingNamespaceEvents operation middleware
+func (siw *ServerInterfaceWrapper) GetReleaseBindingNamespaceEvents(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "namespaceName" -------------
+	var namespaceName NamespaceNameParam
+
+	err = runtime.BindStyledParameterWithOptions("simple", "namespaceName", r.PathValue("namespaceName"), &namespaceName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "namespaceName", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "releaseBindingName" -------------
+	var releaseBindingName ReleaseBindingNameParam
+
+	err = runtime.BindStyledParameterWithOptions("simple", "releaseBindingName", r.PathValue("releaseBindingName"), &releaseBindingName, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "releaseBindingName", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetReleaseBindingNamespaceEventsParams
+
+	// ------------- Optional query parameter "type" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "type", r.URL.Query(), &params.Type)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "type", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "limit", r.URL.Query(), &params.Limit)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetReleaseBindingNamespaceEvents(w, r, namespaceName, releaseBindingName, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetReleaseBindingK8sResourceTree operation middleware
 func (siw *ServerInterfaceWrapper) GetReleaseBindingK8sResourceTree(w http.ResponseWriter, r *http.Request) {
 
@@ -9330,6 +9392,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("PUT "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}", wrapper.UpdateReleaseBinding)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/events", wrapper.GetReleaseBindingK8sResourceEvents)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/logs", wrapper.GetReleaseBindingK8sResourceLogs)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/namespace-events", wrapper.GetReleaseBindingNamespaceEvents)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/tree", wrapper.GetReleaseBindingK8sResourceTree)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/resourcereleasebindings", wrapper.ListResourceReleaseBindings)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1/namespaces/{namespaceName}/resourcereleasebindings", wrapper.CreateResourceReleaseBinding)
@@ -18250,6 +18313,70 @@ func (response GetReleaseBindingK8sResourceLogs500JSONResponse) VisitGetReleaseB
 	return json.NewEncoder(w).Encode(response)
 }
 
+type GetReleaseBindingNamespaceEventsRequestObject struct {
+	NamespaceName      NamespaceNameParam      `json:"namespaceName"`
+	ReleaseBindingName ReleaseBindingNameParam `json:"releaseBindingName"`
+	Params             GetReleaseBindingNamespaceEventsParams
+}
+
+type GetReleaseBindingNamespaceEventsResponseObject interface {
+	VisitGetReleaseBindingNamespaceEventsResponse(w http.ResponseWriter) error
+}
+
+type GetReleaseBindingNamespaceEvents200JSONResponse ResourceEventsResponse
+
+func (response GetReleaseBindingNamespaceEvents200JSONResponse) VisitGetReleaseBindingNamespaceEventsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingNamespaceEvents400JSONResponse struct{ BadRequestJSONResponse }
+
+func (response GetReleaseBindingNamespaceEvents400JSONResponse) VisitGetReleaseBindingNamespaceEventsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingNamespaceEvents401JSONResponse struct{ UnauthorizedJSONResponse }
+
+func (response GetReleaseBindingNamespaceEvents401JSONResponse) VisitGetReleaseBindingNamespaceEventsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingNamespaceEvents403JSONResponse struct{ ForbiddenJSONResponse }
+
+func (response GetReleaseBindingNamespaceEvents403JSONResponse) VisitGetReleaseBindingNamespaceEventsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingNamespaceEvents404JSONResponse struct{ NotFoundJSONResponse }
+
+func (response GetReleaseBindingNamespaceEvents404JSONResponse) VisitGetReleaseBindingNamespaceEventsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetReleaseBindingNamespaceEvents500JSONResponse struct{ InternalErrorJSONResponse }
+
+func (response GetReleaseBindingNamespaceEvents500JSONResponse) VisitGetReleaseBindingNamespaceEventsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type GetReleaseBindingK8sResourceTreeRequestObject struct {
 	NamespaceName      NamespaceNameParam      `json:"namespaceName"`
 	ReleaseBindingName ReleaseBindingNameParam `json:"releaseBindingName"`
@@ -22797,6 +22924,9 @@ type StrictServerInterface interface {
 	// Get pod logs for a release binding
 	// (GET /api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/logs)
 	GetReleaseBindingK8sResourceLogs(ctx context.Context, request GetReleaseBindingK8sResourceLogsRequestObject) (GetReleaseBindingK8sResourceLogsResponseObject, error)
+	// List Kubernetes events in the release binding workload namespace
+	// (GET /api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/namespace-events)
+	GetReleaseBindingNamespaceEvents(ctx context.Context, request GetReleaseBindingNamespaceEventsRequestObject) (GetReleaseBindingNamespaceEventsResponseObject, error)
 	// Get K8s resource tree for a release binding
 	// (GET /api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/tree)
 	GetReleaseBindingK8sResourceTree(ctx context.Context, request GetReleaseBindingK8sResourceTreeRequestObject) (GetReleaseBindingK8sResourceTreeResponseObject, error)
@@ -27182,6 +27312,34 @@ func (sh *strictHandler) GetReleaseBindingK8sResourceLogs(w http.ResponseWriter,
 	}
 }
 
+// GetReleaseBindingNamespaceEvents operation middleware
+func (sh *strictHandler) GetReleaseBindingNamespaceEvents(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam, params GetReleaseBindingNamespaceEventsParams) {
+	var request GetReleaseBindingNamespaceEventsRequestObject
+
+	request.NamespaceName = namespaceName
+	request.ReleaseBindingName = releaseBindingName
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetReleaseBindingNamespaceEvents(ctx, request.(GetReleaseBindingNamespaceEventsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetReleaseBindingNamespaceEvents")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetReleaseBindingNamespaceEventsResponseObject); ok {
+		if err := validResponse.VisitGetReleaseBindingNamespaceEventsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // GetReleaseBindingK8sResourceTree operation middleware
 func (sh *strictHandler) GetReleaseBindingK8sResourceTree(w http.ResponseWriter, r *http.Request, namespaceName NamespaceNameParam, releaseBindingName ReleaseBindingNameParam) {
 	var request GetReleaseBindingK8sResourceTreeRequestObject
@@ -29653,181 +29811,187 @@ var swaggerSpec = []string{
 	"UZGKIimeikSnV0nheKBNSLouJ4EpHhwPno4Px09NbUl1ZQ7GdyhJRu8JvSMHVJK/5AlChYaMmJdTEywq",
 	"OUEiY4SDK0nLcjfAfZxHLrhuU5Brq4hWFibPT8E///Hk6/GUvDLGmJen1yBKMLJSg4pKeXGhKsZhHknl",
 	"rVT1yNwJr4TJlMgv9SwlA2CJgHL1UCrsRFc7xSiJOdizwIH/87+f7B9PyQi8y6n5rYHx3bHZeHA1RXfK",
-	"XmL/YJqCnL64kE9vcUrLzd7+/+x9W3PcNrbuX0H1S+w6krqT8UzlaNc8OI7H8SRj68iePacqSpXQJNSN",
-	"mA30kGgpPar933fhQhIkQRJg89Ymn+K0SFy/hbW+D4sAIpyW+PfXIM7zyl3xgrm7f6ChFxNBHKlhkGBL",
-	"MhXe++JjLCbaeBPPS+zB/5FeFh0fGSUA8d1qlROnYHp2yPJ3lVKeKl+Vu0/VNYv1JucFxHhWgCiz9C+u",
-	"f/3tYhEddjsYHmVnQX0JFwsGOVf6NT1INlr8xstdwj1ePn675CNOluoKmUtxe3+tCeRWXf3+GbVnWXMJ",
-	"0FVh7n7BEdOuIYpOnSq7qxIL9x4VRaviWW7JOSfmAeBlvFp9W1Z30qvlP0k8JkiITX+WXax+KfYZMplB",
-	"ACSBhGhZti3p/Gc8cBEC/1kqF1I7+TAIkqUtu0CpEsyT+9qLw9Hu51XW9Z57d4cJjQeg6fy9Wv2p/qW/",
-	"0XCNfR+R9mYcJiNrPdfJoWjiS0JqEljfJuemUZk+tqMhyk14KM+mjOTd7yrPxINBUIRAUtxCBtsoYj9Q",
-	"/9j+3McVxQdqGgGQhvtil74PTP6IPHnOkwUis0G0r95MTnIUO8/y+i+174zJ/sDS6XgRv/Ir/g14NJS9",
-	"81WCqHjoV/zbSwlaCwj+wMlwMpzNjOO772xeUicm8bDgjRr+NuwkBkXhKjpri1FHTlq5RvNhlTGbhqar",
-	"E0W49smjewT+fUDhMfs1YBDQp3TmtxiFPEg/qiN0FQbikOOn5M8SejKiU6T2Xn4Rrc5SFZma98lo3nMz",
-	"v4+DCPFohJh4XXuGO3PtIRgiUDyCF7yI8DrAZBOp9OqkAS9FYLrD8tqpioLD2N/EfP4y4uPjxwNaEgEq",
-	"n36j5iubiP2rST2Qh6CKwsXe1uJ6IeYgzoW4zux9pWZfUBEM+4PCFVcVnYoSDgUnx7BVFq1rLQ6FJzKe",
-	"KDuZyMzRbmpSVeNfljRAy/wqr/+3DmPy0kNmDWtufLthbOh9ro39Bw6cPUS5Hluthuq4ErEohjRAa207",
-	"pjZsVC/HhszfB3EB5qhRpZzfUm3jp2DSpmFIH1mKw5c/oQB5jIY3/PcFR33dW3iHmfXTbw5hlBTeJaTj",
-	"c3L4+GujIjbJq8iKfC075F85xkXfzR0vh/pFSTj8Rt4FBSAg6KkKyEUcy1eLSD4hEm6AELvA99t+mpEb",
-	"W8McxRdKZU/OHDVgX63+b/0bbyh5CLDcJhg2JpawNBrIaa5g+cz9//9IGwqQ6dr/H8Xv3JpM1RdNSD5v",
-	"NKHK8M6ILJXgKiIWce9QJs5b5I1ED160LStxX7g2XrVhzSvDomJqXnx/YhH4PaH4Vf0bHyj7Gz2QdmQr",
-	"ObmuQLyoDjfUp7Fyby0Rv+3Q9g6x84baajSrePyF8teMXx5LO4N3fzCAV14IEwFI0ptM7CAr3zw71I4s",
-	"+hmP3RzEfJ5X9ONod2cWLkkLazFcakSZc/o7L6aWOM+MOWOKLlR5chS5dWpcBKwFQe6JGQ9NiWu9wcyB",
-	"++fADRfzxqTXguw6BXGtBG+xEYsgrhV2e26s1hnIXdDgLulvHe09B9Cthluap0hs2ye030Rx9oo6+yJ5",
-	"2YLijhShY4lbBjSOKbDXsZFRp7glqdAu3xMmH9nmovs0IUAUVElFM3dbz5y0MCS2vDQ35lNiqPmup5A3",
-	"Y6whZ81WU8NXM1V2S1yzVQ1DXg1tMDuC7CDOVLZnKpsdfgtLqXMSy2dPfhPnxnHNNhV/IlpDfvO25eYx",
-	"TIXwDpSu7+UcNlPG5HdonbF1Clm1XZRT9tozalZjWWKnQknhKUA00tRbtA+gZ+apJQvYC271iui8rCGr",
-	"3QNyTCHHaOxh3kMd+R5qhzHKMkVY7ecaia3FN2LJU1dbdkSfkoPRzsUdyRZX5cyXGJ4qfirSqLn3TdDs",
-	"QwbVzb71ksy+cAJaDqjpR/rVwsyPkMGb5D7hyYsyyXDYCjLaOE9JjNG7XQC7hqmGIkxafI0Ak1TVrfiS",
-	"VjOM8JKr37gQJ8/MckvPckuK1hpbqFr0l8+ev28usWiHstjJK7rlNIpKkgIayiopXqcuqVjjpw0ppWpp",
-	"TaPXntCxGnahnNo+vgPQGksl2kLkIpN0B7ixBAUDY30WREYuiJwQRVD9Qr72OGSmWBsymbkYcGaViaUW",
-	"x8WWXpqmYEo809j/gnmYcNeQeRoqrKGgxcq75aKG+oYhpWUNMTqi4sMzTe2ZphqgbWtKVi5n+eyVleHO",
-	"a02ttWS2RoNsFFOaO9KA6xrQP3XSewIa26DBVut8yocHw9Rq0FXbaIXTSzU4CavOTNo46C5cuk+wji7M",
-	"WY0tzJmJ98iJd6txkToV78TU+vh+rvrEenXM4JxWvywOiC3Jzoz2lNh1tuMFzGew1ZBP61XUEGmtum4Z",
-	"tF7RMNS50AJz9KUP3hToctuMVx+/WnhXr+XLZ29/QgZ8ZibtaGzWHBqFb1oRDYmrVsLkGasTmtrgqNVr",
-	"Z0pOe0TKagwr4fQIqCP0Gm/eZobZhXJ2C8HxRAKjwP/MKDsIHXKksJPQocPE9Aa+4rSk9P49hn1KesZa",
-	"JpaQbuq7O37j0/tP1DGSO6nqhQz9Qt5ZyciPiPW5dZkBn9QBdtmeFyCfxVfTs971SurOstMq7FbPyNQ0",
-	"jKBRbELJCTH6AM6SRoNT6vQBrEd5zcq+fPbCE1SN7GzayRo5s2gUe+hlNBQ2Mve/T/7UdTdQtaFt1Kyk",
-	"2nF0feJlNY51cXoChzMCG0sc2ZF20Ti6RuKI4oOR2MEsdHQvdHQVUHSodTTyHaepHQN4EHu5I2s0E9M7",
-	"jJ1vAGMWQsxOkDrk+5USx2dZxaxtqKGwFTXU1ExIzGAxUnIwVghqqF6IUmtUC1FDt3KFrGIYnUKr27yW",
-	"ijGKhYn5a4TuvkZgCmhlCC9boZOvDMSTzbULOdF2mkVsFI1Ch6SdDVQK8e7k5Yk6qLShR5SsjWks2TEG",
-	"VgOtdNOTGurR1FhbkEPqoim0j6oxuO2hwKz0gjm7fkTZ9S36+Q4lBbvl/zQNoU8nYC8eSMuZmGiQ6bQL",
-	"Np9o+OUhoE/WhyyUqAVxOTanKvxLPTsfqJCYUmZIbGWE3JhPSU/Id70A+RzGGgoM2WpqlIZMld0qDtmq",
-	"hlEeDG0wLsiZ5+YzEnpWJbIItrCTOheRhDGZN5vLFtkGWuoXeVOrvDmLt40vmzyKKh0Ww1VaZf2svF7r",
-	"lLsFs5YydZHEGbltqCZ1C34aP58zBFdD+YK8tU9PrGmA6sbqTW6wXWScM0P3mAKt1TgCrTnVZOQ6UouR",
-	"WQu83Y6xz2RdHw1Xnj5Jhl7BzU+m5ZaEvB8uPjANt4q65jSA3gh3Newr1vICwW6BW7ux6qb7AXqDG+QG",
-	"xK/PzNcKQm3SXRui2ykqVoMui9OlobXO+WTu2YR1tg21kfj+YUE+5xKMlwO2HCx0mFfg4jFOyy7o2W/Y",
-	"JxgkFjWxHIN8v20xyyPPaM8dRqM7HD7uEXmzpSGigE90SAOlZ6blCiAfIhSCLYwAFFEjYPTqjnwkwVF/",
-	"8AmzrXg6gGsUgHu6R8QThV/56HGpKrgUFfyVr+L3AIYIhKJ9yL+6I5+3OAIPOOBQBfTAQHSMGNrplbxA",
-	"V5urC5CWfZkp9wJ8OazRpXzvJYDEvyPaJTPhgTC807t3dUeM4syHdGAnLcsk41AnyGhInIASQ3R4xKaq",
-	"YcZWfKk3QGEW2v8DHAF4YHQHGfZgEByluXH3we3PwupMkJetSjrQkaqTlt+znpOruLjFIod2TqDoR88h",
-	"Gs6MxmP0cMvn5N8uso3ZrOpkG90U3Jb/D3ojXaSaFIdTFWlqcdFIl0mXUlNc3fVEr/pexKYiuFiAxUFh",
-	"KVklrBSWDiA0uO/tHbZT2FMfgzzSju9d8sH7T0gDtMbEx2RjwT+DIK08OZ2BBgjERVxVM7FbGqAf4tra",
-	"sLSLaVG513zKtEG0ZnTZWZoUvct1PTWZ16qdYiKs6V4l/q/qWJk2d2P2NHmc9U32zPWX+R19BmYC2DcB",
-	"zAx/hXk1dEryCUumaG5ULUFs2yovnu2wSmQ2pyH3k9TleaI/4G4f8Ed99IgC3r1LbQ6apNmXNLKcyX41",
-	"UV3r5NfWJk4jwzUg15nxBBG+GoM3yjD52V6M5N/eWIxigCRFWS3A1kRy5H8aVjKWcHEUBjp/BzDSHJCu",
-	"48uGagfUaxVNs9E8ZrHjFKt2UzkmqG50oGoUcW6lbZyFqDGYmmHhl2b5Ygj5okW3coJeYaVT9BKYthuQ",
-	"tiRITECI6P90cKNy0a1iUa9UfK0YXw3iUmYNwlKD6EJ7+CYC0ONP84d8oL1upUZ8RZYweEA3jPXNSRFD",
-	"6AUnB3RJM0IUIBg1TM5PSgFxMSLFFxM99rsAVJQlMoFl6jzywfqYvl1y+ED859u4if2IDEm9/++AwuM0",
-	"tYn82NeedVAAwuyOTacjFIdJ+4ymgHfr8xHyxRqssPSwhFytY1Y4Cm3t+8wFY/25mSnMxSx59HQEQ37k",
-	"a2yroaNcPnu5wpxS/fPoqDuboQvzdPCBWhedznQo9HOypzo4orLZuQ75Sszf554BllYDL9ZT+TSh48Xy",
-	"RDrhRCPUDfE1JKIv9qCuop+5A2HWpGEmC5VkwUgSmrCDBqzgLOjAYDyg2qfMgX/PgX+Znbg6Ly3EbxTb",
-	"28b0fQdgzaP4yUfv5UvwKeF6dZg+Knis+l49JxeJV3h5h4+E4+GzO3htLFAbPDjoHd5zYu5YD2frOppY",
-	"bhDhpoguY+p9/VwSyL9TTwojx7vdgfFOJ2JFROA+2lIGHkK6k+fvH8JQhJ4JziLGO/Ui6cHn4x5dAHkl",
-	"2AX4Fw2/BBT6L02eSNY9kFjU/QqR62BiUGe0pzBvtLdo/zEe7LSxVlYCh4MaPbpbY4L8shMbNc+fsXXw",
-	"f5Sxv6wONhue1ngeIafF6Y7pgjmRYx3zHW4H4+y4PzmXRJQB4CPEgXB3mAgLqBCtMkrvZ9GE+YOU5q6I",
-	"j6B9xoec8incbZHrssFiJPbclVleYBN5ltd3FhKtaOhQoVVaedmiL8Z/1mv7TtRgEr6lZtTE+SyfvWaq",
-	"rcCArXTbmuE5BEu8zuYSrujenIVRB7kT8y948dWB9iiRsxps0Z1ewkU9ApvovWIw3UTfsSBxFGHHcBYw",
-	"K8FjV4K7jVNava7D0RENo/r06I5clB9hjZOTf/RenwxxHzIoL4pvpAGl92CkGYCkTvj5ETKobkmdRR9n",
-	"A0lGr07w0eZmCmKP3t3ULDSs2Yo82t0uVpCWbycVjVndSRvZs7KTqzjH7eM/zoJOT4JOCvEyU3H1Hstn",
-	"f+8g4mg2ViPgtGtX9et4Up+rcJOieKqaTT2qGmk1abHG8HicAFn1vXRORZaxAZm9HKOtQ1ZSzGjANnhs",
-	"0DvAZ9VlpKpLa8EE2gf0uEOE7fEeBbgxJ03KAUlBVlu1gpsmL98kjZhJqrtNF4axlq0aZm0StNXUb82O",
-	"DHi0JrLFoh1SFoo1j5rZFlvbN8UtaUGeAhXnZGa9PbHe4tjXWlpj17V89gsFuhBkA07qmHI3BmsRpBo7",
-	"6sSdDb2dLItugNJmvLpYkZlgnwmuViNYyifDwhuB1IGXG8bWjqCPF6zjCXrGYCnzMZQ9sfPOgh5EHnFI",
-	"ya7x6TF6Afa7x2/1amdq7myy2vjVcfLMDE+Ai6MstGIjySDOlnxrZblsI2t1jZlu683smWcXqs7Ogvbn",
-	"mVj3RKxRBrQlZuPuVJbPiDzac2aSsbkasty2ndUv8FqNrvRYx/RUabEVxhrxYK1kI/8dL1RWQyyqU6G4",
-	"loCz57T66mTFZUcFvBHEEIPAfd52Hum2c4tBB11HKHyEaxxgdoQBCllEKOPOQYDL20JCUNCM5GbKBrJw",
-	"oJcO4uKt96g/6kW+FiV+0Ap8Ezd3JsfOC4Pd0NbxZvs5nwKrdhiN1I5tMW5Lx60b4bBDbtfGMdN4yx70",
-	"zPBdWpWd84/WszxLA/1IA9Z218j2W3Xvy2dqVbGLImG/7NToFT2uNfXu+KP1OLmoHPbGO1UNpFtjaiSe",
-	"WDfJKK18bahenZUPnIqS07XZ2EtA9u7ASiD6Csxn3DHtednznFLRj/I0upj2hA/4s33JfcnvJETNX/S3",
-	"sjZYfdpvmrXpSUmFj/1NeGwmEGU//3eUgkZ/DIChtUNKPKUf/xWfmnWbQXSb/Nd9ZkNr7LlyykvywWsz",
-	"lcXqWIGODNYxTG500IDBKmZBxB6lLcgc5YcRnAusVkOu5MpCpyk/2IK0qajgcJjBiME6nphnNXzMM6eg",
-	"jDQFpbsgSV2Rq64zWWPiY7JpxvBVUen95aqw1m7sVRfoqutwfojbOt/e2496YBz+OgGhDBRTEBFK+56a",
-	"bgmkbbWEkhoc9ARjA8YsKZgb3LOqUNGI7HTdlEzQBNSFtgSCEozbGNEpLnD5vDcV63CyQplx1ggG3Vmk",
-	"tZMrdtlFNijD/FS1gxMA3EhCKKnPKCOcF9hW41nAp6IpnARee2mhbK3MygvgnxHyAaMA+o+QeAjcc9Bf",
-	"ZRfqe/BCnIcf0h1lCDwE9OkloKHYKt3Er2g5/dxn4U10f6X+RJ8ICu8BJH7x2XsAQ5Ret1qmd4zeqkYV",
-	"lo3IqicggLQlSfQclrUiSXQlRcwaxDAahKP4MEXRoVxsaK4yGNQF8IGGO2FC3kF8Es9dcLzK8pkPaRCg",
-	"8L8A+mNPuRPfohCJK2row4M4pgftMAN7GGJ2tNMqzkekGFadsPF/sxzRVI6oNK9Gji4vPJyiOLgoDYPE",
-	"p6dqC7OmUI/CNkQEC/FgfPhZDbiiTlQfaG85PCngdzjl7Saubs4nbmoWlmF4NDPp8njdEKe7B+gOx7+p",
-	"Os4giB4oeq5a5Ofc4H5yg/cJSA2m4eZNkqi6QThtF0b3G/80DZwnHjCXrbLNI+SqyHhEkFj1uT5OLPgt",
-	"dd3O219W2bSjANfA7r5XOM9psSNNi20vPhD3rp+0xSRKsP6gVbVTXqE9M8+mVsvHz3YTSE7xhHaAmAJX",
-	"zjbia9vdqKW4C945rZTXdQYUUzRzGJqZVm32PWLc5+0Z5+0ZJpFXgn1337B83jehjmL67Phja7ZiHdPx",
-	"GhvySP7q5DdfqjF20rYLL7qKWY4QLKtBlsapUE1ojTp31ikG0oV6jgN9IwgHhsH8zEc7iB9yaY2dxQ/L",
-	"FA+V/kHkMMd2AORLImGqobf4JKv9Wn2G7N6tKr7WhFShU9md1/t8Iqjb+FL4lC+Ek3EwCyvDfBz8Jv51",
-	"wqm5bt8Fn9f3wAPlBlR8ONz0i+HmXwqfzyfCw34bXP/1ye30PgYeRTpB+acqTb9RKXwzHDb9WNjxI+FB",
-	"Pi077bPg2/lzYKEeuaCwkYZk893v2PGzGnA5noqk5AZEe1mp+hveEmVphIAcR2AypCXM53z3k8cwTGCy",
-	"/PJ9FKKIHkJeAnq0ul7958MahUQELfKNvCYVlwgwERpWrm/fROkTLETIwjv9/H10q155+9jjZeylq8NF",
-	"fnBe37wHm5Ae9twTy06rLr5Auz07goiF4gDFENAdZtyk+Kh5NEwfjV4uLhaYl/bvAwqPi4sFn9LF9UIU",
-	"vLjQjFxok9cLWShHlKk9jyiMMCWGFl1trsDjt2XVqfcW+ZXJqQE/Y+Lnay6p7wsm/mmV8ZmxrEz8x6Wy",
-	"biMTHdRV0mX8pDK5WSspBjM/f68tLJmVaQyLa0AtlFL+UEHhp34nC+kvdDO+ZVQ35D31S2x4T/0PrmZc",
-	"WRU3ZogJCgGj4AExb6umIqS7K/D+IV6zL9KfAQyC9L0oniI+W1Cs6XxG+RtPmG0Bgt4WIMLCI2Bws4l1",
-	"bPX2VUk/kwfc1v4Ph90ahbxvEfIo8SMQYeIh8LTF3pb3MNrSJ9GTknrF45/ku5mqH2i4g2xxvcCE/eXV",
-	"4mKxwwTvDrvF9eoibhcmDG1Q2NPKeUN9DuTKXR/qy87Oa2Zxd0iNzYgWSr6SWWwpbTEKYehtsQcD8IjR",
-	"k5BAggAE+BHpMWpSMvDRPqBHaXvachoB+kTiX3GUH4QLgIkXHKRMu8WBr5X4grNf7MFPiEUX4Ib60QX4",
-	"O11HL92W4s+8y1+xAJPrapWxZpy4gMJstdWRDh+kDs1X1tLOlq9q8Sl7v3EhZVu/8q/DbAHHtU96B9g0",
-	"AfU7wSXImEKufnnndfM149p+y9dch9Per6kJ494DNra4973g8laUUPz5pOgT9nfNY2hlSye5RB7Zmgp2",
-	"2gAuAUC8Eww+b9MfHzCBAf4PCgHCbItC4MHIgz6SeYMH4qMwOPIHbxH/N/Jjaf9FiDirvKEB9o5/ldWL",
-	"41G3NPCj3J9vxf+8LN+E7mxVsPe3p25Kl4z6dHenT7ChhtvV5hpLWNR5QW41JlcynY3tkzDsstNdMtJW",
-	"x1bnXIbVudX68nwPlrmSPh/36G2nJ1ufgf2NK5Yc1QIwH2/tsCXfdyzZjq7SnZ4yCylDCSmuCsoklZMK",
-	"xeQEqcT2qOtkybU/61omYtxTTwuBN4hwK0T3ABPw+O3Vdy8tFZkzkmIG1mCsHOYsujQWXarNsJlnLMgr",
-	"J+kqdZn17RuWc2h7sowxyxc2aGxFr7DRKUaIotWgC+xUpYg2V8fTCEN7d+HcJu2Zb8Hplx+8JxGDxLMm",
-	"CHMWVBWTMDGIBtTBfVf1HIL3GGpDRe/Z+ku8yxy2O4ftJZh39ERpgN4kMs/scCaTmW5xrgPqfYlkTIsp",
-	"AQfCcCDS/WTuXokQJ4TuvJcVMrcXIMhfPOzrWEDPgVvjuH/q8X7p0n1CgF8Z2I8JGKthVtupxfDl4YH7",
-	"hmFug/AfBwbFA/I+22T+gXdgcYCRW8nAI4Zl0mPd7t3A4B1LlDKQ3cy7cM67cK1EKc3P+E7TrcUh3/AR",
-	"4gCug+Qb15rDvm+17fn5tO8TzMvmuO/sXE1qJyx/4HcWd85E1vHIb722c2C0Qxz6Xay7xEfMx3433IXK",
-	"nduZN4EGHmP5HLImrNbm6O/WbcY+KGty+HcWnpPfY6rB2mm7S6Vnuo4ZM6uBVsrJbSfVQq8BJ7U/Bnxk",
-	"EBxDjDAU8uezwLs7C7yPoKLN48DdfEevB4IP4EHqTwTPWtJEjgQPTZ0+FdsR8kLEQvSAQkSaZibIQkBa",
-	"ivVtap/Em7dp9bPG4m4u2TGsk1kKkzUFpaXY6dRwChi01VvyhTpILrk6x6y65Jvas/BirD47K5/y8zAf",
-	"y93Psdx5A6g2qmYOafkcZYtyUHQKBloj6nRhlfWO4lOxfy7STgH9U1V33NDYSOPJV2EM1cePotWgq/NU",
-	"JB9XPNoLP4V1zUr7GSUuRxKvDGsR82nd/ZzW3UW8wkKIWTPaLF91Tkr4LGucmbKzbYqRq+PHakInQIpZ",
-	"DKTYCBSybPmveN+B9Irix0x1ZQN7JrhapdnBFn+YuWxPXJYpcBZswcUNLJ/Ffx0oqrShGl7anuHUL8af",
-	"4w64cFAJ1akSz1LoNOKYojQjsRwXDFZ9rYBT4YsVMLKnhnI9seKDg8NpUAfeG3znff6xeXzFBlv3+G1m",
-	"BNR4gV5TAPr0BfV7/9KqJrLnz/TONobqEw2/PAT0aR9A0nCLPy4CyDKMxyt9Pu6xJ04goASBPQrrlIx/",
-	"qUJvZLtmRcPZXDIjWKds5OZwChJHvsupCeWwZ6t5ZAt0ED8y9Y1ZBMk2tGcxxFB5djYyD8ziSE/iSBb1",
-	"VVbUxCEtn5/0YhzUk5w11sgo7ZtgvSf4V75nLrJKFuxTlVfswddIb8kWbwy5xw2cVf+rr7K3qSgzLgi0",
-	"l2pyi5eVZjM6JI4i/lgNFX/M2s5ItZ2uApbwQGz4c8yaxanAuo/h71tu88ctveVV9mvpEz6gTxt1azot",
-	"QDElMh1KSOZtqopFfw7xZoPCmEabDKOOOd8eyDnwZt7MgVhzUnVJ1BYeSEyZ5/SyDllyKJBqMg93b7N8",
-	"Dg+kCSXmk21JiNuyLHsPcyv71IQMi45NnguXQ+w0EmxchzUKPD6orAZZRidHfasA14Dz8jF0YryjAN4I",
-	"ooZh4D5nqPfMW7sJIZbokbeplsFq9/DLN/LpCS7+4q2sc0jjvch39G/iiPy4c+sjYDD6ImKlxcUC8yf+",
-	"zTnw4mIhfrte8L8vLjTLEidLXC8iFsq73E51TJihXeRgsmJU3xIWCjtUrYFhCI+1xqxA0NR8z89xxT3u",
-	"wKACanGtPn+oyoLAQ0h3QhPKbUaAX/ibMETgATFvK/IxHlHZ4/8FCAUw9Lb4kT8ZvxqKViBftICPpQyd",
-	"eUfqTJdXP0rDFZ1rw2wvzHMmKyDoCYWAbSERx8MFkPHR9w9yvAAmIEIeJX5UUnuEiYc+JY+krXig4Q6y",
-	"xfUCE/aXV4uLxQ4TvDvsFterxJYxYWiDwgGWll/optnCIoxhQstKQDedLCoRg+wQWeUR0kcUwiAA8hVx",
-	"cP4ehZcRQ/v4t+ZM75NsxwT4nuxpVdphBuhqgs4Vt1E8r6cj95TdEPdPH9N2zrmCjeFuu68xqT0N1/2M",
-	"bFZgYTvDPS/wHLY2htrXqFyP5xzAfnc32nEbac5fk70Ny32NniOXxjsaU9/N6GInozK2HRMwVv0ul1Pb",
-	"uGhz08Jpw2JgjA0dBfQM6zkTb+SZeJ2EDW1+cWnlOHr97rJn91H/6WVibRP5+vIp199TIRxQ6Df//FK8",
-	"7XL3c9LncjFFtqgfOL+Jf514eikfcxsNRs7NfL2cWbSJkatbpPzN5VNO/oajWMNfGbtYI9o4gFiT1lt0",
-	"HGKoZ7GmP7FGAdVkII4uS0Zd/J+OYo2YcwuxpjWbsguq4p64ijWiO1MWayog1Vis4QWUxtxjA8aq3+Vy",
-	"SmJNJbbcxBoxdtZizQgwNnQU0DOs52zS/rQXqygABvst/HYJD4yuDzjwee3mEPpGNhhFABOP7oTFofWW",
-	"0i9JpmhIdwCSI4gO+z0N+TxvMAP7kD5iH4WAUcDkx2CA17eDDHtA1Bpd3ZHPW5R9HEfpY4Lh+oghj5ea",
-	"ZMEp+wFbBH0URtd35BK8w+ynw/oa3P//y58O68tPeEMgO4To8rs//+VePfALlA+8wyyA68vP9Asi4m8/",
-	"YLY+eF8QE38WmZaXP6PjPXgR4Q1BkjEUir5/eUfuyNtHFB7zzd8iwpvPkH+tWiYydZJ6xJXwP/3j9ZvL",
-	"Tz+9/u7PfwFRXOgdeUQh95Uy5QxuICYRE932KHnAmwMn+/EUyAOuL1TnRKmYRSDaQv4U4x28uiPKfKSW",
-	"QA8MQPAIA+yntS7Fo0Ih4zUlQ550S+YV/i5+vbojhdX1J0j8AL0+MPqDwFNhec2iSo1J0o24HWpKwSES",
-	"zVcNEWMnWsxBrt6V6LuKM/Hki2kqngEGbnmBakjjJsoBsmsef6+2eToI3VqWoihjiZdf0LGkgekbtc1K",
-	"wH9qm4zoBi/uoy387s9/+evdYbX6k7dFf4h/oPuXSZuTkXRodWau69O2m7lf6PtY6m43IUc/w9ydcgd7",
-	"UcROajrxgOzhMV6bZZvomttT7w5bNkfMc6X2GzdbOYABvfcQrhV5hxCz4+L61990RyvXuazHUhOsOd10",
-	"HTQ43QoCvsFMrugWonEQiFao54HN5XvvsLqrJmpPz+oIpUlTeburYBoLqNpYnF1Omt72FETabFmnpSUF",
-	"CVeuro/0qI/0oATT0k/vkzrHLHjmmposL/3Kn1r95eh8l07IrIT2o4RCzQrKrKnZmrx83sSFOMiimk3W",
-	"CKPtGl+9OPFO742LNKqheqriaNsoC1GAYITWmPiYbKLls/rhB/lDfAK1oNHlZD31Bn+n65Qv+2gf0CPy",
-	"wZuQkr/T9TeRUGSvfqfrz2i3D4R0wBkuJIA+ERTqNyhC74ug8FsUv34h/ieCOwTWaAsfMT2EAEbg/sth",
-	"jTwWqKUO/E7X4PKSt+KvXkjJ73S9lFE/77sK+6/ARxIceTRDnziv3SKiuK6al2+iVOET9yDjCKjSrsDn",
-	"LYq1BeSLPr/gXIxT4D31o5cA7vcIhvHHBumFyiFCgrWJr74C/AUJAYOyLQrjXl7ykRCFFu1VHW5zm5kj",
-	"9V5v13Tn8dFDVKa6mHS/4tDuLRLzEXu9BIvxKM3b3Jll5R+QHITaFUtlwggkzuUeiloQgFoiMheB61Bw",
-	"XXmsCUfpPeAR2EECNzIHhbdb3Xf3+ua9tDwc3RHt2PC30NsCzNAOYOIFBx/JfC3tG3RVgA8ZTD6E5Qi6",
-	"I/xBBsMNYvEXs+8Z2kXgaUuj+C+X8nxFVcgWRoBQBo7cASNE7kh0JB7yhaRFd5hl4LmHG2TSt9K7y3v7",
-	"FGmcCS3aQNjQsgwl+5q+LOJvfWu1SLzf7QO0Q0QcwlV2U3nxfnLXa8mlN4w0y8GR1CgiTLknU05Qt547",
-	"AnkhRcvbBwf+h5tDtFW/sC1kgFtOBDCLA4JUkb4j6A85PnETIkZDdAVeg9xNi9KBS6+AY2dPWEiDuE0R",
-	"5b9Ehx0KI+BBokUjLO3i+gi+oKPJVvUb18fPYwclsWqQyu8snVlr+6y1jaUjIbsFCtKMfyQUN3Llt1lu",
-	"m3rSjFGLYDvjtytvZO/1quKG96+XM995T3tIy0gIeoVlXNSFugrUpXHthQpdMdkItqlHqncksYFspBoX",
-	"/2r1CuAHrcSMb9zhKOLF0lCPdlVMW/TU+fAWyOjW5BeTq+rHY16r/jzZQ/pZzdfDIdswmHeI1VlLTTaW",
-	"evkbZQdCShKR2oFPJ6dXWASGDDJ0BX5GRx6YoggRdkdUCJi/6n59YACu+SPFtI819Y+Cve3DA8nYW8E8",
-	"pFSVhrEX0hEVLU9kSdSap0+RtDbRXEBFugf/f7VQ3JHCSnEV/1uIV3k3KLqBd7sD46unyWj1q/wHtdv2",
-	"41+9a07xb4+rxpy5Nk4vrxLeauPfLYIB29aKWx9/jk0+QuGjTOOSrx6vwD8jdZZagB8RQZGg1WtkPkzt",
-	"J1lhLWYZ+oMt9wHEObSiPyDv9OJ68fHnNFUkSV8x4DTX3ur0BfEM8LbI0/MVPsa9iIeN7hGBe3wVW1Pt",
-	"x5Yf94i8vnkP/nS1SrK9ZQabzCnDUSwH/v3Txw9AnodmHEBV0qc98hYnWn62ueVN9Kl34Cgzp+aYS8mU",
-	"UDnm3L+a36qYgBBBudJWjvwtf6qIXPEyYBRAz0N7FjvOSIMyfwTXYVkU3waU44Ic0CwHoGpcb5Mu1ML5",
-	"EYURtkCyeg5gIgEqMjDX9CDzL8UEigYaR+u/VSUduitVRZXw+t/FLtSiUyHnMemAeSCzpTwv1giGKHx9",
-	"4Ovrr7/xKEEWZEr4/IV6MAA+ekQB3StbO4TB4nqxZWx/vVwG/IEtjdj196vvVyLmUK3IFyXXsIsUwjKo",
-	"i+cOEX9PsTz9U+UHat0oZi4mMZIK4lTj1KvJX02v3oSULxPai/GnhanSkhalnjYVlHwpayhqH7+WFJQ8",
-	"bSrqLXnEISU7c2GmdmlvmAr8ETIoLz/SiuNLyFP60co+oEfxu4xttcKTt01FZ+9WyhX/5v3yzY8yT5yD",
-	"OYQRCw+eyu9Upecu9ynW8HHNIQnXOMDsaKxmRwlmlK9H8YbwRu6uxdgplGCcwOAQMRReRh7dIx+Yxkyb",
-	"P/lw5dDkCiwbqUKhtSOSK7hygAqlNxqMBK6fOQNiKuEgAj56wESKK/wXvlwBRDaYIL6E5KvOlGJRq7w1",
-	"Oq0tPguXiggWeCGNokvvwATp9CjxUEiKtap7lysstmGn6npzYvPL250dpeTAg2xNwupik4i/xiAbcfpu",
-	"VIo5U33v8gflJRUVrdj0/i0N0OUa8rAFCgaW6MqqaYIrSU9tAu5r/YmFMcu/mKm9FUm+oTrCOffNSqZs",
-	"leVbLFfRx3TnytS4nLxQtkSKRVbP5RQgw9KhZUYxPkGg3L/EWQRGI4+fUgkFxvnIZiEYy8nnIxh8Suox",
-	"9niPAlyy7KTP3ajHahd5AAMUMqHKpAG+t4WEoMBYR+bt1+LlD9q7b+SrUQl2MkJx4lTKE2/TerVUsVL4",
-	"aMVCYfKpHXH4C7Utueg6AyoL279V2VAnLct6IWa8nFKJbekVYRN4obS5y2wQwaMWRHxEPIyil8UqK6ur",
-	"sqL4oUojypVTbU2Z8iqsKg5HbUpVzxYK/e1//jcAAP//J5jELxoeBQA=",
+	"XmL/YJqCnL64kE9vcUrLzd7+/+x93XLcNtrmraD6JFZtS93JOFNZTc2B43gcTxJbK3u+bFXkKqFJSI2I",
+	"DfSQaMk9qq9qL2KvcK9kCz8kQRIkATabZJs8Stwi/p/378ELABEelvi3lyDO88o98YK5ub+joRcHgjhS",
+	"0yDBlmQqvPPFYSwm+ngVr0tswX9LH4uOr4wSgPhuucyRUzC9O2Txp0opT5mvyt2n6paFvslZATGfFSDK",
+	"qP7Z5R+f57Not9nAcC8HC+prmM8Y5LHSH+lFstHsM693Abd48fjtgs84WagnZM7F6/21IpDTuvr7M2rP",
+	"suYRoIvC2v2KI6Y9QxQdulR2TyUW3j0qklbFu9ySe07ME8DreLn8tqztZFSLf5F4TpAgm76XQ6wuFNsM",
+	"mcwgAJJAQvQs25d0/TMWuAiB/yyUCaldfBgEiWrLKihVg3lxX3mxO3r8dZVtvePW3WFB4wloun4vl3+p",
+	"L/QPGq6w7yPS3orDZGat1zq5FE2cJKQmgvVNcm8aleljGxqi3IKH8m7KSL79rvJMPBgERQgk1c2ks40i",
+	"9iP19+2vfdxQfKGmEQCpuy926bvA5E/Ik/c8WSAy60T7qmRyk6PYeZbPf6l9Z0y2O5Yux4u4yB/4M/Bo",
+	"KEfnqwRR8dEf+POZBK0FBH/kwXAync2E47vvbAqpG5O4W/BaTX8bchKDovAUnbXEqCsnrUyj+bLKOJqG",
+	"pqcThbv20aNbBP69Q+E+exowCOhTuvJrjELupO/VFboKA7HL8XPyZwk96dGpoPZWnohWd6mKTM3bZDZv",
+	"uZjfxk6E+DRCTBTXvuHGXPsIhggUr+AFLyK8CjC5j1R6ddKBM+GYbrB8dqqi4jC2N3E8fx7x+fHjCS3x",
+	"AJVNv1LrlU3E/sPEHshLUEXlYm9rdjkTaxDnQlxm9r5SsS+wCIb9QWGKq6pOSQmHipNr2Cqr1rkWh8oT",
+	"Gk/UnSxk5mo3taiq82clHdAyv8rb/3xEn7z0klmDzo1fN4wFvUvd2L3jwKOHKDdiK22orisRSjGkAVpp",
+	"2zG1bqMqHAsyLw/iCsxeo0o5v6baxk9BpE3TkH6yEJcvf0QB8hgNr/jvM476ulJ4g5n11693YZRUfkxI",
+	"x/fk8PnXZkVsklcFK7JYdsq/coyLsZsHXg71eYk7/Fq+BQUgIOipCshFHMuiRSQf4Ak3QIid4/ttN93I",
+	"za1hjeIHpbI3Zw4asC+X/7O+xGtK7gIstwn69YklLI0CcpgpWDxz+//fUoYCZHr2/yfxO5cmU/NFEZLf",
+	"G0Wo0r0zIksluAqPRbw7lPHzZnkh0Z0XbctKvBeuzVetW/PSoFRM3YvfTywCvyMUv6wv8Z6yf9AdaYe2",
+	"kovrCsR5tbuhjsbKvbWE/LZD21vEThtqy8Fo8fiE8teMX+5LO4N3uzOAVz4IEwFI0pdM7CArS54cagfm",
+	"/QxHbnZiPU/L+3GUuxNzl6SEteguNQqZc/w7r6Y2cJ4i5owouoTKowuRWw+Ni4C1CJA7ioz7DolrrcEU",
+	"A3cfAzdU5o2DXotg18mJa8V5i4VYOHGtRLenFtU6A/kYYfAxw9+6sPcUQLfsTzWPMbBtP6D9JoqzV9Td",
+	"F0lhixB3oAgdit/So3CMIXodWjDq5LckDdrle8LkkG3Ou08TAkRFlaFo5m3rKSYtTIltXJqb8zFFqPmh",
+	"p5A3Y6xhzJptpiZezTR53MA121Q/wauhD2ZDkJ3EKZTtOJTNTr+FpNQZicWzJ8/EucW4ZpmKj4jWBL95",
+	"2XKzGKZK+ABK9Xt5DJupY/Q7tM7YOiRYtVXKafTaMWqWQ1GxYwlJ4SFANIap12gbQM8cp5YosBdc6lWg",
+	"c1YTrB4fkENyOQYjD9Me6sD3UI/ooyxShNUe10hkLX4RS9662rIh+phcjHYq5kj2uCpnvkTwVPVjoUbN",
+	"o2+CZh8yqF72radktoUb0HJATQ/pVxMzP0EGr5L3hEdPyiTTYUvIaPM8JjJGH3YB7BqmGpIwafU1BEzS",
+	"1HHJl7SZfoiXXPtGRZx8M9EtHdMtKVprZKFK6S+ePX/bnGLRLmWxo1d0yWnklSQVNKRVUryOnVKxxk8b",
+	"VEqVak29147QsexXUY5tH98BaI2pEk0RudAkxwPcUJyCnrE+ESIDJ0QO8CKo/iBfezFkplqbYDLzMOAU",
+	"VSaSWpwX2/DStARjijON4y+Ihwl3DSNPQ4M1IWix8ePGoob2+glKyzpiNETFj6cwteMw1QBtW1GyMjmL",
+	"Z6+sDve41tRby8jWKJCNfErzQBrEugb0jz3oPQCNbYTBVno+jYd7w9SyV61tlMLxpRochFXnSNo46S6x",
+	"dJdgHZybsxyamzMF3gMPvFv1i9SteAem1sfvc9Un1qtrBqe0+kVxQmyD7Mxsjym6zg68gPkMthrG03oT",
+	"NYG01txxI2i9oX5C50IPzN6XPnljCJfbjnj1+auFd7UuXzx72wMy4DMraRfGZsWhkfumVdEwcNVqGH3E",
+	"6oSmNmLUat2ZBqcdImU5BE04vgDUEXqNN28z0+wSch4XgsPxBAaB/ymiPILrkAsKj+I6HDExvYGtOCwp",
+	"vXuLYZ+SnpGWkSWkm8bujt/49v4DeYzkTap6IkN/kHdiMvIzYn1vXWbCR3WBXXbkBchn8dX0rne9kbq7",
+	"7LQGj8tnZFrqh9AodqHkhhh9AidKo8EtdfoE1qO8RrMvnr3wAFYju5p2tEZOLBr5HnodDYmNzPvvo791",
+	"3Q1UbXAbNZpUu46uS7wsh6EXx0dwOCOwMcWRnWkXjuPYSByQfzAQOZiIjuMTHcdyKI7IdTSyHYexHT1Y",
+	"EHu6Iys0I+M7jINvAGMWQswOoDpk+UqK45NsYuI21FTYkhpqaUZEZrAYKTkYKwQ1ZC9ErTWshWjhuHSF",
+	"bKIfnkJr26xLxRzFxMR0GuF4pxGYAloZwss0dHLKQHzZnLuQC23HWcRC0ch1SPrZgKUQZUdPT9RBpQ0+",
+	"okQ3pr7kkTGw7EnTjY9qqEdTY25BTqkLp9A+qoZgtvsCs+ILpuz6AWXXt2jnj0gp2Kn/wziELo2APXkg",
+	"JWdkpEFm0C7YfKLhw11An6wvWShhC+J6bG5V+F19O12okIhSZkpsaYTcnI+JT8gPvQD5HMYaEgzZZmqY",
+	"hkyTx2Ucsk31wzwY+mBUyJnvpjsSOmYlsgi2kJM6E5G4MZmSzWmLbAct+Yu8qFW+nMX7xtUm96JKp8Xw",
+	"lFbZOCuf1zrkbcGspIydJHFGbhusSZ3CT/3nU4bgsi9bkJf28ZE1DVDdmL3JTbYLjXNi6B6So7UchqM1",
+	"pZoMnEdq0TNrIW63i9inYF2fDdc4fZQRekVsfnBYbhmQdxOL9xyGW3ldUxpAZwF3NewrdHkhwG4htnaL",
+	"qpvuB+gdbpAbEBefIl8rCLUZ7toEukdFxbJXtTjeMLTWOB8cezaJOtuG2kBsf78gn3IJhhsDtuwsHDGv",
+	"wMViHJZd0LHdsE8wSCRqZDkG+XHbYpZ7ntGWG4xGbzh82CLyek1DRAFf6JAGis9M6xVA3kUoBGsYASi8",
+	"RsDoxQ35QIK9/uETZmvxdQBXKAC3dIuIJyq/8NHjQjVwLhr4O9fitwCGCISif8i/uCGf1jgCdzjgUAV0",
+	"x0C0jxja6I28QBf3F3OQ1n2eqXcOHnYrdC7LnQFI/BuiPTIT7gjDG314FzfESM68Tyd21LRMMg91hIyG",
+	"xBEwMUSHRyyqGmZsyZd6ARRiof0b4AjAHaMbyLAHg2AvxY2bDy5/FlJngrzsVTKAI7E6af0d8zm5hotb",
+	"LHJqpwSKbvgcouHMKDxGC7d4Tv7fhbYxi1UdbaOLgpv6f6930oWqSXE4VpKmFheNeJlUlZr86mMv9LJr",
+	"JTYWwsUCLA4MS4mWsGJYjgCh3m1v57Adw576EOiRdmzvgk/ef0IaoBUmPib3FvFnEKSNJ7cz0ACBuIqL",
+	"6kjsmgbox7i1NiRtPq5Q7hVfMm0SrSO67CqNKrzLDT0VmVeqn2IhrMO9Svxf1EVl2toN2dLkcdZ1sGdu",
+	"v8zu6CswBYBdB4CZ6a8Qr4ZGSX5hGSmaO1UbILYtlfNnO6wSmc1pyP0kdXme6AvcbAP+qY8eUcCHd66t",
+	"QZM0+5JOlkeyX41X13rwaysThwXDNSDXI+MRInw5BGuUieQneTEG//bCYiQDZFCU5QJsRSQX/I9DSobi",
+	"Lg5CQKdzAAPNATm2f9mQ7YB6q6JrNpzHRHYcItVuLMcI2Y0jsBpFnFtxGydBavTGZljYpYm+6IO+aNGs",
+	"HMBXWPEUnTim7TqkLRESIyAiur8d3MhcHJexqGcqvlaML3sxKRMHYclBHIN7+CYC0ONf8498oBW3YiO+",
+	"Ikno3aHrR/qmpIg++IKDHbqkGyEKEIwaJucntYC4GpHii4nu+80BFXWJTGCZOo98sNqnpUsuH4j/fB13",
+	"sRuSIWn3f+1QuB8nN5Gf+9q7DgpAmMyx6XaE4jRpx2gKeLe+HyFfrUEKSy9LyLU6ZIaj0Neu71wwtp9b",
+	"mcJaTJRHR1cw5Ge+RrYaGsrFs5erzCnVP4+OursZjiGeDjZQG6LTnQ6FcY72VgdHVDa71yHfiPl87glg",
+	"admzsh7L0YQjK8sDwwmnMEK9EF8TRHQVPain6KfYgTDroGEKFiqDBWOQ0CQ6aBAVnEQ40FscUG1TJse/",
+	"Y8e/TE5cjZfm4jfy7W19+q4dsOZe/Oi993IVfIi7Xu2mDwoey6615+g88Qor73BIOJ4+u4vXhgK13p2D",
+	"zuE9JeYO9XK2Y3sTi3tEuCii8zj0vnwuceTfqi+FkOPNZsf4oBOyIiJwG60pA3ch3cj793dhKFzPBGcR",
+	"44N6kYzg036L5kA+CTYHv9PwIaDQPzNZItl2T2TR8TVEboCJQJ3QnsK00d6i/Md4sOPGWtEEDhc1enSz",
+	"wgT5ZTc2apY/I+vgfyhhP6t2Nhve1ngaLqfF7Y6pwhzJtY75AbeDcbbfHpxLIuoA8BHiQJg7TIQEVJBW",
+	"Gab3k+jCdCCluSniM2if8SGXfAxvW+SGbJAYiT13ZpZX2ISe5e2dBEUrOtqXa5U2Xqb0xfxPfG3XiRpM",
+	"wrdUjJoYn8Wz14y1FRiwpW5bEzwHZ4m32ZzCFcObsjDqIHdg/gWvvtrRHiRylr0p3fElXNQjsAnfKybT",
+	"jfQdChIH4Xb0JwETEzx0Jvi4fkqrz3U4GqJ+WJ8OzZEL8yOkcXT0jz7qgyHuQwblQ/GNOKD0HYw0A5DU",
+	"ET8/QQbVK6kT6eMsIMns1RE+2tqMgezRh5uKhYY1W5JHe9vFCtKydNLQkNmdtJMdMzu5hnOxffzHidDp",
+	"iNBJIV4mKq7WY/Hsbx1IHE3GagicduWqXo8n7bkSNymKx8rZ1KOqEVeTVmt0j4cJkGXXqnMstIwNyOzp",
+	"GE0PWVExgwFb775B5wCfWJeBsi6tORNoG9D9BhG2xVsU4MYxaVIPSCqy2qoVsWlS+CrpxBSkust0YRpr",
+	"o1XDqo0ibDWNW5MjAx6tA9li1Q4pC8WWBx3ZFnvbdYhb0oN8CFRckynq7SjqLc59raQ1Nl2LZ79QoUuA",
+	"bMBJXaR8HIG1cFKNA3WKnQ2jHW0U3QClzeLqYkPmAPtEcLUcgCofTRTeCKQOcblhbu0C9OGCdThOzxAk",
+	"ZbqGsqPo/GhODyKPOKRk0/j2GL0C+93jN3qzU2juLLLa/NXF5JkVHkEsjrLQioUkgzjb4Fury2UbWWtr",
+	"yOG23s2O4+xC09lV0P48BdYdBdYoA9oSsXE3KotnRB7tY2aSkbmaYLltOatX8FqLruGxjumxhsVWGGsU",
+	"B2s1G+Pf4UJl2YdSHUuIawk4+5hW105WseyggDcAH6IXuE/bzgPddm7R6aCrCIWPcIUDzPYwQCGLCGXc",
+	"OAhweWtICAqaBbmZuoGsHOi1g7h66z3qD3qVr0SN77UKX8fdnYJjZ8VgN7V1cbP9mo8hqnaYjVSObTFu",
+	"G45bd8Jhh9yuj0MO4y1H0HGE79Kr7Jp/sF7liRrohhqwlrtGst+qeV88U6uGXRgJe7VTw1d0qGvqzfEH",
+	"63lyYTnshXesHMhxhakReWLdJSO18rWhenlSNnAsTM6xxcaeArI3B1YE0VcgPsP2aU9LnqeUim6Yp8H5",
+	"tAcc4M+OJXeS34mImk70t6IbrI72m1ZtfFRS4bC/CY/NCKLs8X9HKmjw1wAYetsnxVN6+K/41cTb9MLb",
+	"5E/3mQWtseXKMS/JgddmLIvVtQJHElhHN7nRRQMGqZgIEXuUtkBzlF9GcCqwWvapyZWEjpN+sAVpU1LB",
+	"4TKDAYN1OD7Psn+fZ0pBGWgKyvGcJPVErnrOZIWJj8l9swhfVZW+X64qa+3FXvWArnoO58e4r9Prvd2w",
+	"B8bpryMQykAxBhKhdOyp6JZA2pZLKGnBgU8wdmDIlIK5wx2zChWdyC7XVckCjYBdaIsgKMG4jRAdYgIX",
+	"z1tTtQ43K5QJZw1hcDyJtDZyxSG70AZlmB8rd3AAgBtRCCXtGWmE0wLbcjgKfCycwkHgtacWynRlll4A",
+	"/4qQDxgF0H+ExEPgloP+Iquob8ELcR9+SDeUIXAX0KczQEOxVXofF9Fy+rnNwvfR7YX6E30iKLwFkPjF",
+	"b28BDFH63GoZ3zF4qRqUWzYgqR4BAdIWJdGxW9YKJXEsKmLiIPrhIBzJhzGSDuVkQ3OWwcAugPc03AgR",
+	"8nbiSDw3wbGW5Ssf0iBA4d8A+rKl3IivUYjEEzX07k5c04M2mIEtDDHb23EVp0NS9MtO2Ni/iY5oSkdU",
+	"ilcjQ5cnHg5hHFyYhl7800O5hYlTqEdhGySCBXkwPPwse9SoI+UH2lOHBzn8Dre8XcXNTfnETcXC0g2P",
+	"pki63F83+OnuDrrD9W+qjRNwonvynquU/JQb3E1u8DYBqUE03KxJ4lU3cKft3Ohu/Z+mjvPIHeYyLdvc",
+	"Q67yjAcEiWWX+nFkzm+p6Xbe/rLKph0EuHo2953CeUqLHWhabHv+gXh3/aAtJlGD9YFW1U/5hPYUeTaV",
+	"Wj5/tptAcolHtAPEFLhyshE/2+4WWoq34J3TSnlbJxBiim72E2amTZttj5j3aXvGeXuGSeSVYN/dNiye",
+	"t01CR7F8dvFja7Ji7dPxFhvGkbzo6DdfqjF20LYLr7oqshwgWJa9qMaxhJrQGnXuUaeYSJfQcxjoG4A7",
+	"0A/mp3j0CP5DLq3xaP7DIsVDpX0QOcyxHABZSCRMNbQWH2WzX6vNkMO7VtXXipCqdCy78/qYDwR1GyeF",
+	"DzkhnMyDmVjp53Dw6/jXEafmup0LPq3zwD3lBlQcHG56Yrj5SeHTOSLc79ng+tMn1+M7DDyIdILyoypN",
+	"z6gUzgyHTQ8LOx4S7uVo2WHHgq+n48CCPXJBYSMOyebc79Dxs+xRHY+FUnIDoj2tVH2Gt4RZGiAgh+GY",
+	"9CkJ0z3f3eQx9OOYLB5+iEIU0V3Ia0CPVs+r/7JboZAIp0WWyHNScY0AE8Fh5cb2TZR+wUKELKzTLz9E",
+	"16rIm8cOH2Mv1Q7z/OS8unoH7kO623JLLAethvgCbbZsDyIWigsUQ0A3mHGR4rPm0TD9NDqbzWeY1/bv",
+	"HQr3s/mML+nsciYqns01IRfc5OVMVsoRZerPIwojTImhRxf3F+Dx27LmVLlZXjM5deAXTPx8yyXtPWDi",
+	"H9YYXxnLxsR/XBo7rmeig7qKuoy/VCI3cSVFZ+aXHzTFktFMQ1CuAbVgSvlHBYaf+kdRpL/S++GpUV2Q",
+	"t9QvkeEt9d+7inFlU1yYISYoBIyCO8S8tVqKkG4uwLu7WGfP058BDIK0XBQvEV8tKHQ6X1Fe4gmzNUDQ",
+	"WwNEWLgHDN7fxzy2Kn1RMs7kAzfd/363WaGQjy1CHiV+BCJMPASe1thb8xFGa/okRlLSrvj8oyybafqO",
+	"hhvIZpczTNhfX87msw0meLPbzC6X87hfmDB0j8KONOcV9TmQK3d9qC8HO+nM4u6QmpsBKcqkgnN3f/SN",
+	"0vpcPrk0+pBB9bwGDR8CCv2U5Ab0iQg5vCH80+wAL8C/SIAfENii8DxRsgZveQ7YGkfAp0g8y3NDlEYC",
+	"EAT4EQG6ErtvvFXw//7P/016SMOE/eIRNPbgR8SixRX1I/CC/xV9gZttgG4IvGMoBD+jYAN2BJOIccUT",
+	"og3ysRCcM/4PiAl4xBFeBULMA6GAuOrw45s4Xl29uyERCh9ReAE+enSrrtHiuuE+QNq8vEj+1we/vvv4",
+	"CVAS7P8GCHpEIfCCXcRQeB6JGs4ubki90UmMxkB993+IvUU+UWJNVTLM7zAkymOXN5ucXYAPG8ykqASB",
+	"TK4tU90qeSBVZohwNfnHTFU7m89krbPP83qN/hv8wtUsIIlmV/4No8rSgBc+uoO7gIHvlss52MAv4Pvl",
+	"sszDD/AGs0z3VOnZJS8+28j2Zpffi3/FSv7bnpR8vXucQGTyj8v3EouBu9mvNCjLXiwB92ktkgvWGIUw",
+	"9NbYgwF4xOhJkOFBIBWwNuikZuCjbUD3qXJMLgeLbYLU6rl5mQNMvGAnN+zWOPC1Gl9oWnwOuBqfg3/S",
+	"VXTm5pR/4kP+iqn43FCrRDoTzgkoTDJdHfPySTqiIydbaSf5R/X4kCyguJKyJCD5136SgeLWR50LZFqA",
+	"+pygEmSM4dRW+eB18TXj2j75x9yGUxaQqQvDzgYy9rjzrKDyXpSQvdObAQdk+pjn0EqWDjKJ3LM1VeyU",
+	"ClQCgDgnCHxapz/eYQID/B8UAoTZmgfpMPKgj2QG+Y74KAz2/MNrxP8f+fEm7wtJElzRAHv7v8vmxUXZ",
+	"axr4Ue7P1+IfZ+XpSEfTCvb29tD0pJJZH2+e0gEy1DBxydxiSRR1WpBbDsmUjCfF6SAMu+Q8lcy01QMG",
+	"OZNh9YKBrp5vwSJX06f9Fr056hsHJyB/w/IlB6UApocOHJKzuvYl2+FVjsenTERKX0SKK4MySuakgjE5",
+	"gCqxffQgUbn2rx7IlLxb6mku8D0iXArRLcAEPH578d2ZJSNzQlRMzxyMlcGcSJfGpEu1GDazjAV65SBe",
+	"pe6MVfuC5ezaHkxjTPSFDRpb4StseIoBomjZq4IdKxXRpnY8LGBo71W066Q/03to3cYH70jEIPGsA4Qp",
+	"R6oqkjBFEA1CB/dd1VNw3mOo9eW9Z9svsS6T2+7stpdg3tESpQ56E888s8OZLGa6xbkKqPcQSZ8WUwJ2",
+	"hOFApPvJ3L0SIk4Q3XkrK2huL0CQF9xt66KAjh23xn7/2P39UtV9gINf6dgPCRjLfrTt2Hz4cvfAfcMw",
+	"t0H4245B8YF82TxZf+DtWOxg5DQZeMSwjHqs273rGbxD8VJ6kptpF855F64VL6X5aw9purV47gE+QhzA",
+	"VZDcdlDz7MO1tj0/vftwgHjZPPyQXatR7YTln37I4s45kHV8/EFv7RQi2j6efyi2XWIjpgcgGu5C5W5w",
+	"zotAA4uxeA5Zk6jW5hGI1mXG3ilr8gxEFp6j32Oqwdphu0ult3sPGTPLnjTl6LaTaqHXICa1fxBiYBAc",
+	"go/QF/KnVyGO9ypEF05Fmw9DuNmOTp+G6MGC1L8NkZWkkTwOEZoGfSi2I+SFiIXoDoWINM1MkJWAtBbr",
+	"dzU/ipLXafMTx+IuLtk5rKNZCos1BqalOOhUcAoYtOVb8pU6UC65NofMuuS72jHxYmw+uyof8+swPdDQ",
+	"zQMNeQGoFqpmBmnxHGWrcmB0CgJaQ+ocQyrrDcXH4vhcqJ0C+sfK7rihsRHHk2/C6KoPH0XLXrXzWCgf",
+	"VzzaEz8FvWbF/QwSlwPxV/qViOndhm7ebTiGv8JCiFmzsFkWdU5K+CRbnCJlZ9kUM1cXH6sFHUFQzGIg",
+	"xUKgkGUb/4ryDkGvqH7Ioa7sYMcBrtZodrLFH6ZYtqNYlilwFmTBxQwsnsV/HUJUKUM1cWl7glOvjD/F",
+	"A3CJQSVUxxp4lkKnUYwpajMGlsOCwbIrDTiWeLECRvahodQnVvFg73Dq1YB3Bt9pn39oFl9Fg61b/DYz",
+	"AmqsQKcpAF3agvq9fylVI9nzZ/pgG0P1iYYPdwF9Eq/rNOMq4iqArMN4vdKn/RZ74gYCSsRjPHVMxu+q",
+	"0ivZr4nRcBaXzAzWMRu5NRwDxZEfcipCOezZch7ZCh3Ij0x7QyZBsh3tmAwxNJ5djcwHEznSETmSRX2V",
+	"FDUxSIvnJ70aB/YkJ401NEr7IlhvCX7Pj8yFVsmCfaz0ij34GvEt2eqNLvewgbPsXvsqeRsLM+OCQHuq",
+	"Jqe8rDibwSFxEP7Hsi//Y+J2BsrtHMthCXfEJn6Oo2ZxK7BuY3h5y23+uKfXvMluJX3EF/Rps24dTgtQ",
+	"jCmYDiUk8zJVFUV/CvH9PQrjMNokGHWR8/WOnELczLvZU9ScNF3itYU7EofMU3rZEaPkUCDVJB7u1mbx",
+	"HO5Ik5CYL7ZlQNyWZNlbmGs5pibBsBjY6GPhcogdFgQb9bAWAg8PKste1OjoQt8qwDWIefkcOkW8gwDe",
+	"ALyGfuA+Zah3HLcex4VYoEfep9oIVnuHX5bIpye42Is3ss0+hXeeH+g/xBX58eBWe8Bg9CB8pdl8hvkX",
+	"/+Yx8Gw+E79dzvjfZ3NNssTNEpeziIXyLbdDDRNmaBM5iKyY1TeEhUIOVW9gGMJ9rTArEDQV39MzXPGI",
+	"jyBQAbV4Vp9/VCVB4C6kG8EJ5TYjwK+8JAwRuEPMW4t8jEdU9vnfAKEAht4aP/Iv46Kh6AXyRQ/4XErX",
+	"mQ+kTnR584MUXDG4NsR2bl4z2QBBTygEbA2JuB4ugIzPvr+T8wUwARHyKPGjktYjTDz0Mfkk7cUdDTeQ",
+	"zS5nmLC/vpzNZxtM8Ga3mV0uE1nGhKF7FPagWn6l980UixCGEamVgN4fRalEDLJdZJVHSB9RCIMAyCLi",
+	"4vwtCs8jhrbxb80jvY+yHyOI9+RIq9IOM0BXC3SquI3idT0cuYfshrgffUz7OeUKNoa77b7GqPY0XPcz",
+	"slmBhe0M97zAU9ja6Gtfo1IfTzmA3e5utGM20py/JnsblvsaHXsujXc0xr6bcYydjErfdkjAWHarLse2",
+	"cdHmpoXThkXPGOvbC+gY1lMm3sAz8Y7iNrR54tLKcHR67rJj81F/9DKRtpGcvnzKjfdQCAcU+s2PX4rS",
+	"Lm8/J2MuJ1Nkj7qB8+v415Gnl/I5t+Fg5NpMz8uZSZsYubpEyt9cjnLyEo5kDS8ydLJG9LEHsiZtt2g4",
+	"xFRPZE13ZI0CqklAHE2W9Lr4/zqSNWLNLcia1mTKzqmKR+JK1ojhjJmsqYBUY7KGV1Dqcw8NGMtu1eWY",
+	"yJpKbLmRNWLurMmaAWCsby+gY1hP2aTdcS9WXgAMtmv47QLuGF3tcODz1s0u9JXsMIoAJh7dCIlDqzWl",
+	"D0mmaEg3AJI9iHbbLQ35Ot9jBrYhfcQ+CgGjgMnDYIC3t4EMe0C0Gl3ckE9rlP0cR+lnIsL1EUMerzXJ",
+	"glPyA9YI+iiMLm/IOXiL2c+71SW4/d/nP+9W5x/xPYFsF6Lz777/66364FcoP3iLWQBX55/oAyLibz9i",
+	"ttp5D4iJP4tMy/Nf0P4WvIjwPUEyYihUfXt2Q27Im0cU7vPdXyPCu8+Qf6l6JjJ1knbEk/A///bq9fnH",
+	"n1999/1fQRRXekMeUchtpUw5g/cQk4iJYXuU3OH7HQ/24yWQF1zP1eBErZhFIFpD/hXjA7y4IUp8JJdA",
+	"dwxA8AgD7KetLsSngiHjLSVTngxL5hX+KX69uCEF7fozJH6AXu0Y/VHgqaBes6hSc5IMI+6HWlKwi0T3",
+	"VUfE3Ikec5CrshJ9F3EmniyYpuIZYOCWF6imNO6inCC77vFytd3TQejWsxRFGUk8f0D7kg6mJWq7lYD/",
+	"0D4Z0Q1e3EZr+N33f/37zW65/Iu3Rl/E/6Dbs6TPyUw69Dqz1vVp283ML/R9LHm3q5Cjn2FuTrmBnRex",
+	"k4pOPCFbuI91s+wTXXF56txgy+6Ida7kfuNuKwPQo/Xuw7Qibxditp9d/vFZN7RSz2UtllpgzeimetBg",
+	"dCsC8HvMpEa3II2DQPRCfQ9sHt97i9VbNVF7fNaRUJp0lfe7CqYxgarNxcnlpOl9T0GkrZZ1WlpSkTDl",
+	"6vlIj/pId0owLT16n7Q5ZMIz19VEvXRLf2rtl6PzbbogExPaDRMKNSkok6ZmOnnxfB9X4kCLajJZQ4y2",
+	"K3z15MRbfTQu1KiG6rGSo22jLEQBghFaYeJjch8tntUPP8of4huoRRhdHqyn1uCfdJXGyz7aBnSPfPA6",
+	"pOSfdPVNJBjZiz/p6hPabANBHfAIFxJAnwgK9RcUofcgQvg1iovPxT8iuEFghdbwEdNdCGAEbh92K+Sx",
+	"QKk68CddgfNz3ou/eyElf9LVQnr9fOzK7b8AH0iw594MfeJx7RoRFeuqdfkmShk+8Q4yjoCq7QJ8WqOY",
+	"W0C+GPMLHovxEHhL/egMwO0WwTA+bJA+qBwiJKI2ceorwA9IEBiUrVEYj/Kcz4SotCiv6nKb68waqXKd",
+	"PdOdx0cHXpkaYjL8iku710isR2z1EizGszRtc2fUym+Q7ATbFVNlQggkzuUeilIIQKmIzEPgOhRcNY91",
+	"wFH6DngENpDAe5mDwvut3rt7dfVOSh6Oboh2bfgb6K0BZmgDMPGCnY9kvpZ2Bl1V4EMGk4OwHEE3hH/I",
+	"YHiPWHxi9h1Dmwg8rWkU/+Vc3q+oKlnDCBDKwJ4bYITIDYn2xEO+oLToBrMMPLfwHpn4rfTt8s6OIg0z",
+	"oUWbCJuwLBOSfU0ni3ipb62UxLvNNkAbRMQlXGUvlRffJ3d9llxaw0iTHBxJjiLClFsyZQR16bkhkFdS",
+	"lLxtsON/uNpFa/ULW0MGuOREALPYIUgZ6RuCvsj5ibsQMRqiC/AK5F5alAZcWgUcG3vCQhrEfYoo/yXa",
+	"bVAYAQ8SzRth6RBXe/CA9iZZ1V9cH34c22sQqyap/M3SKWptP2ptQ3UkwW4hBGkWfyQhbuQa32Zj29SS",
+	"ZoRaONsZu135InunTxU3fH+9PPKd9rT7lIwkQK+QjHmdq6tAXerXzpXrism9iDZ1T/WGJDKQ9VTj6l8u",
+	"XwJ8p9WYsY0bHEW8Whrq3q7yaYuWOu/eAundmuxi8lT9cMRr2Z0lu0uP1Xw9MWQbAvMWsTppqcnGUoW/",
+	"UXIgqCThqe34cvLwCgvHkEGGLsAvaM8dUxQhwm6IcgHzT92vdgzAFf+kmPaxov5eRG/bcEcy8lYQD0lV",
+	"pW7sXBqiouSJLIla8fQpktImuguoSPfg/1aK4oYUNMVF/P+CvMqbQTEMvNnsGNeeJqHVn/LvVW7b93/1",
+	"oTn5vx1qjSlzbZhWXiW81fq/awQDtq4ltz78Eot8hMJHmcYli+4vwL8idZdagB8RQZEIq1fIfJnaz7LB",
+	"Wswy9IUttgHEObSiL5APenY5+/BLmiqSpK8YcJrrb3X6gvgGeGvk6fkKH+JRxNNGt4jALb6Ipan2sOWH",
+	"LSKvrt6Bv1wsk2xvmcEmc8pwFNOB//z44T2Q96EZJ1DV9HGLvNmBkp/tbnkXfertOMrMqTnmWjI1VM45",
+	"t6/mUhULECIoNW3lzF/zr4rIFYUBowB6Htqy2HBGGpT5J7gOy6L6NqAcV+SAZjkBVfN6nQyhFs6PKIyw",
+	"BZLVdwATCVCRgbmiO5l/KRZQdNA4W/+lGjmiuVJNVBGv/1UcQi06FXIekwGYJzJby/NshWCIwlc7rl//",
+	"+My9BFmRKeHzV+rBAPjoEQV0q2RtFwazy9mase3lYhHwD9Y0Ypc/LH9YCp9D9SJfldRh8xTC0qmL1w4R",
+	"f0uxvP1T5QdqwyhmLiY+knLiVOdU0eSvpqJXIeVqQisYHy1MmZa0KvW1qaLkpKyhqm1cLKko+dpU1Rvy",
+	"iENKNubKTP3SSpgq/AkyKB8/0qrjKuQpPbSyDehe/C59W63ypLSp6uzbSrnqX79bvP5J5olzMIcwYuHO",
+	"U/mdqvbc4z7FFj6sOCThCgeY7Y3NbCjBjHJ9FG8I38vdtRg7hRqMCxjsIobC88ijW+QD05xp6yc/rpya",
+	"XIVlM1WotHZGchVXTlCh9kaTkcD1E4+AmEo4iICP7jCR5Ar/hasrgMg9JoirkHzTmVosWpWvRqetxXfh",
+	"UuHBAi+kUXTu7ZgIOj1KPBSSYqvq3eUKiW04qLrRHNj98n5nZym58CDbkpC6WCTi0xjkXty+G5ViztTe",
+	"2/xFeUlDRSk2lb+mATpfQe62QBGBJbyy6pqIlaSlNgH3lf7FzJjlX8zUXosk31Bd4Zw7s5KpW2X5FutV",
+	"4WO6c2XqXI5eKFORQsnquZwCZFgatMwsxjcIlNuXOIvAKOTxVyqhwLge2SwEYz35fASDTUktxhZvUYBL",
+	"1E763ZX6rFbJAxigkAlWJnXwvTUkBAXGNjKlX4nC77Wyr2XRqAQ7GaI4MSrlibdpu1qqWCl8tGqhEPlU",
+	"jjj8BduWPHSdAZWF7F+rbKiD1LJeiRkvhzRiW3uF2wReKG7uPOtEcK8FER8RD6PorNhkZXNVUhR/VClE",
+	"uXqqpSlTX4VUxe6oTa3q20Kln//7/wcAAP//fnrEZCQkBQA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/openchoreo-api/api/handlers/releasebinding_k8sresources.go
+++ b/internal/openchoreo-api/api/handlers/releasebinding_k8sresources.go
@@ -59,6 +59,61 @@ func (h *Handler) GetReleaseBindingK8sResourceTree(
 	}, nil
 }
 
+// GetReleaseBindingNamespaceEvents returns Kubernetes Events from the ReleaseBinding
+// dataplane workload namespace (namespaced LIST; works after uninstall remediation).
+func (h *Handler) GetReleaseBindingNamespaceEvents(
+	ctx context.Context,
+	request gen.GetReleaseBindingNamespaceEventsRequestObject,
+) (gen.GetReleaseBindingNamespaceEventsResponseObject, error) {
+	h.logger.Debug("GetReleaseBindingNamespaceEvents called",
+		"namespace", request.NamespaceName,
+		"releaseBinding", request.ReleaseBindingName)
+
+	eventType := ""
+	if request.Params.Type != nil {
+		eventType = string(*request.Params.Type)
+	}
+	limit := 200
+	if request.Params.Limit != nil {
+		limit = *request.Params.Limit
+	}
+
+	resp, err := h.services.K8sResourcesService.GetNamespaceEvents(
+		ctx,
+		request.NamespaceName,
+		request.ReleaseBindingName,
+		eventType,
+		limit,
+	)
+	if err != nil {
+		return h.handleK8sNamespaceEventsError(err)
+	}
+
+	result, err := convert[models.ResourceEventsResponse, gen.ResourceEventsResponse](*resp)
+	if err != nil {
+		h.logger.Error("Failed to convert namespace events response", "error", err)
+		return gen.GetReleaseBindingNamespaceEvents500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
+	}
+
+	return gen.GetReleaseBindingNamespaceEvents200JSONResponse(result), nil
+}
+
+func (h *Handler) handleK8sNamespaceEventsError(err error) (gen.GetReleaseBindingNamespaceEventsResponseObject, error) {
+	switch {
+	case errors.Is(err, services.ErrForbidden):
+		return gen.GetReleaseBindingNamespaceEvents403JSONResponse{ForbiddenJSONResponse: forbidden()}, nil
+	case errors.Is(err, k8sresourcessvc.ErrReleaseBindingNotFound):
+		return gen.GetReleaseBindingNamespaceEvents404JSONResponse{NotFoundJSONResponse: notFound("ReleaseBinding")}, nil
+	case errors.Is(err, k8sresourcessvc.ErrRenderedReleaseNotFound):
+		return gen.GetReleaseBindingNamespaceEvents404JSONResponse{NotFoundJSONResponse: notFound("RenderedRelease")}, nil
+	case errors.Is(err, k8sresourcessvc.ErrEnvironmentNotFound):
+		return gen.GetReleaseBindingNamespaceEvents404JSONResponse{NotFoundJSONResponse: notFound("Environment")}, nil
+	default:
+		h.logger.Error("Failed to get namespace k8s events", "error", err)
+		return gen.GetReleaseBindingNamespaceEvents500JSONResponse{InternalErrorJSONResponse: internalError()}, nil
+	}
+}
+
 // GetReleaseBindingK8sResourceEvents returns Kubernetes events for a specific resource
 // in the release binding's resource tree.
 func (h *Handler) GetReleaseBindingK8sResourceEvents(

--- a/internal/openchoreo-api/services/k8sresources/interface.go
+++ b/internal/openchoreo-api/services/k8sresources/interface.go
@@ -27,6 +27,7 @@ type K8sResourceTreeResult struct {
 type Service interface {
 	GetResourceTree(ctx context.Context, namespaceName, releaseBindingName string) (*K8sResourceTreeResult, error)
 	GetResourceEvents(ctx context.Context, namespaceName, releaseBindingName, group, version, kind, name string) (*models.ResourceEventsResponse, error)
+	GetNamespaceEvents(ctx context.Context, namespaceName, releaseBindingName string, eventType string, limit int) (*models.ResourceEventsResponse, error)
 	GetResourceLogs(ctx context.Context, namespaceName, releaseBindingName, podName, container string, sinceSeconds *int64) (*models.ResourcePodLogsResponse, error)
 	TriggerCronJob(ctx context.Context, namespaceName, releaseBindingName string) (*models.CronJobTriggerResponse, error)
 }

--- a/internal/openchoreo-api/services/k8sresources/mocks/service.go
+++ b/internal/openchoreo-api/services/k8sresources/mocks/service.go
@@ -88,6 +88,64 @@ func (_c *MockService_GetResourceEvents_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
+
+// GetNamespaceEvents provides a mock function with given fields: ctx, namespaceName, releaseBindingName, eventType, limit
+func (_m *MockService) GetNamespaceEvents(ctx context.Context, namespaceName string, releaseBindingName string, eventType string, limit int) (*models.ResourceEventsResponse, error) {
+	ret := _m.Called(ctx, namespaceName, releaseBindingName, eventType, limit)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNamespaceEvents")
+	}
+
+	var r0 *models.ResourceEventsResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, int) (*models.ResourceEventsResponse, error)); ok {
+		return rf(ctx, namespaceName, releaseBindingName, eventType, limit)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, int) *models.ResourceEventsResponse); ok {
+		r0 = rf(ctx, namespaceName, releaseBindingName, eventType, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*models.ResourceEventsResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, int) error); ok {
+		r1 = rf(ctx, namespaceName, releaseBindingName, eventType, limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockService_GetNamespaceEvents_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetNamespaceEvents'
+type MockService_GetNamespaceEvents_Call struct {
+	*mock.Call
+}
+
+// GetNamespaceEvents is a helper method to define mock.On call
+func (_e *MockService_Expecter) GetNamespaceEvents(ctx interface{}, namespaceName interface{}, releaseBindingName interface{}, eventType interface{}, limit interface{}) *MockService_GetNamespaceEvents_Call {
+	return &MockService_GetNamespaceEvents_Call{Call: _e.mock.On("GetNamespaceEvents", ctx, namespaceName, releaseBindingName, eventType, limit)}
+}
+
+func (_c *MockService_GetNamespaceEvents_Call) Run(run func(ctx context.Context, namespaceName string, releaseBindingName string, eventType string, limit int)) *MockService_GetNamespaceEvents_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(int))
+	})
+	return _c
+}
+
+func (_c *MockService_GetNamespaceEvents_Call) Return(_a0 *models.ResourceEventsResponse, _a1 error) *MockService_GetNamespaceEvents_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockService_GetNamespaceEvents_Call) RunAndReturn(run func(context.Context, string, string, string, int) (*models.ResourceEventsResponse, error)) *MockService_GetNamespaceEvents_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetResourceLogs provides a mock function with given fields: ctx, namespaceName, releaseBindingName, podName, container, sinceSeconds
 func (_m *MockService) GetResourceLogs(ctx context.Context, namespaceName string, releaseBindingName string, podName string, container string, sinceSeconds *int64) (*models.ResourcePodLogsResponse, error) {
 	ret := _m.Called(ctx, namespaceName, releaseBindingName, podName, container, sinceSeconds)

--- a/internal/openchoreo-api/services/k8sresources/service.go
+++ b/internal/openchoreo-api/services/k8sresources/service.go
@@ -174,7 +174,8 @@ func (s *k8sResourcesService) GetNamespaceEvents(ctx context.Context, namespaceN
 	rawQuery := ""
 	switch eventType {
 	case "Warning", "Normal":
-		rawQuery = "type=" + eventType
+		// Kubernetes Event LIST filters via fieldSelector, not a top-level "type" query.
+		rawQuery = "fieldSelector=type=" + eventType
 	}
 
 	eventsPath := fmt.Sprintf("api/v1/namespaces/%s/events", workloadNS)

--- a/internal/openchoreo-api/services/k8sresources/service.go
+++ b/internal/openchoreo-api/services/k8sresources/service.go
@@ -139,6 +139,111 @@ func (s *k8sResourcesService) GetResourceEvents(ctx context.Context, namespaceNa
 	return &models.ResourceEventsResponse{Events: events}, nil
 }
 
+// GetNamespaceEvents lists Kubernetes Events in the ReleaseBinding's dataplane
+// workload namespace. Unlike GetResourceEvents, this does not require a live
+// object name — Events for deleted ReplicaSets/Pods remain queryable while the
+// API server retains them. Uses namespaced Event LIST only (never cluster-scoped).
+func (s *k8sResourcesService) GetNamespaceEvents(ctx context.Context, namespaceName, releaseBindingName string, eventType string, limit int) (*models.ResourceEventsResponse, error) {
+	s.logger.Debug("Getting namespace k8s events", "namespace", namespaceName, "releaseBinding", releaseBindingName,
+		"type", eventType, "limit", limit)
+
+	if s.gatewayClient == nil {
+		return nil, fmt.Errorf("gateway client is not configured")
+	}
+
+	if limit <= 0 {
+		limit = 200
+	}
+	if limit > 500 {
+		limit = 500
+	}
+
+	releaseContexts, err := s.resolveReleaseContexts(ctx, namespaceName, releaseBindingName)
+	if err != nil {
+		return nil, err
+	}
+	if len(releaseContexts) == 0 {
+		return &models.ResourceEventsResponse{Events: []models.ResourceEvent{}}, nil
+	}
+
+	rc, workloadNS := selectDataplaneNamespaceContext(releaseContexts)
+	if rc == nil || workloadNS == "" {
+		return &models.ResourceEventsResponse{Events: []models.ResourceEvent{}}, nil
+	}
+
+	rawQuery := ""
+	switch eventType {
+	case "Warning", "Normal":
+		rawQuery = "type=" + eventType
+	}
+
+	eventsPath := fmt.Sprintf("api/v1/namespaces/%s/events", workloadNS)
+	items, err := s.fetchK8sList(ctx, rc.plane, eventsPath, rawQuery)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch namespace events: %w", err)
+	}
+
+	events := make([]models.ResourceEvent, 0, len(items))
+	for _, item := range items {
+		events = append(events, mapNamespaceEventItem(item))
+	}
+
+	sort.SliceStable(events, func(i, j int) bool {
+		ti, tj := eventSortTime(events[i]), eventSortTime(events[j])
+		return ti.After(tj)
+	})
+	if len(events) > limit {
+		events = events[:limit]
+	}
+
+	return &models.ResourceEventsResponse{Events: events}, nil
+}
+
+// selectDataplaneNamespaceContext picks a dataplane release context with a known
+// workload namespace for namespaced Event LIST.
+func selectDataplaneNamespaceContext(contexts []releaseContext) (*releaseContext, string) {
+	for i := range contexts {
+		rc := &contexts[i]
+		if rc.release != nil && rc.release.Spec.TargetPlane == planeTypeObservabilityPlane {
+			continue
+		}
+		if rc.namespace != "" {
+			return rc, rc.namespace
+		}
+	}
+	for i := range contexts {
+		if contexts[i].namespace != "" {
+			return &contexts[i], contexts[i].namespace
+		}
+	}
+	return nil, ""
+}
+
+func eventSortTime(event models.ResourceEvent) time.Time {
+	if event.LastTimestamp != nil {
+		return *event.LastTimestamp
+	}
+	if event.FirstTimestamp != nil {
+		return *event.FirstTimestamp
+	}
+	return time.Time{}
+}
+
+// mapNamespaceEventItem maps a raw Event and prefixes the message with
+// involvedObject kind/name so callers can identify deleted resources.
+func mapNamespaceEventItem(item map[string]any) models.ResourceEvent {
+	event := mapEventItem(item)
+	kind := getNestedString(item, "involvedObject", "kind")
+	name := getNestedString(item, "involvedObject", "name")
+	if kind != "" && name != "" {
+		prefix := fmt.Sprintf("[%s/%s] ", kind, name)
+		if !strings.HasPrefix(event.Message, prefix) {
+			event.Message = prefix + event.Message
+		}
+	}
+	return event
+}
+
 // GetResourceLogs returns logs for a specific pod in the release binding's resource tree.
 // When container is empty, logs from every container in the pod are returned, each entry
 // tagged with its container name and merged into a single timeline ordered by timestamp.

--- a/internal/openchoreo-api/services/k8sresources/service_authz.go
+++ b/internal/openchoreo-api/services/k8sresources/service_authz.go
@@ -46,6 +46,13 @@ func (s *k8sResourcesServiceWithAuthz) GetResourceTree(ctx context.Context, name
 	return s.internal.GetResourceTree(ctx, namespaceName, releaseBindingName)
 }
 
+func (s *k8sResourcesServiceWithAuthz) GetNamespaceEvents(ctx context.Context, namespaceName, releaseBindingName string, eventType string, limit int) (*models.ResourceEventsResponse, error) {
+	if err := s.checkReleaseBindingAuthz(ctx, namespaceName, releaseBindingName); err != nil {
+		return nil, err
+	}
+	return s.internal.GetNamespaceEvents(ctx, namespaceName, releaseBindingName, eventType, limit)
+}
+
 func (s *k8sResourcesServiceWithAuthz) GetResourceEvents(ctx context.Context, namespaceName, releaseBindingName, group, version, kind, name string) (*models.ResourceEventsResponse, error) {
 	if err := s.checkReleaseBindingAuthz(ctx, namespaceName, releaseBindingName); err != nil {
 		return nil, err

--- a/internal/openchoreo-api/services/k8sresources/service_integration_test.go
+++ b/internal/openchoreo-api/services/k8sresources/service_integration_test.go
@@ -479,6 +479,138 @@ func TestGetResourceEvents(t *testing.T) {
 	})
 }
 
+// --- GetNamespaceEvents ---
+
+func TestGetNamespaceEvents(t *testing.T) {
+	t.Run("nil gateway client returns error", func(t *testing.T) {
+		fc := newFakeClient()
+		svc := NewService(fc, nil, testLogger())
+
+		_, err := svc.GetNamespaceEvents(context.Background(), testNamespace, "rb-1", "Warning", 50)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "gateway client is not configured")
+	})
+
+	t.Run("no owned releases returns empty events", func(t *testing.T) {
+		rb := testReleaseBinding()
+		env := testEnvironment()
+		dp := testDataPlane("default")
+		fc := newFakeClient(rb, env, dp)
+		gc := testGatewayServer(t, func(w http.ResponseWriter, r *http.Request) {
+			t.Fatalf("unexpected gateway call: %s", r.URL.String())
+		})
+		svc := NewService(fc, gc, testLogger())
+
+		result, err := svc.GetNamespaceEvents(context.Background(), testNamespace, "rb-1", "Warning", 50)
+		require.NoError(t, err)
+		assert.Empty(t, result.Events)
+	})
+
+	t.Run("success uses namespaced path and fieldSelector type", func(t *testing.T) {
+		rb := testReleaseBinding()
+		env := testEnvironment()
+		dp := testDataPlane("default")
+		rr := testRenderedRelease(rb, planeTypeDataPlane, []openchoreov1alpha1.RenderedManifestStatus{
+			{ID: "dep", Group: "apps", Version: "v1", Kind: "Deployment", Name: "web", Namespace: "dp-ns"},
+		})
+		fc := newFakeClient(rb, env, dp, rr)
+
+		var capturedPath, capturedQuery string
+		eventList := k8sList(map[string]any{
+			"type":          "Warning",
+			"reason":        "FailedCreate",
+			"message":       "exceeded quota: team-quota",
+			"lastTimestamp": "2024-01-15T10:05:00Z",
+			"involvedObject": map[string]any{
+				"kind": "ReplicaSet",
+				"name": "web-abc",
+			},
+		})
+		gc := testGatewayServer(t, func(w http.ResponseWriter, r *http.Request) {
+			capturedPath = r.URL.Path
+			capturedQuery = r.URL.RawQuery
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(jsonMarshal(t, eventList))
+		})
+
+		svc := NewService(fc, gc, testLogger())
+		result, err := svc.GetNamespaceEvents(context.Background(), testNamespace, "rb-1", "Warning", 50)
+		require.NoError(t, err)
+		require.Len(t, result.Events, 1)
+		assert.Equal(t, "FailedCreate", result.Events[0].Reason)
+		assert.Contains(t, result.Events[0].Message, "[ReplicaSet/web-abc]")
+		assert.Contains(t, result.Events[0].Message, "exceeded quota")
+		assert.Contains(t, capturedPath, "api/v1/namespaces/dp-ns/events")
+		assert.Equal(t, "fieldSelector=type=Warning", capturedQuery)
+	})
+
+	t.Run("orders by lastTimestamp descending and caps limit", func(t *testing.T) {
+		rb := testReleaseBinding()
+		env := testEnvironment()
+		dp := testDataPlane("default")
+		rr := testRenderedRelease(rb, planeTypeDataPlane, []openchoreov1alpha1.RenderedManifestStatus{
+			{ID: "dep", Group: "apps", Version: "v1", Kind: "Deployment", Name: "web", Namespace: "dp-ns"},
+		})
+		fc := newFakeClient(rb, env, dp, rr)
+
+		eventList := k8sList(
+			map[string]any{
+				"type": "Warning", "reason": "Older", "message": "old",
+				"lastTimestamp": "2024-01-15T10:00:00Z",
+			},
+			map[string]any{
+				"type": "Warning", "reason": "Newer", "message": "new",
+				"lastTimestamp": "2024-01-15T11:00:00Z",
+			},
+			map[string]any{
+				"type": "Warning", "reason": "Middle", "message": "mid",
+				"lastTimestamp": "2024-01-15T10:30:00Z",
+			},
+		)
+		gc := testGatewayServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(jsonMarshal(t, eventList))
+		})
+
+		svc := NewService(fc, gc, testLogger())
+		result, err := svc.GetNamespaceEvents(context.Background(), testNamespace, "rb-1", "", 2)
+		require.NoError(t, err)
+		require.Len(t, result.Events, 2)
+		assert.Equal(t, "Newer", result.Events[0].Reason)
+		assert.Equal(t, "Middle", result.Events[1].Reason)
+	})
+
+	t.Run("limit above max is capped at 500", func(t *testing.T) {
+		rb := testReleaseBinding()
+		env := testEnvironment()
+		dp := testDataPlane("default")
+		rr := testRenderedRelease(rb, planeTypeDataPlane, []openchoreov1alpha1.RenderedManifestStatus{
+			{ID: "dep", Group: "apps", Version: "v1", Kind: "Deployment", Name: "web", Namespace: "dp-ns"},
+		})
+		fc := newFakeClient(rb, env, dp, rr)
+
+		items := make([]map[string]any, 0, 510)
+		for i := 0; i < 510; i++ {
+			items = append(items, map[string]any{
+				"type": "Warning", "reason": "R", "message": "m",
+				"lastTimestamp": "2024-01-15T10:00:00Z",
+			})
+		}
+		gc := testGatewayServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(jsonMarshal(t, k8sList(items...)))
+		})
+
+		svc := NewService(fc, gc, testLogger())
+		result, err := svc.GetNamespaceEvents(context.Background(), testNamespace, "rb-1", "Warning", 9999)
+		require.NoError(t, err)
+		assert.Len(t, result.Events, 500)
+	})
+}
+
 // --- GetResourceLogs ---
 
 func TestGetResourceLogs(t *testing.T) {

--- a/internal/openchoreo-api/services/k8sresources/service_test.go
+++ b/internal/openchoreo-api/services/k8sresources/service_test.go
@@ -829,3 +829,34 @@ func TestResolveDataPlaneInfo_BothNil(t *testing.T) {
 	pi := resolveDataPlaneInfo(dpResult)
 	assert.Equal(t, planeInfo{}, pi)
 }
+
+func TestMapNamespaceEventItem_PrefixesInvolvedObject(t *testing.T) {
+	event := mapNamespaceEventItem(map[string]any{
+		"type":    "Warning",
+		"reason":  "FailedCreate",
+		"message": "pods \"web-abc\" is forbidden: exceeded quota: team-quota, requested: requests.cpu=1, used: 0, limited: 0",
+		"involvedObject": map[string]any{
+			"kind": "ReplicaSet",
+			"name": "web-7b987fd964",
+		},
+		"lastTimestamp": "2026-08-06T19:10:02Z",
+	})
+	assert.Equal(t, "Warning", event.Type)
+	assert.Equal(t, "FailedCreate", event.Reason)
+	assert.Contains(t, event.Message, "[ReplicaSet/web-7b987fd964]")
+	assert.Contains(t, event.Message, "exceeded quota")
+}
+
+func TestSelectDataplaneNamespaceContext_SkipsObservability(t *testing.T) {
+	obs := &openchoreov1alpha1.RenderedRelease{}
+	obs.Spec.TargetPlane = planeTypeObservabilityPlane
+	dp := &openchoreov1alpha1.RenderedRelease{}
+	dp.Spec.TargetPlane = planeTypeDataPlane
+	contexts := []releaseContext{
+		{release: obs, namespace: "obs-ns"},
+		{release: dp, namespace: "app-ns"},
+	}
+	rc, ns := selectDataplaneNamespaceContext(contexts)
+	require.NotNil(t, rc)
+	assert.Equal(t, "app-ns", ns)
+}

--- a/openapi/openchoreo-api.yaml
+++ b/openapi/openchoreo-api.yaml
@@ -4342,6 +4342,54 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
+  /api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/namespace-events:
+    get:
+      operationId: getReleaseBindingNamespaceEvents
+      summary: List Kubernetes events in the release binding workload namespace
+      description: |
+        Returns Kubernetes Events from the dataplane workload namespace owned by
+        the ReleaseBinding. Unlike per-resource k8sresources/events, this does not
+        require a live object name — Events for deleted ReplicaSets/Pods (for example
+        after Helm uninstall remediation) remain visible while retained by the API
+        server. Scoped to a single namespace (namespaced LIST only; never cluster-scoped).
+      tags: [ReleaseBindings]
+      parameters:
+        - $ref: '#/components/parameters/NamespaceNameParam'
+        - $ref: '#/components/parameters/ReleaseBindingNameParam'
+        - name: type
+          in: query
+          required: false
+          description: Filter by event type (Warning or Normal). Omit for all types.
+          schema:
+            type: string
+            enum: [Warning, Normal]
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of events to return (default 200, max 500)
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 200
+      responses:
+        '200':
+          description: Namespace events
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResourceEventsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
   /api/v1/namespaces/{namespaceName}/releasebindings/{releaseBindingName}/k8sresources/events:
     get:
       operationId: getReleaseBindingK8sResourceEvents


### PR DESCRIPTION
## Summary

Adds `GET /api/v1/namespaces/{ns}/releasebindings/{rb}/k8sresources/namespace-events` so API clients can list **real Kubernetes Events** in the ReleaseBinding workload namespace **without** knowing live object names.

Today `…/k8sresources/events` requires `kind` + `name`. After Helm install failure + uninstall remediation, ReplicaSets/Pods are gone from the live tree, so UIs that fan out from the resource tree miss the root-cause Events (e.g. `FailedCreate` / ResourceQuota) even though the API server still retains them for a while.

This endpoint:
- resolves the dataplane workload namespace from the ReleaseBinding’s RenderedRelease
- performs a **namespaced** `LIST events` via the existing plane gateway proxy (never cluster-scoped)
- supports optional `type=Warning|Normal` and `limit` (default 200, max 500)
- prefixes messages with `[Kind/name]` from `involvedObject` so callers can identify deleted resources

## Motivation / repro sketch

1. Deploy a workload that fails before Pod creation (e.g. ResourceQuota blocks ReplicaSet).
2. Flux/Helm uninstall remediation deletes Deployment/ReplicaSet.
3. `k8sresources/tree` no longer exposes the ReplicaSet → per-resource events fan-out returns empty / Helm `NotFound` noise.
4. `kubectl -n <workload-ns> get events` still shows `FailedCreate`.
5. With this PR, `namespace-events` returns that Event.

## Test plan

- [x] `go test ./internal/openchoreo-api/services/k8sresources/`
- [x] `go test ./internal/openchoreo-api/api/handlers/ -run TestGetReleaseBindingK8sResourceEvents`
- [x] `go build ./cmd/openchoreo-api/`
- [ ] Manual: call new endpoint against a ReleaseBinding whose inventory was remediating; confirm Warning Events for deleted ReplicaSets appear while still in etcd

## Notes

- Authz reuses existing ReleaseBinding authorization.
- No UI/Backstage changes in this PR.
- Follow-up could add structured `involvedKind` / `involvedName` fields on `ResourceEvent` instead of message prefixing.

Made with [Cursor](https://cursor.com)