### PR TITLE
feat(api): expand HelmRelease inventory into resource tree

### DIFF
--- a/internal/openchoreo-api/services/k8sresources/helm_inventory.go
+++ b/internal/openchoreo-api/services/k8sresources/helm_inventory.go
@@ -1,0 +1,163 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sresources
+
+import (
+	"encoding/json"
+	"strings"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/models"
+)
+
+// fluxInventoryResource coordinates parsed from Flux helm-controller inventory entry IDs.
+type fluxInventoryResource struct {
+	Namespace string
+	Name      string
+	Kind      string
+	Group     string
+	Version   string
+}
+
+var fluxInventoryKindAPI = map[string]fluxInventoryResource{
+	"Deployment":              {Kind: "Deployment", Group: "apps", Version: "v1"},
+	"ReplicaSet":              {Kind: "ReplicaSet", Group: "apps", Version: "v1"},
+	"StatefulSet":             {Kind: "StatefulSet", Group: "apps", Version: "v1"},
+	"DaemonSet":               {Kind: "DaemonSet", Group: "apps", Version: "v1"},
+	"Job":                     {Kind: "Job", Group: "batch", Version: "v1"},
+	"Pod":                     {Kind: "Pod", Version: "v1"},
+	"PersistentVolumeClaim":   {Kind: "PersistentVolumeClaim", Version: "v1"},
+}
+
+// parseFluxHelmInventoryEntryID parses Flux helm-controller inventory entry IDs.
+//
+// Examples:
+//
+//	obt-dev_smollm2_apps_Deployment
+//	obt-dev_smollm2-model-storage__PersistentVolumeClaim
+func parseFluxHelmInventoryEntryID(id string) *fluxInventoryResource {
+	trimmed := strings.TrimSpace(id)
+	if trimmed == "" {
+		return nil
+	}
+
+	for kind, api := range fluxInventoryKindAPI {
+		suffix := kind
+		if kind == "PersistentVolumeClaim" {
+			suffix = "__" + kind
+		} else {
+			suffix = "_" + kind
+		}
+		if !strings.HasSuffix(trimmed, suffix) {
+			continue
+		}
+		prefix := trimmed[:len(trimmed)-len(suffix)]
+		out := api
+
+		if kind == "PersistentVolumeClaim" {
+			splitAt := strings.Index(prefix, "_")
+			if splitAt <= 0 {
+				return nil
+			}
+			out.Namespace = prefix[:splitAt]
+			out.Name = prefix[splitAt+1:]
+			return &out
+		}
+
+		groupSplit := strings.LastIndex(prefix, "_")
+		if groupSplit <= 0 {
+			return nil
+		}
+		out.Group = prefix[groupSplit+1:]
+		nsName := prefix[:groupSplit]
+		nsSplit := strings.Index(nsName, "_")
+		if nsSplit <= 0 {
+			return nil
+		}
+		out.Namespace = nsName[:nsSplit]
+		out.Name = nsName[nsSplit+1:]
+		return &out
+	}
+
+	return nil
+}
+
+func inventoryEntryIDsFromStatus(status map[string]any) []string {
+	inventory, _ := status["inventory"].(map[string]any)
+	entries, _ := inventory["entries"].([]any)
+	ids := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		entryMap, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		id := strings.TrimSpace(getStringField(entryMap, "id"))
+		if id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func inventoryEntryIDsFromObject(obj map[string]any) []string {
+	status, _ := obj["status"].(map[string]any)
+	if status == nil {
+		return nil
+	}
+	return inventoryEntryIDsFromStatus(status)
+}
+
+func inventoryEntryIDsFromManifestStatus(entry *openchoreov1alpha1.RenderedManifestStatus) []string {
+	if entry == nil || entry.Status == nil || len(entry.Status.Raw) == 0 {
+		return nil
+	}
+	var status map[string]any
+	if err := json.Unmarshal(entry.Status.Raw, &status); err != nil {
+		return nil
+	}
+	return inventoryEntryIDsFromStatus(status)
+}
+
+func helmManifestStatusHasInventoryKind(entry *openchoreov1alpha1.RenderedManifestStatus, kind string) bool {
+	for _, id := range inventoryEntryIDsFromManifestStatus(entry) {
+		parsed := parseFluxHelmInventoryEntryID(id)
+		if parsed != nil && parsed.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func helmInventoryResourceMatch(
+	entry *openchoreov1alpha1.RenderedManifestStatus,
+	group, version, kind, name string,
+) (namespace string, matched bool) {
+	for _, id := range inventoryEntryIDsFromManifestStatus(entry) {
+		parsed := parseFluxHelmInventoryEntryID(id)
+		if parsed == nil || parsed.Kind != kind || parsed.Name != name {
+			continue
+		}
+		if parsed.Group != group {
+			continue
+		}
+		if version != "" && parsed.Version != "" && parsed.Version != version {
+			continue
+		}
+		return parsed.Namespace, true
+	}
+	return "", false
+}
+
+func dedupeResourceNodes(nodes []models.ResourceNode) []models.ResourceNode {
+	seen := make(map[string]bool, len(nodes))
+	out := make([]models.ResourceNode, 0, len(nodes))
+	for _, node := range nodes {
+		if node.UID == "" || seen[node.UID] {
+			continue
+		}
+		seen[node.UID] = true
+		out = append(out, node)
+	}
+	return out
+}

--- a/internal/openchoreo-api/services/k8sresources/helm_inventory_test.go
+++ b/internal/openchoreo-api/services/k8sresources/helm_inventory_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8sresources
+
+import (
+	"testing"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestParseFluxHelmInventoryEntryID(t *testing.T) {
+	t.Parallel()
+
+	deployment := parseFluxHelmInventoryEntryID("obt-dev_smollm2_apps_Deployment")
+	if deployment == nil {
+		t.Fatal("expected deployment parse")
+	}
+	if deployment.Namespace != "obt-dev" || deployment.Name != "smollm2" || deployment.Group != "apps" {
+		t.Fatalf("unexpected deployment: %+v", deployment)
+	}
+
+	pvc := parseFluxHelmInventoryEntryID("obt-dev_smollm2-model-storage__PersistentVolumeClaim")
+	if pvc == nil {
+		t.Fatal("expected pvc parse")
+	}
+	if pvc.Namespace != "obt-dev" || pvc.Name != "smollm2-model-storage" {
+		t.Fatalf("unexpected pvc: %+v", pvc)
+	}
+}
+
+func TestHelmManifestStatusHasInventoryKind(t *testing.T) {
+	t.Parallel()
+
+	entry := &openchoreov1alpha1.RenderedManifestStatus{
+		Kind: "HelmRelease",
+		Status: &runtime.RawExtension{
+			Raw: []byte(`{"inventory":{"entries":[{"id":"obt-dev_smollm2_apps_Deployment"}]}}`),
+		},
+	}
+	if !helmManifestStatusHasInventoryKind(entry, "Deployment") {
+		t.Fatal("expected Deployment in inventory")
+	}
+	if helmManifestStatusHasInventoryKind(entry, "Pod") {
+		t.Fatal("did not expect Pod in inventory")
+	}
+}
+
+func TestHelmInventoryResourceMatch(t *testing.T) {
+	t.Parallel()
+
+	entry := &openchoreov1alpha1.RenderedManifestStatus{
+		Kind: "HelmRelease",
+		Status: &runtime.RawExtension{
+			Raw: []byte(`{"inventory":{"entries":[{"id":"obt-dev_smollm2_apps_Deployment"}]}}`),
+		},
+	}
+	ns, ok := helmInventoryResourceMatch(entry, "apps", "v1", "Deployment", "smollm2")
+	if !ok || ns != "obt-dev" {
+		t.Fatalf("expected match in obt-dev, got ok=%v ns=%q", ok, ns)
+	}
+}
+
+func TestHelmReleaseResourceRef(t *testing.T) {
+	t.Parallel()
+
+	ref := helmReleaseResourceRef(map[string]any{
+		"apiVersion": "helm.toolkit.fluxcd.io/v2",
+		"kind":       "HelmRelease",
+		"metadata": map[string]any{
+			"name":      "smollm2",
+			"namespace": "obt-dev",
+			"uid":       "hr-uid-1",
+		},
+	})
+	if ref == nil {
+		t.Fatal("expected parent ref")
+	}
+	if ref.Kind != "HelmRelease" || ref.Name != "smollm2" || ref.UID != "hr-uid-1" {
+		t.Fatalf("unexpected ref: %+v", ref)
+	}
+	if ref.Group != "helm.toolkit.fluxcd.io" || ref.Version != "v2" {
+		t.Fatalf("unexpected GVK: %+v", ref)
+	}
+	if helmReleaseResourceRef(map[string]any{"metadata": map[string]any{"name": "x"}}) != nil {
+		t.Fatal("expected nil without uid")
+	}
+}

--- a/internal/openchoreo-api/services/k8sresources/service.go
+++ b/internal/openchoreo-api/services/k8sresources/service.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"maps"
 	"net/http"
+	"net/url"
 	"slices"
 	"sort"
 	"strings"
@@ -417,9 +418,14 @@ func (s *k8sResourcesService) buildResourceTreeNodes(ctx context.Context, rc *re
 
 		childNodes := s.fetchChildResources(ctx, rc.plane, obj, rs)
 		allNodes = append(allNodes, childNodes...)
+
+		if rs.Kind == "HelmRelease" {
+			inventoryNodes := s.fetchHelmInventoryWorkloadNodes(ctx, rc.plane, obj)
+			allNodes = append(allNodes, inventoryNodes...)
+		}
 	}
 
-	return allNodes
+	return dedupeResourceNodes(allNodes)
 }
 
 // findResourceRelease finds which release context contains the requested resource
@@ -431,6 +437,24 @@ func (s *k8sResourcesService) findResourceRelease(contexts []releaseContext, gro
 		for _, rs := range rc.release.Status.Resources {
 			if rs.Group == group && rs.Version == version && rs.Kind == kind && rs.Name == name {
 				return rc, rs.Namespace
+			}
+		}
+	}
+
+	// Match resources referenced from HelmRelease inventory when RenderedRelease
+	// status.resources tracks the HelmRelease but not child Deployments/Pods.
+	for i := range contexts {
+		rc := &contexts[i]
+		for j := range rc.release.Status.Resources {
+			rs := &rc.release.Status.Resources[j]
+			if rs.Kind != "HelmRelease" {
+				continue
+			}
+			if ns, ok := helmInventoryResourceMatch(rs, group, version, kind, name); ok {
+				if ns != "" {
+					return rc, ns
+				}
+				return rc, rc.namespace
 			}
 		}
 	}
@@ -521,6 +545,162 @@ func (s *k8sResourcesService) fetchK8sList(ctx context.Context, pi planeInfo, k8
 	}
 
 	return result, nil
+}
+
+func helmReleaseResourceRef(helmObj map[string]any) *models.ResourceRef {
+	uid := getNestedString(helmObj, "metadata", "uid")
+	name := getNestedString(helmObj, "metadata", "name")
+	if uid == "" || name == "" {
+		return nil
+	}
+	return &models.ResourceRef{
+		Group:     getAPIGroup(helmObj),
+		Version:   getAPIVersion(helmObj),
+		Kind:      "HelmRelease",
+		Namespace: getNestedString(helmObj, "metadata", "namespace"),
+		Name:      name,
+		UID:       uid,
+	}
+}
+
+func (s *k8sResourcesService) appendWorkloadSubtree(
+	ctx context.Context,
+	pi planeInfo,
+	parentRef *models.ResourceRef,
+	obj map[string]any,
+	group, version, kind, namespace, name string,
+) []models.ResourceNode {
+	var nodes []models.ResourceNode
+	if node, ok := buildResourceNode(obj, parentRef, ""); ok {
+		nodes = append(nodes, node)
+	}
+	status := &openchoreov1alpha1.RenderedManifestStatus{
+		Group:     group,
+		Version:   version,
+		Kind:      kind,
+		Namespace: namespace,
+		Name:      name,
+	}
+	nodes = append(nodes, s.fetchChildResources(ctx, pi, obj, status)...)
+	return nodes
+}
+
+func (s *k8sResourcesService) fetchHelmInventoryWorkloadNodes(ctx context.Context, pi planeInfo, helmObj map[string]any) []models.ResourceNode {
+	parentRef := helmReleaseResourceRef(helmObj)
+	var nodes []models.ResourceNode
+	seenDeployments := map[string]bool{}
+
+	for _, id := range inventoryEntryIDsFromObject(helmObj) {
+		parsed := parseFluxHelmInventoryEntryID(id)
+		if parsed == nil {
+			continue
+		}
+
+		switch parsed.Kind {
+		case "Deployment", "StatefulSet", "DaemonSet":
+			plural, err := s.resolveResourcePlural(parsed.Group, parsed.Version, parsed.Kind)
+			if err != nil {
+				s.logger.Warn("Failed to resolve workload plural from Helm inventory", "id", id, "error", err)
+				continue
+			}
+			k8sPath := buildK8sGetPath(parsed.Group, parsed.Version, plural, parsed.Namespace, parsed.Name)
+			obj, err := s.fetchLiveResource(ctx, pi, k8sPath)
+			if err != nil {
+				s.logger.Warn("Failed to fetch workload from Helm inventory", "id", id, "error", err)
+				continue
+			}
+			key := parsed.Namespace + "/" + parsed.Kind + "/" + parsed.Name
+			seenDeployments[key] = true
+			nodes = append(nodes, s.appendWorkloadSubtree(
+				ctx, pi, parentRef, obj,
+				parsed.Group, parsed.Version, parsed.Kind, parsed.Namespace, parsed.Name,
+			)...)
+		case "PersistentVolumeClaim":
+			plural, err := s.resolveResourcePlural(parsed.Group, parsed.Version, parsed.Kind)
+			if err != nil {
+				continue
+			}
+			k8sPath := buildK8sGetPath(parsed.Group, parsed.Version, plural, parsed.Namespace, parsed.Name)
+			pvcObj, err := s.fetchLiveResource(ctx, pi, k8sPath)
+			if err != nil {
+				continue
+			}
+			if pvcNode, ok := buildResourceNode(pvcObj, parentRef, ""); ok {
+				nodes = append(nodes, pvcNode)
+			}
+		}
+	}
+
+	// When Flux inventory is empty/stale (Progressing / remediating), fall back to
+	// namespaced LIST of Deployments owned by this HelmRelease via Flux labels.
+	if !hasWorkloadKind(nodes, "Deployment") && !hasWorkloadKind(nodes, "StatefulSet") {
+		nodes = append(nodes, s.fetchHelmLabeledWorkloadNodes(ctx, pi, helmObj, parentRef, seenDeployments)...)
+	}
+
+	return nodes
+}
+
+func hasWorkloadKind(nodes []models.ResourceNode, kind string) bool {
+	for _, n := range nodes {
+		if n.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *k8sResourcesService) fetchHelmLabeledWorkloadNodes(
+	ctx context.Context,
+	pi planeInfo,
+	helmObj map[string]any,
+	parentRef *models.ResourceRef,
+	seen map[string]bool,
+) []models.ResourceNode {
+	hrName := getNestedString(helmObj, "metadata", "name")
+	hrNS := getNestedString(helmObj, "metadata", "namespace")
+	if hrName == "" || hrNS == "" {
+		return nil
+	}
+
+	// Workloads land in HelmRelease targetNamespace when set; otherwise HR namespace.
+	targetNS := hrNS
+	if spec, _ := helmObj["spec"].(map[string]any); spec != nil {
+		if tn := strings.TrimSpace(getStringField(spec, "targetNamespace")); tn != "" {
+			targetNS = tn
+		}
+	}
+
+	plural, err := s.resolveResourcePlural("apps", "v1", "Deployment")
+	if err != nil {
+		return nil
+	}
+	k8sPath := buildK8sListPath("apps", "v1", plural, targetNS)
+	rawQuery := "labelSelector=" + url.QueryEscape(
+		"helm.toolkit.fluxcd.io/name="+hrName+",helm.toolkit.fluxcd.io/namespace="+hrNS,
+	)
+	items, err := s.fetchK8sList(ctx, pi, k8sPath, rawQuery)
+	if err != nil {
+		s.logger.Warn("Failed to list Deployments by HelmRelease labels",
+			"helmRelease", hrName, "namespace", targetNS, "error", err)
+		return nil
+	}
+
+	var nodes []models.ResourceNode
+	for _, item := range items {
+		item["kind"] = "Deployment"
+		item["apiVersion"] = "apps/v1"
+		name := getNestedString(item, "metadata", "name")
+		ns := getNestedString(item, "metadata", "namespace")
+		key := ns + "/Deployment/" + name
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		nodes = append(nodes, s.appendWorkloadSubtree(
+			ctx, pi, parentRef, item, "apps", "v1", "Deployment", ns, name,
+		)...)
+	}
+	return nodes
 }
 
 func (s *k8sResourcesService) fetchChildResources(ctx context.Context, pi planeInfo, parentObj map[string]any, rs *openchoreov1alpha1.RenderedManifestStatus) []models.ResourceNode {
@@ -935,6 +1115,18 @@ func hasParentResourceInRelease(childKind string, resources []openchoreov1alpha1
 	for i := range resources {
 		if slices.Contains(parentKinds, resources[i].Kind) {
 			return true
+		}
+	}
+	// HelmRelease inventory lists Deployments helm waits on even when RR inventory
+	// omits them (namespace-scoped / identity inventory profiles).
+	if childKind == "Pod" || childKind == "ReplicaSet" {
+		for i := range resources {
+			if resources[i].Kind != "HelmRelease" {
+				continue
+			}
+			if helmManifestStatusHasInventoryKind(&resources[i], "Deployment") {
+				return true
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
## Summary

`GET …/releasebindings/{rb}/k8sresources/tree` previously stopped at the Flux `HelmRelease` for helm-based workloads. Child Deployments/Pods never appeared in the portal resource tree, so users could not open per-resource Events on the real failing object.

This PR expands the tree from the live HelmRelease:

1. **Inventory** — parse `status.inventory.entries`, GET matching Deployments/StatefulSets/DaemonSets/PVCs, attach `parentRefs` → HelmRelease, then fan out owned ReplicaSets/Pods via existing `fetchChildResources`
2. **Label fallback** — if inventory is empty/stale while the release is Progressing, namespaced LIST Deployments with `helm.toolkit.fluxcd.io/name` + `helm.toolkit.fluxcd.io/namespace` (never cluster-scoped)
3. **Authz** — `findResourceRelease` / `hasParentResourceInRelease` recognize inventory children so per-resource Events/logs keep working

Companion UI: [backstage-plugins#750](https://github.com/openchoreo/backstage-plugins/pull/750) nests inventory siblings under HelmRelease when `parentRefs` were missing.

## Motivation / repro

1. Deploy a helm ComponentType workload (e.g. inference HelmRelease)
2. Open portal Runtime tree → only OCIRepository / HelmRelease / HTTPRoute / ExternalSecret
3. HelmRelease is a leaf; Deployment/Pod Events are unreachable from the tree
4. With this PR, tree includes Deployment (and Pods) under the HelmRelease

## Test plan

- [x] `go test ./internal/openchoreo-api/services/k8sresources/`
- [ ] Manual: Progressing HelmRelease with inventory or labeled Deployment → tree shows Deployment under HR
- [ ] Click Deployment/Pod → Events for that object only

## Notes

- Namespaced LIST/GET only (compatible with namespace-scoped dataplane RBAC)
- No Backstage changes in this PR


Made with [Cursor](https://cursor.com)