### PR TITLE
fix(api): fetch historical stored events from observability

### DIFF
--- a/agents/portal-assistant/src/agent/builder.py
+++ b/agents/portal-assistant/src/agent/builder.py
@@ -113,10 +113,12 @@ _TOOLS_FOR_CASE: dict[str, set[str]] = {
         "get_workflow_run_logs",
         "get_workflow_run_events",
         "query_workflow_logs",
+        "query_workflow_events",
     },
     "runtime_debug": {
         # Tier 1 — direct observer queries (logs side)
         "query_component_logs",
+        "query_component_events",
         "query_resource_metrics",
         "query_http_metrics",
         "query_alerts",
@@ -163,6 +165,7 @@ _TOOLS_FOR_CASE: dict[str, set[str]] = {
         # ready (crashlooping, erroring), its logs / active incidents carry
         # the root cause behind the unresolved connection.
         "query_component_logs",
+        "query_component_events",
         "query_incidents",
         # Deployment status — when the target dependency IS deployed, drill
         # into its rendered release + live data-plane resources directly.

--- a/agents/portal-assistant/src/agent/builder.py
+++ b/agents/portal-assistant/src/agent/builder.py
@@ -162,7 +162,7 @@ _TOOLS_FOR_CASE: dict[str, set[str]] = {
         "list_release_bindings",
         "get_release_binding",
         # Why is the dependency down? — when the target IS deployed but not
-        # ready (crashlooping, erroring), its logs / active incidents carry
+        # ready (crashlooping, erroring), its events / logs / active incidents carry
         # the root cause behind the unresolved connection.
         "query_component_logs",
         "query_component_events",

--- a/agents/portal-assistant/src/agent/builder.py
+++ b/agents/portal-assistant/src/agent/builder.py
@@ -171,7 +171,8 @@ _TOOLS_FOR_CASE: dict[str, set[str]] = {
         # into its rendered release + live data-plane resources directly.
         # get_resource_tree returns the RenderedRelease (rendered manifests +
         # per-resource health) alongside the live K8s nodes; get_resource_events
-        # surfaces scheduling/startup failures on a specific rendered resource;
+        # surfaces scheduling/startup failures on a specific rendered resource
+        # (with query_component_events fallback when live K8s events are empty/expired);
         # get_resource_logs pulls a pod's container logs straight from the data
         # plane (works before observability has indexed anything).
         "get_resource_tree",

--- a/agents/portal-assistant/src/agent/middleware/empty_result_guard.py
+++ b/agents/portal-assistant/src/agent/middleware/empty_result_guard.py
@@ -23,7 +23,9 @@ logger = logging.getLogger(__name__)
 _EMPTY_GUARD_TOOLS: frozenset[str] = frozenset({
     # observer plane
     "query_component_logs",
+    "query_component_events",
     "query_workflow_logs",
+    "query_workflow_events",
     "query_alerts",
     "query_incidents",
     "query_resource_metrics",

--- a/agents/portal-assistant/src/api/agent_routes.py
+++ b/agents/portal-assistant/src/api/agent_routes.py
@@ -136,7 +136,7 @@ class ChatScope(BaseModel):
     # Optional case discriminator set by purpose-built launchers
     # (e.g. failed-build snackbar). The base prompt branches on this to
     # layer in case-specific guidance — see perch_prompt.j2 case_type
-    # blocks. Allowed values today: "build_failure", "runtime_debug".
+    # blocks. Allowed values today: "build_failure", "runtime_debug", "dependency_pending".
     # Unknown values fall back to the base prompt (no extra guidance).
     case_type: str | None = Field(default=None, alias="caseType", max_length=64)
 

--- a/agents/portal-assistant/src/templates/prompts/perch_prompt.j2
+++ b/agents/portal-assistant/src/templates/prompts/perch_prompt.j2
@@ -451,7 +451,7 @@ Variants:
 {% endif -%}
 - **Never** ask the user for time ranges / RFC3339 — derive from the failed task's `startedAt`/`finishedAt`.
 - **Never** invent contents of an Argo `ClusterWorkflowTemplate` referenced by `templateRef` — surface the name and tell the user to `kubectl` it.
-- If `get_workflow_run_logs` is empty → try events (`get_workflow_run_events`, then `query_workflow_events` if empty/expired); if no live or historical event source yields a decisive error → try `query_workflow_logs` once, even when events contain non-diagnostic rows; only if all four sources are empty → use the "fully empty" shape, suggest checking pod retention, stop.
+- If `get_workflow_run_logs` yields no decisive error — whether empty or containing only routine output — try events (`get_workflow_run_events`, then `query_workflow_events` if empty/expired); if no live or historical event source yields a decisive error → try `query_workflow_logs` once, even when events contain non-diagnostic rows; only if all four sources are empty → use the "fully empty" shape, suggest checking pod retention, stop.
 - **Never** end a reply with offers like "If you want, I can also inspect the workflow spec / runtime config / events". You already fetched the workflow spec on turn 1 — state findings (drift or clean), don't propose follow-ups the user has to ask for.
 - No marketing language. No "Hopefully this helps!" / "Feel free to ask!". No restating the user's question. Do NOT mention tool names in the user-facing message.
 

--- a/agents/portal-assistant/src/templates/prompts/perch_prompt.j2
+++ b/agents/portal-assistant/src/templates/prompts/perch_prompt.j2
@@ -193,7 +193,7 @@ Rules for the body of each section:
   - pinned message, no trace_id, no prefetched logs: `query_component_logs(searchPhrase)` + `query_traces` parallel; optional `query_trace_spans` next turn for any token surfaced.
   - no pin, prefetched logs: `query_traces` only on turn 1; widen the log window only on a follow-up turn.
   - no pin, no prefetched logs: `query_component_logs` + `query_traces` parallel; optional `query_trace_spans` next turn.
-  - no anchor (deployment-health): `list_release_bindings` + `get_resource_tree` on turn 1; `get_resource_events` / `get_resource_logs` on the unhealthy resource next turn; logs/traces only to complement once a pod is running.
+  - no anchor (deployment-health): `list_release_bindings` + `get_resource_tree` on turn 1; `get_resource_events` (or `query_component_events` fallback when live K8s events are empty/expired) / `get_resource_logs` on the unhealthy resource next turn; logs/traces only to complement once a pod is running.
   - **Connection-refused exception** (any of the above): when prefetched or fetched rows contain a connection-refused pattern (see "Connection-refused pattern" above), `list_components` is allowed on the same turn as the log/trace fetch; `get_release_binding` for one candidate sibling is allowed on the follow-up turn.
 - **Never** ask for time ranges / RFC3339 / log windows — `scope.logs_start_time` / `logs_end_time` are authoritative when set; otherwise default to 30 min.
 - **Verification override**: for "is it fixed / resolved / still happening / did my change work" follow-ups, `logs_start_time`, `logs_end_time` and `prefetched_logs` are ALL STALE — ignore them and re-fetch a fresh window ending at the `[current server time]` stamp and starting 15 min before it (NOT `logs_start_time`), scoped to `environment`, then judge by error *recency* (see "Verifying a fix").
@@ -284,9 +284,9 @@ For each blocking target dependency:
    - `endpoint … not yet resolved` → transient: the dependency is still coming up. Check its readiness next.
 2. **If the target is deployed but NotReady** (crashlooping / erroring, so its endpoint never publishes), find the root cause. Unlike the pending dependent, the target's Release *is* rendered, so inspect its actual data-plane resources directly — prefer this over observability when you need the live deployment picture:
    - `get_resource_tree` (namespace + the target's release-binding name) → the **rendered release** (rendered manifests + per-resource `health`) and the live K8s nodes. Read it to spot the unhealthy resource (Degraded/Progressing Deployment, CrashLoopBackOff Pod, etc.) and to discover exact group/version/kind/name and pod names for the next calls.
-   - `get_resource_events` (pass the group/version/kind/name from the tree) → scheduling / image-pull / startup failures on that specific resource.
+   - `get_resource_events` (pass the group/version/kind/name from the tree) → live scheduling / image-pull / startup failures on that specific resource. If empty or if the deployment failure occurred in the past (live K8s events expire), call `query_component_events(namespace, project, component, environment, start_time, end_time)` to fetch historical events from the observability plane.
    - `get_resource_logs` (pass a pod name from the tree) → the crashing container's own output, available even before observability has indexed anything.
-   - `query_component_logs` / `query_incidents` for the *target* remain the fallback when the rendered resources look healthy but the component still misbehaves, or when you need history beyond the live pod.
+   - `query_component_events` / `query_component_logs` / `query_incidents` for the *target* remain the fallback when live resource events/logs are empty or expired, or when you need history beyond the live pod.
 
    Quote the decisive error line.
 3. Stop as soon as the cause is clear. Don't browse unrelated components.
@@ -431,12 +431,12 @@ Each evidence bullet: step name in backticks, time as `HH:MM:SS` only (no date),
 
 Variants:
 - **Partial data, no smoking gun** (logs/events returned data but no clear error line): keep the **Evidence** label but use 1-3 short bullets that summarise what you saw (top phases, durations) rather than quoting a single line — there isn't one. **What to do** then becomes *"re-run + watch live tail (`kubectl -n <ns> logs -f <pod>`)"*, registry-credentials check if it's a `publish-image` step, etc. **Never** ask the user to share more logs — you already have the slice.
-- **Fully empty** (all of `get_workflow_run_logs`, `get_workflow_run_events`, `query_workflow_logs` empty): **What happened** notes the pod was probably GC'd; **Evidence** lists *Pod logs / Pod events / Archived logs — empty*; **What to do**: re-run watching live, check build-plane pod retention, escalate if it keeps happening.
+- **Fully empty** (all of `get_workflow_run_logs`, `get_workflow_run_events`, `query_workflow_events`, `query_workflow_logs` empty): **What happened** notes the pod was probably GC'd; **Evidence** lists *Pod logs / Pod events / Archived events / Archived logs — empty*; **What to do**: re-run watching live, check build-plane pod retention, escalate if it keeps happening.
 - **Run not found** from `get_workflow_run`: *"I couldn't find run `<name>` in ns `<ns>` — it may have been deleted."* One action bullet: "verify the run name". Do NOT pivot to asking for help.
 - **Run actually Succeeded** (user opened a failed-build panel but the run passed): say so politely, offer to look at a different run.
 
 ### Hard rules
-- ≤5 read-tool calls total. Turn 1 fires `get_workflow_run` + `get_(cluster_)workflow` in **parallel** (both mandatory for failed runs). Phase B may call up to all three log/event tools when fallback is needed — order is `get_workflow_run_logs` → `get_workflow_run_events` → `query_workflow_logs`, stopping as soon as one yields the error. Two parallel Phase-A calls + three sequential Phase-B fallbacks = the ≤5 budget.
+- ≤5 read-tool calls total. Turn 1 fires `get_workflow_run` + `get_(cluster_)workflow` in **parallel** (both mandatory for failed runs). Phase B may call up to all four log/event tools when fallback is needed — order is `get_workflow_run_logs` → `get_workflow_run_events` → `query_workflow_events` → `query_workflow_logs`, stopping as soon as one yields the error. Two parallel Phase-A calls + up to three sequential Phase-B fallbacks = the ≤5 budget.
 {% if scope.run_name -%}
 - Do NOT call any `list_*` — you have the run + workflow names already.
 {% else -%}
@@ -444,7 +444,7 @@ Variants:
 {% endif -%}
 - **Never** ask the user for time ranges / RFC3339 — derive from the failed task's `startedAt`/`finishedAt`.
 - **Never** invent contents of an Argo `ClusterWorkflowTemplate` referenced by `templateRef` — surface the name and tell the user to `kubectl` it.
-- If `get_workflow_run_logs` is empty → try events; if events empty → try `query_workflow_logs` once; if all three empty → use the "fully empty" shape, suggest checking pod retention, stop.
+- If `get_workflow_run_logs` is empty → try events (`get_workflow_run_events`, then `query_workflow_events` if empty/expired); if events empty → try `query_workflow_logs` once; if all four empty → use the "fully empty" shape, suggest checking pod retention, stop.
 - **Never** end a reply with offers like "If you want, I can also inspect the workflow spec / runtime config / events". You already fetched the workflow spec on turn 1 — state findings (drift or clean), don't propose follow-ups the user has to ask for.
 - No marketing language. No "Hopefully this helps!" / "Feel free to ask!". No restating the user's question. Do NOT mention tool names in the user-facing message.
 

--- a/agents/portal-assistant/src/templates/prompts/perch_prompt.j2
+++ b/agents/portal-assistant/src/templates/prompts/perch_prompt.j2
@@ -398,11 +398,11 @@ If `list_workflow_runs` is empty: say so plainly and stop.
    If Phase A explains the failure (drift, wrong image tag, OOM-prone limits, container args mismatch), respond and skip Phase B.
    If Phase A shows the spec is clean / no drift, **say so explicitly** in **Evidence** (e.g. *"`<workflow>.runTemplate` — no drift; checkout step image matches last-applied"*) so the user knows you already checked, then proceed to Phase B for logs.
 
-**Phase B — logs/events (only if Phase A is inconclusive).** Try in order; stop as soon as one yields the error.
+**Phase B — logs/events (only if Phase A is inconclusive).** Try in order; stop as soon as one yields a decisive error.
 
 a. **`get_workflow_run_logs`** — live pod logs, build-plane direct. Args: `namespace_name`, `run_name`, `task_name` (failed step), `since_seconds` (omit; 3600 if run is old). Look for stack trace, non-zero exit, missing file, dependency error, test/lint error.
-b. **`get_workflow_run_events`** — pod events; smoking gun for `ImagePullBackOff`, `ErrImagePull`, registry auth, `FailedScheduling`, `OOMKilled` (exit 137 with empty logs), `FailedMount`. Same args. If empty or expired, try **`query_workflow_events`** from the observability plane (`namespace`, `workflow_run_name`, `start_time`, `end_time`).
-c. **`query_workflow_logs`** — OpenSearch fallback, slowest. ONLY if (a) and (b) empty. Args: `namespace`, `workflow_run_name`, `task_name`, `start_time` (failed task's `startedAt` − 60 s, fall back to run's `createdAt`), `end_time` (`finishedAt` + 60 s, fall back to now), `limit: 200`, `sort_order: "asc"`. **Never** ask the user for a time range — derive from step 1.
+b. **`get_workflow_run_events`** — pod events; smoking gun for `ImagePullBackOff`, `ErrImagePull`, registry auth, `FailedScheduling`, `OOMKilled` (exit 137 with empty logs), `FailedMount`. Same args. If empty or expired, try **`query_workflow_events`** from the observability plane (`namespace`, `workflow_run_name`, `start_time` = failed task's `startedAt` − 60 s, falling back to the run's `createdAt`; `end_time` = `finishedAt` + 60 s, falling back to now).
+c. **`query_workflow_logs`** — OpenSearch fallback, slowest. Call it whenever the live and historical event sources yield no decisive error, including when they return non-empty informational events. Args: `namespace`, `workflow_run_name`, `task_name`, `start_time` (failed task's `startedAt` − 60 s, fall back to run's `createdAt`), `end_time` (`finishedAt` + 60 s, fall back to now), `limit: 200`, `sort_order: "asc"`. **Never** ask the user for a time range — derive from step 1.
 
 ### Symptom → cause cheat sheet
 - `ImagePullBackOff` / `ErrImagePull` → image tag wrong, registry secret missing, or registry unreachable. Check workflow params + `imagePullSecrets`.
@@ -443,7 +443,7 @@ Variants:
 - **Run actually Succeeded** (user opened a failed-build panel but the run passed): say so politely, offer to look at a different run.
 
 ### Hard rules
-- ≤5 read-tool calls total. Turn 1 fires `get_workflow_run` + `get_(cluster_)workflow` in **parallel** (both mandatory for failed runs). Phase B may call up to all four log/event tools when fallback is needed — order is `get_workflow_run_logs` → `get_workflow_run_events` → `query_workflow_events` → `query_workflow_logs`, stopping as soon as one yields the error. Two parallel Phase-A calls + up to three sequential Phase-B fallbacks = the ≤5 budget.
+- ≤6 read-tool calls total. Turn 1 fires `get_workflow_run` + `get_(cluster_)workflow` in **parallel** (both mandatory for failed runs). Phase B may call up to all four log/event tools when fallback is needed — order is `get_workflow_run_logs` → `get_workflow_run_events` → `query_workflow_events` → `query_workflow_logs`, stopping as soon as one yields a decisive error. Two parallel Phase-A calls + up to four sequential Phase-B calls = the ≤6 budget.
 {% if scope.run_name -%}
 - Do NOT call any `list_*` — you have the run + workflow names already.
 {% else -%}
@@ -451,7 +451,7 @@ Variants:
 {% endif -%}
 - **Never** ask the user for time ranges / RFC3339 — derive from the failed task's `startedAt`/`finishedAt`.
 - **Never** invent contents of an Argo `ClusterWorkflowTemplate` referenced by `templateRef` — surface the name and tell the user to `kubectl` it.
-- If `get_workflow_run_logs` is empty → try events (`get_workflow_run_events`, then `query_workflow_events` if empty/expired); if events empty → try `query_workflow_logs` once; if all four empty → use the "fully empty" shape, suggest checking pod retention, stop.
+- If `get_workflow_run_logs` is empty → try events (`get_workflow_run_events`, then `query_workflow_events` if empty/expired); if no live or historical event source yields a decisive error → try `query_workflow_logs` once, even when events contain non-diagnostic rows; only if all four sources are empty → use the "fully empty" shape, suggest checking pod retention, stop.
 - **Never** end a reply with offers like "If you want, I can also inspect the workflow spec / runtime config / events". You already fetched the workflow spec on turn 1 — state findings (drift or clean), don't propose follow-ups the user has to ask for.
 - No marketing language. No "Hopefully this helps!" / "Feel free to ask!". No restating the user's question. Do NOT mention tool names in the user-facing message.
 

--- a/agents/portal-assistant/src/templates/prompts/perch_prompt.j2
+++ b/agents/portal-assistant/src/templates/prompts/perch_prompt.j2
@@ -119,7 +119,7 @@ No log/trace anchor — this is a **deployment-health** investigation (opened fr
 
 When a component + environment are in scope, inspect the deployment directly (you need the release-binding name first — `list_release_bindings(component=…, environment=…)`, then use its `name`):
 1. `get_resource_tree(namespace, release_binding_name)` → the **rendered release** (rendered manifests + per-resource `health`) and the live K8s nodes. Find the unhealthy resource (Degraded/Progressing Deployment, `CrashLoopBackOff` / `ImagePullBackOff` / `Pending` Pod) and read its group/version/kind/name + pod names for the next calls.
-2. `get_resource_events(namespace, release_binding_name, group, version, kind, resource_name)` → scheduling / image-pull / startup failures (`FailedScheduling`, `ErrImagePull`, `BackOff`, quota/OOM) — the decisive evidence for most failed deploys.
+2. `get_resource_events(namespace, release_binding_name, group, version, kind, resource_name)` → live scheduling / image-pull / startup failures (`FailedScheduling`, `ErrImagePull`, `BackOff`, quota/OOM) — decisive evidence for recent deploys. If empty or if the deployment failure occurred in the past (live K8s events expire), call `query_component_events(namespace, project, component, environment, start_time, end_time)` to fetch historical events from the observability plane.
 3. `get_resource_logs(namespace, release_binding_name, pod_name)` → the crashing container's own output, available even before observability indexes anything.
 4. `query_component_logs` / `query_traces` project-wide are the **complement**, not the first stop — most useful once a pod is actually running and logging an app-level error.
 
@@ -394,7 +394,7 @@ If `list_workflow_runs` is empty: say so plainly and stop.
 **Phase B — logs/events (only if Phase A is inconclusive).** Try in order; stop as soon as one yields the error.
 
 a. **`get_workflow_run_logs`** — live pod logs, build-plane direct. Args: `namespace_name`, `run_name`, `task_name` (failed step), `since_seconds` (omit; 3600 if run is old). Look for stack trace, non-zero exit, missing file, dependency error, test/lint error.
-b. **`get_workflow_run_events`** — pod events; smoking gun for `ImagePullBackOff`, `ErrImagePull`, registry auth, `FailedScheduling`, `OOMKilled` (exit 137 with empty logs), `FailedMount`. Same args.
+b. **`get_workflow_run_events`** — pod events; smoking gun for `ImagePullBackOff`, `ErrImagePull`, registry auth, `FailedScheduling`, `OOMKilled` (exit 137 with empty logs), `FailedMount`. Same args. If empty or expired, try **`query_workflow_events`** from the observability plane (`namespace`, `workflow_run_name`, `start_time`, `end_time`).
 c. **`query_workflow_logs`** — OpenSearch fallback, slowest. ONLY if (a) and (b) empty. Args: `namespace`, `workflow_run_name`, `task_name`, `start_time` (failed task's `startedAt` − 60 s, fall back to run's `createdAt`), `end_time` (`finishedAt` + 60 s, fall back to now), `limit: 200`, `sort_order: "asc"`. **Never** ask the user for a time range — derive from step 1.
 
 ### Symptom → cause cheat sheet

--- a/agents/portal-assistant/src/templates/prompts/perch_prompt.j2
+++ b/agents/portal-assistant/src/templates/prompts/perch_prompt.j2
@@ -291,6 +291,12 @@ For each blocking target dependency:
    Quote the decisive error line.
 3. Stop as soon as the cause is clear. Don't browse unrelated components.
 
+### Hard rules
+- ≤4 read-tool calls per turn:
+  - Target NotReady inspection order: `get_release_binding` → `get_resource_tree` → `get_resource_events` (or `get_resource_logs`). If live K8s events are empty or expired, fallback to `query_component_events(namespace, project, component, environment, start_time, end_time)`; if container logs are unavailable or expired, fallback to `query_component_logs` / `query_incidents`.
+  - If the target dependency is undeployed, stop after `get_release_binding` / `list_release_bindings`. Do NOT attempt resource or log/event queries for an undeployed component.
+- **Never** ask for time ranges / RFC3339 windows when querying historical events/logs — use `logs_start_time`/`logs_end_time` when set; otherwise default to 30 min.
+
 ### Response format
 
 The chat drawer is narrow (~340 px) — never use fenced code blocks for tabular data; quote any log line inline with backticks so it wraps.
@@ -319,7 +325,7 @@ Rules for the body of each section:
 
 ### External-agent investigation prompt (`fix_prompt`)
 
-`ChatResponse.fix_prompt` drives the drawer's "Prompt for AI Agents" Copy button. Populate it whenever you named a concrete blocking dependency — the recipient is an external AI assistant configured with the **OpenChoreo MCP server** (`get_release_binding`, `list_release_bindings`, `get_component`, `get_resource_tree`, `get_resource_events`, `get_resource_logs`, `query_component_logs`, `query_incidents`) and `kubectl` access to the data-plane cluster; hand it the *next* step to confirm and remediate. `kubectl` / MCP hints are encouraged.
+`ChatResponse.fix_prompt` drives the drawer's "Prompt for AI Agents" Copy button. Populate it whenever you named a concrete blocking dependency — the recipient is an external AI assistant configured with the **OpenChoreo MCP server** (`get_release_binding`, `list_release_bindings`, `get_component`, `get_resource_tree`, `get_resource_events`, `get_resource_logs`, `query_component_events`, `query_component_logs`, `query_incidents`) and `kubectl` access to the data-plane cluster; hand it the *next* step to confirm and remediate. `kubectl` / MCP hints are encouraged.
 
 **Shape (≤ 2000 chars, plain markdown):**
 
@@ -338,6 +344,7 @@ Scope:
 
 Suggested next steps:
 - `get_release_binding` for `<dependency>` in env `<env>` — confirm it is deployed and Ready
+- `query_component_events(namespace="<ns>", component="<dependency>", ...)`  # if live K8s events are empty or expired
 - `query_component_logs(namespace="<ns>", component="<dependency>", ...)`  # if deployed but not ready
 - `kubectl -n <ns> get pods -l openchoreo.dev/component=<dependency>`
 - `kubectl -n <ns> describe pod <pod>`  # if the dependency pod is unhealthy

--- a/agents/portal-assistant/tests/test_perch_prompt.py
+++ b/agents/portal-assistant/tests/test_perch_prompt.py
@@ -1,0 +1,42 @@
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for case-specific Perch investigation instructions."""
+
+from src.template_manager import render
+
+
+def _render_build_failure_prompt() -> str:
+    return render(
+        "prompts/perch_prompt.j2",
+        {
+            "read_tools": [],
+            "rca_tools_available": False,
+            "scope": {
+                "case_type": "build_failure",
+                "namespace": "default",
+                "run_name": "sample-run",
+                "workflow_name": "sample-workflow",
+                "workflow_kind": "Workflow",
+            },
+        },
+    )
+
+
+def test_build_failure_prompt_allows_complete_fallback_chain():
+    prompt = _render_build_failure_prompt()
+
+    assert "≤6 read-tool calls total" in prompt
+    assert "up to four sequential Phase-B calls" in prompt
+    assert (
+        "`get_workflow_run_logs` → `get_workflow_run_events` → "
+        "`query_workflow_events` → `query_workflow_logs`"
+    ) in prompt
+
+
+def test_build_failure_prompt_continues_after_non_diagnostic_events():
+    prompt = _render_build_failure_prompt()
+
+    assert "no live or historical event source yields a decisive error" in prompt
+    assert "even when events contain non-diagnostic rows" in prompt
+    assert "only if all four sources are empty" in prompt

--- a/agents/portal-assistant/tests/test_perch_prompt.py
+++ b/agents/portal-assistant/tests/test_perch_prompt.py
@@ -27,7 +27,7 @@ def test_build_failure_prompt_allows_complete_fallback_chain():
     prompt = _render_build_failure_prompt()
 
     assert "≤6 read-tool calls total" in prompt
-    assert "up to four sequential Phase-B calls" in prompt
+    assert "Phase B may call up to all four log/event tools" in prompt
     assert (
         "`get_workflow_run_logs` → `get_workflow_run_events` → "
         "`query_workflow_events` → `query_workflow_logs`"
@@ -40,3 +40,11 @@ def test_build_failure_prompt_continues_after_non_diagnostic_events():
     assert "no live or historical event source yields a decisive error" in prompt
     assert "even when events contain non-diagnostic rows" in prompt
     assert "only if all four sources are empty" in prompt
+
+
+def test_build_failure_prompt_continues_after_non_diagnostic_live_logs():
+    prompt = _render_build_failure_prompt()
+
+    assert "`get_workflow_run_logs` yields no decisive error" in prompt
+    assert "whether empty or containing only routine output" in prompt
+    assert "try events (`get_workflow_run_events`" in prompt

--- a/agents/portal-assistant/tests/test_tool_registry.py
+++ b/agents/portal-assistant/tests/test_tool_registry.py
@@ -50,7 +50,9 @@ def test_query_prefix_is_read():
     # two ~30 s LLM round-trips per turn.
     for name in (
         "query_component_logs",
+        "query_component_events",
         "query_workflow_logs",
+        "query_workflow_events",
         "query_resource_metrics",
         "query_http_metrics",
         "query_alerts",

--- a/agents/sre-agent/src/agent/tool_registry.py
+++ b/agents/sre-agent/src/agent/tool_registry.py
@@ -30,8 +30,14 @@ class TOOLS:
     QUERY_COMPONENT_LOGS = Tool(
         "query_component_logs", server=OBSERVABILITY, active_form="Fetching component logs..."
     )
+    QUERY_COMPONENT_EVENTS = Tool(
+        "query_component_events", server=OBSERVABILITY, active_form="Fetching component events..."
+    )
     QUERY_WORKFLOW_LOGS = Tool(
         "query_workflow_logs", server=OBSERVABILITY, active_form="Fetching workflow logs..."
+    )
+    QUERY_WORKFLOW_EVENTS = Tool(
+        "query_workflow_events", server=OBSERVABILITY, active_form="Fetching workflow events..."
     )
     QUERY_RESOURCE_METRICS = Tool(
         "query_resource_metrics",


### PR DESCRIPTION
## Purpose
Currently, when a deployment failure or pending state occurs, Portal Assistant analyzes logs, traces, and Kubernetes events fetched from the control plane (`get_resource_events` and `get_workflow_run_events`). However, control plane Kubernetes events expire after a short cluster retention period (typically ~1 hour). For components or workflow runs that have been failing or pending for longer (e.g. >2 hours), control plane events return empty.

This PR enables Portal Assistant to query stored historical events (`query_component_events` and `query_workflow_events`) from the Observability Plane when control plane events are absent or expired.

## Approach
1. **Tool Allowlists**: Added `query_component_events` to `_TOOLS_FOR_CASE` for `runtime_debug` and `dependency_pending` case types, and `query_workflow_events` for `build_failure` in `agents/portal-assistant/src/agent/builder.py`.
2. **Empty Result Guard**: Included `query_component_events` and `query_workflow_events` in `_EMPTY_GUARD_TOOLS` in `agents/portal-assistant/src/agent/middleware/empty_result_guard.py` to prevent unbounded empty search loops.
3. **Prompt Guidance**: Updated `agents/portal-assistant/src/templates/prompts/perch_prompt.j2` for deployment health and build failure Phase B to instruct Portal Assistant to fall back to `query_component_events` / `query_workflow_events` from the observability plane when control plane events return empty or have expired.
4. **SRE Agent & Tests**: Registered `QUERY_COMPONENT_EVENTS` and `QUERY_WORKFLOW_EVENTS` in `agents/sre-agent/src/agent/tool_registry.py` and updated unit tests in `agents/portal-assistant/tests/test_tool_registry.py`.

## Related Issues
Fixes #4443

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks
None
