### PR TITLE
feat: add tools to the Observability MCP server to query costs and recommendations

### DIFF
--- a/cmd/observer/main.go
+++ b/cmd/observer/main.go
@@ -303,6 +303,7 @@ func main() {
 		authzMetricsService,
 		authzAlertIncidentService,
 		authzTracesService,
+		authzFinOpsService,
 		logger.With("component", "mcp-handler"),
 	)
 	if err != nil {

--- a/internal/observer/mcp/handlers.go
+++ b/internal/observer/mcp/handlers.go
@@ -20,6 +20,7 @@ type MCPHandler struct {
 	metricsService       service.MetricsQuerier
 	alertIncidentService service.AlertIncidentService
 	tracesService        service.TracesQuerier
+	finopsService        service.FinOpsQuerier
 	logger               *slog.Logger
 }
 
@@ -30,6 +31,7 @@ func NewMCPHandler(
 	metricsService service.MetricsQuerier,
 	alertIncidentService service.AlertIncidentService,
 	tracesService service.TracesQuerier,
+	finopsService service.FinOpsQuerier,
 	logger *slog.Logger,
 ) (*MCPHandler, error) {
 	if healthService == nil {
@@ -50,6 +52,9 @@ func NewMCPHandler(
 	if tracesService == nil {
 		return nil, fmt.Errorf("missing tracesService")
 	}
+	if finopsService == nil {
+		return nil, fmt.Errorf("missing finopsService")
+	}
 	if logger == nil {
 		return nil, fmt.Errorf("missing logger")
 	}
@@ -60,6 +65,7 @@ func NewMCPHandler(
 		metricsService:       metricsService,
 		alertIncidentService: alertIncidentService,
 		tracesService:        tracesService,
+		finopsService:        finopsService,
 		logger:               logger,
 	}, nil
 }
@@ -287,4 +293,40 @@ func (h *MCPHandler) QueryIncidents(ctx context.Context, namespace, project, com
 		},
 	}
 	return h.alertIncidentService.QueryIncidents(ctx, req)
+}
+
+func (h *MCPHandler) QueryCosts(ctx context.Context, namespace, environment, project, component,
+	startTime, endTime, granularity string) (any, error) {
+	if err := validateFinOpsScope(namespace, environment, project, component); err != nil {
+		return nil, err
+	}
+	if err := validateGranularity(granularity); err != nil {
+		return nil, err
+	}
+	req := &types.CostQueryRequest{
+		Namespace:   namespace,
+		Environment: environment,
+		Project:     project,
+		Component:   component,
+		StartTime:   startTime,
+		EndTime:     endTime,
+		Granularity: granularity,
+	}
+	return h.finopsService.GetComponentCosts(ctx, req)
+}
+
+func (h *MCPHandler) QueryRecommendations(ctx context.Context, namespace, environment, project, component,
+	startTime, endTime string) (any, error) {
+	if err := validateFinOpsScope(namespace, environment, project, component); err != nil {
+		return nil, err
+	}
+	req := &types.RecommendationQueryRequest{
+		Namespace:   namespace,
+		Environment: environment,
+		Project:     project,
+		Component:   component,
+		StartTime:   startTime,
+		EndTime:     endTime,
+	}
+	return h.finopsService.GetRecommendations(ctx, req)
 }

--- a/internal/observer/mcp/handlers_test.go
+++ b/internal/observer/mcp/handlers_test.go
@@ -385,3 +385,98 @@ func TestQueryWorkflowEvents(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestQueryCosts(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("builds cost request and forwards to finops service", func(t *testing.T) {
+		finopsSvc := mocks.NewMockFinOpsQuerier(t)
+		finopsSvc.EXPECT().
+			GetComponentCosts(mock.Anything, mock.MatchedBy(func(req *types.CostQueryRequest) bool {
+				return req.Namespace == testNamespace &&
+					req.Environment == testEnvironment &&
+					req.Project == testProject &&
+					req.Component == testComponent &&
+					req.StartTime == testStartTime &&
+					req.EndTime == testEndTime &&
+					req.Granularity == "1d"
+			})).
+			Return(map[string]any{}, nil)
+
+		h := newTestMCPHandler(t, withFinOpsService(finopsSvc))
+		_, err := h.QueryCosts(ctx, testNamespace, testEnvironment, testProject, testComponent,
+			testStartTime, testEndTime, "1d")
+		require.NoError(t, err)
+	})
+
+	t.Run("missing environment is rejected", func(t *testing.T) {
+		h := newTestMCPHandler(t)
+		_, err := h.QueryCosts(ctx, testNamespace, "", "", "", testStartTime, testEndTime, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "environment is required")
+	})
+
+	t.Run("component without project is rejected", func(t *testing.T) {
+		h := newTestMCPHandler(t)
+		_, err := h.QueryCosts(ctx, testNamespace, testEnvironment, "", testComponent, testStartTime, testEndTime, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "project is required")
+	})
+
+	t.Run("invalid granularity is rejected", func(t *testing.T) {
+		h := newTestMCPHandler(t)
+		_, err := h.QueryCosts(ctx, testNamespace, testEnvironment, "", "", testStartTime, testEndTime, "5x")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "granularity")
+	})
+
+	t.Run("finops service error propagated", func(t *testing.T) {
+		finopsSvc := mocks.NewMockFinOpsQuerier(t)
+		finopsSvc.EXPECT().GetComponentCosts(mock.Anything, mock.Anything).Return(nil, errors.New("backend down"))
+
+		h := newTestMCPHandler(t, withFinOpsService(finopsSvc))
+		_, err := h.QueryCosts(ctx, testNamespace, testEnvironment, "", "", testStartTime, testEndTime, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "backend down")
+	})
+}
+
+func TestQueryRecommendations(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("builds recommendation request and forwards to finops service", func(t *testing.T) {
+		finopsSvc := mocks.NewMockFinOpsQuerier(t)
+		finopsSvc.EXPECT().
+			GetRecommendations(mock.Anything, mock.MatchedBy(func(req *types.RecommendationQueryRequest) bool {
+				return req.Namespace == testNamespace &&
+					req.Environment == testEnvironment &&
+					req.Project == testProject &&
+					req.Component == testComponent &&
+					req.StartTime == testStartTime &&
+					req.EndTime == testEndTime
+			})).
+			Return(map[string]any{}, nil)
+
+		h := newTestMCPHandler(t, withFinOpsService(finopsSvc))
+		_, err := h.QueryRecommendations(ctx, testNamespace, testEnvironment, testProject, testComponent,
+			testStartTime, testEndTime)
+		require.NoError(t, err)
+	})
+
+	t.Run("missing environment is rejected", func(t *testing.T) {
+		h := newTestMCPHandler(t)
+		_, err := h.QueryRecommendations(ctx, testNamespace, "", "", "", testStartTime, testEndTime)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "environment is required")
+	})
+
+	t.Run("finops service error propagated", func(t *testing.T) {
+		finopsSvc := mocks.NewMockFinOpsQuerier(t)
+		finopsSvc.EXPECT().GetRecommendations(mock.Anything, mock.Anything).Return(nil, errors.New("backend down"))
+
+		h := newTestMCPHandler(t, withFinOpsService(finopsSvc))
+		_, err := h.QueryRecommendations(ctx, testNamespace, testEnvironment, "", "", testStartTime, testEndTime)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "backend down")
+	})
+}

--- a/internal/observer/mcp/helpers.go
+++ b/internal/observer/mcp/helpers.go
@@ -5,8 +5,11 @@ package mcp
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 )
+
+var granularityPattern = regexp.MustCompile(`^[1-9][0-9]*[hdw]$`)
 
 // strPtr returns a pointer to the string, or nil if the string is empty.
 func strPtr(s string) *string {
@@ -46,6 +49,28 @@ func validateComponentScope(namespace, project, component string) error {
 	}
 	if component != "" && project == "" {
 		return fmt.Errorf("project is required when component is provided")
+	}
+	return nil
+}
+
+// validateFinOpsScope validates the scope fields for FinOps queries, which
+// additionally require an environment.
+func validateFinOpsScope(namespace, environment, project, component string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace is required")
+	}
+	if environment == "" {
+		return fmt.Errorf("environment is required")
+	}
+	if component != "" && project == "" {
+		return fmt.Errorf("project is required when component is provided")
+	}
+	return nil
+}
+
+func validateGranularity(granularity string) error {
+	if granularity != "" && !granularityPattern.MatchString(granularity) {
+		return fmt.Errorf("granularity must match <count><unit> notation (e.g. 1h, 2d, 3w)")
 	}
 	return nil
 }

--- a/internal/observer/mcp/helpers_test.go
+++ b/internal/observer/mcp/helpers_test.go
@@ -145,3 +145,59 @@ func TestValidateComponentScope(t *testing.T) {
 		}
 	})
 }
+
+func TestValidateFinOpsScope(t *testing.T) {
+	t.Run("empty namespace returns error", func(t *testing.T) {
+		if err := validateFinOpsScope("", "dev", "", ""); err == nil {
+			t.Error("expected error for empty namespace, got nil")
+		}
+	})
+
+	t.Run("empty environment returns error", func(t *testing.T) {
+		if err := validateFinOpsScope("ns", "", "", ""); err == nil {
+			t.Error("expected error for empty environment, got nil")
+		}
+	})
+
+	t.Run("component without project returns error", func(t *testing.T) {
+		if err := validateFinOpsScope("ns", "dev", "", "comp"); err == nil {
+			t.Error("expected error when component is set but project is empty, got nil")
+		}
+	})
+
+	t.Run("namespace and environment is valid", func(t *testing.T) {
+		if err := validateFinOpsScope("ns", "dev", "", ""); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("all fields set is valid", func(t *testing.T) {
+		if err := validateFinOpsScope("ns", "dev", "proj", "comp"); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestValidateGranularity(t *testing.T) {
+	t.Run("empty is valid", func(t *testing.T) {
+		if err := validateGranularity(""); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("valid units accepted", func(t *testing.T) {
+		for _, g := range []string{"1h", "2d", "3w", "24h"} {
+			if err := validateGranularity(g); err != nil {
+				t.Errorf("expected %q to be valid, got %v", g, err)
+			}
+		}
+	})
+
+	t.Run("invalid values rejected", func(t *testing.T) {
+		for _, g := range []string{"5x", "0h", "h", "1", "1m", "-1d"} {
+			if err := validateGranularity(g); err == nil {
+				t.Errorf("expected %q to be rejected, got nil", g)
+			}
+		}
+	})
+}

--- a/internal/observer/mcp/server.go
+++ b/internal/observer/mcp/server.go
@@ -402,6 +402,62 @@ func registerTools(s *mcpsdk.Server, handler *MCPHandler) {
 		)
 		return handleToolResult(result, err)
 	})
+
+	// Tool 10: query_costs
+	mcpsdk.AddTool(s, &mcpsdk.Tool{
+		Name:        "query_costs",
+		Description: "Query infrastructure costs in OpenChoreo. Returns a flat list of per-component cost records (CPU cost, memory cost, and resource efficiency) for a namespace within the given environment and time range. By default the query covers every component in the namespace+environment; set 'project' to scope it to one project, or 'project'+'component' to scope it to a single component. Useful for cost attribution and spotting inefficient workloads.",
+		InputSchema: createSchema(map[string]any{
+			"namespace":   stringProperty("Organization namespace (required)"),
+			"environment": stringProperty("Environment name (required, e.g., 'development', 'production')"),
+			"project":     stringProperty("Project name. When set, narrows the query to components in this project"),
+			"component":   stringProperty("Component name. When set, narrows the query to this single component. Requires project"),
+			"start_time":  stringProperty("Start of time range in RFC3339 format (e.g., 2025-11-04T08:29:02.452Z)"),
+			"end_time":    stringProperty("End of time range in RFC3339 format (e.g., 2025-11-04T09:29:02.452Z)"),
+			"granularity": stringProperty("Optional time bucket size in <count><unit> notation where unit is h (hours), d (days), or w (weeks), e.g. '1h', '2d', '3w'. Splits each component into one record per bucket"),
+		}, []string{"namespace", "environment", "start_time", "end_time"}),
+	}, func(ctx context.Context, req *mcpsdk.CallToolRequest, args struct {
+		Namespace   string `json:"namespace"`
+		Environment string `json:"environment"`
+		Project     string `json:"project"`
+		Component   string `json:"component"`
+		StartTime   string `json:"start_time"`
+		EndTime     string `json:"end_time"`
+		Granularity string `json:"granularity"`
+	}) (*mcpsdk.CallToolResult, any, error) {
+		result, err := handler.QueryCosts(ctx,
+			args.Namespace, args.Environment, args.Project, args.Component,
+			args.StartTime, args.EndTime, args.Granularity,
+		)
+		return handleToolResult(result, err)
+	})
+
+	// Tool 11: query_recommendations
+	mcpsdk.AddTool(s, &mcpsdk.Tool{
+		Name:        "query_recommendations",
+		Description: "Query right-sizing recommendations in OpenChoreo. Returns per-component recommendations comparing current CPU/memory requests and limits against recommended values derived from observed usage, with associated costs, for a namespace within the given environment and time range. By default the query covers every component in the namespace+environment; set 'project' to scope it to one project, or 'project'+'component' to scope it to a single component. Useful for reducing over-provisioning.",
+		InputSchema: createSchema(map[string]any{
+			"namespace":   stringProperty("Organization namespace (required)"),
+			"environment": stringProperty("Environment name (required, e.g., 'development', 'production')"),
+			"project":     stringProperty("Project name. When set, narrows the query to components in this project"),
+			"component":   stringProperty("Component name. When set, narrows the query to this single component. Requires project"),
+			"start_time":  stringProperty("Start of time range in RFC3339 format (e.g., 2025-11-04T08:29:02.452Z)"),
+			"end_time":    stringProperty("End of time range in RFC3339 format (e.g., 2025-11-04T09:29:02.452Z)"),
+		}, []string{"namespace", "environment", "start_time", "end_time"}),
+	}, func(ctx context.Context, req *mcpsdk.CallToolRequest, args struct {
+		Namespace   string `json:"namespace"`
+		Environment string `json:"environment"`
+		Project     string `json:"project"`
+		Component   string `json:"component"`
+		StartTime   string `json:"start_time"`
+		EndTime     string `json:"end_time"`
+	}) (*mcpsdk.CallToolResult, any, error) {
+		result, err := handler.QueryRecommendations(ctx,
+			args.Namespace, args.Environment, args.Project, args.Component,
+			args.StartTime, args.EndTime,
+		)
+		return handleToolResult(result, err)
+	})
 }
 
 // Helper functions for schema creation

--- a/internal/observer/mcp/server_test.go
+++ b/internal/observer/mcp/server_test.go
@@ -280,6 +280,57 @@ func (m *MockAlertIncidentService) reset() {
 	m.incidentsRequests = nil
 }
 
+type MockFinOpsQuerier struct {
+	costsRequests           []*types.CostQueryRequest
+	recommendationsRequests []*types.RecommendationQueryRequest
+	costsResponse           any
+	recommendationsResponse any
+	getCostsErr             error
+	getRecommendationsErr   error
+}
+
+func NewMockFinOpsQuerier() *MockFinOpsQuerier {
+	return &MockFinOpsQuerier{
+		costsResponse:           map[string]any{"items": []any{}},
+		recommendationsResponse: map[string]any{"items": []any{}},
+	}
+}
+
+func (m *MockFinOpsQuerier) GetComponentCosts(_ context.Context, req *types.CostQueryRequest) (any, error) {
+	m.costsRequests = append(m.costsRequests, req)
+	if m.getCostsErr != nil {
+		return nil, m.getCostsErr
+	}
+	return m.costsResponse, nil
+}
+
+func (m *MockFinOpsQuerier) GetRecommendations(_ context.Context, req *types.RecommendationQueryRequest) (any, error) {
+	m.recommendationsRequests = append(m.recommendationsRequests, req)
+	if m.getRecommendationsErr != nil {
+		return nil, m.getRecommendationsErr
+	}
+	return m.recommendationsResponse, nil
+}
+
+func (m *MockFinOpsQuerier) lastCostsRequest() *types.CostQueryRequest {
+	if len(m.costsRequests) == 0 {
+		return nil
+	}
+	return m.costsRequests[len(m.costsRequests)-1]
+}
+
+func (m *MockFinOpsQuerier) lastRecommendationsRequest() *types.RecommendationQueryRequest {
+	if len(m.recommendationsRequests) == 0 {
+		return nil
+	}
+	return m.recommendationsRequests[len(m.recommendationsRequests)-1]
+}
+
+func (m *MockFinOpsQuerier) reset() {
+	m.costsRequests = nil
+	m.recommendationsRequests = nil
+}
+
 // ---- Test harness ----
 
 type testServices struct {
@@ -288,6 +339,7 @@ type testServices struct {
 	metrics         *MockMetricsQuerier
 	traces          *MockTracesQuerier
 	alertsIncidents *MockAlertIncidentService
+	finops          *MockFinOpsQuerier
 }
 
 func newTestServices() *testServices {
@@ -297,6 +349,7 @@ func newTestServices() *testServices {
 		metrics:         NewMockMetricsQuerier(),
 		traces:          NewMockTracesQuerier(),
 		alertsIncidents: NewMockAlertIncidentService(),
+		finops:          NewMockFinOpsQuerier(),
 	}
 }
 
@@ -306,6 +359,7 @@ func (s *testServices) resetAll() {
 	s.metrics.reset()
 	s.traces.reset()
 	s.alertsIncidents.reset()
+	s.finops.reset()
 }
 
 func buildMCPHandler(svcs *testServices) (*MCPHandler, error) {
@@ -314,7 +368,7 @@ func buildMCPHandler(svcs *testServices) (*MCPHandler, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewMCPHandler(healthSvc, svcs.logs, svcs.events, svcs.metrics, svcs.alertsIncidents, svcs.traces, logger)
+	return NewMCPHandler(healthSvc, svcs.logs, svcs.events, svcs.metrics, svcs.alertsIncidents, svcs.traces, svcs.finops, logger)
 }
 
 func setupTestServer(t *testing.T) (*mcpsdk.ClientSession, *testServices) {
@@ -710,6 +764,60 @@ var allToolSpecs = []toolTestSpec{
 			assert.Equal(t, sortOrderDesc, string(*req.SortOrder))
 		},
 	},
+	{
+		name:                "query_costs",
+		descriptionKeywords: []string{"cost"},
+		descriptionMinLen:   20,
+		requiredParams:      []string{"namespace", "environment", "start_time", "end_time"},
+		optionalParams:      []string{"project", "component", "granularity"},
+		testArgs: map[string]any{
+			"namespace":   testNamespace,
+			"environment": testEnvironment,
+			"project":     testProject,
+			"component":   testComponent,
+			"start_time":  testStartTime,
+			"end_time":    testEndTime,
+			"granularity": "1d",
+		},
+		validateCall: func(t *testing.T, svcs *testServices) {
+			t.Helper()
+			req := svcs.finops.lastCostsRequest()
+			require.NotNil(t, req, "Expected GetComponentCosts to be called")
+			assert.Equal(t, testNamespace, req.Namespace)
+			assert.Equal(t, testEnvironment, req.Environment)
+			assert.Equal(t, testProject, req.Project)
+			assert.Equal(t, testComponent, req.Component)
+			assert.Equal(t, testStartTime, req.StartTime)
+			assert.Equal(t, testEndTime, req.EndTime)
+			assert.Equal(t, "1d", req.Granularity)
+		},
+	},
+	{
+		name:                "query_recommendations",
+		descriptionKeywords: []string{"recommendation"},
+		descriptionMinLen:   20,
+		requiredParams:      []string{"namespace", "environment", "start_time", "end_time"},
+		optionalParams:      []string{"project", "component"},
+		testArgs: map[string]any{
+			"namespace":   testNamespace,
+			"environment": testEnvironment,
+			"project":     testProject,
+			"component":   testComponent,
+			"start_time":  testStartTime,
+			"end_time":    testEndTime,
+		},
+		validateCall: func(t *testing.T, svcs *testServices) {
+			t.Helper()
+			req := svcs.finops.lastRecommendationsRequest()
+			require.NotNil(t, req, "Expected GetRecommendations to be called")
+			assert.Equal(t, testNamespace, req.Namespace)
+			assert.Equal(t, testEnvironment, req.Environment)
+			assert.Equal(t, testProject, req.Project)
+			assert.Equal(t, testComponent, req.Component)
+			assert.Equal(t, testStartTime, req.StartTime)
+			assert.Equal(t, testEndTime, req.EndTime)
+		},
+	},
 }
 
 // ---- Tests ----
@@ -723,6 +831,7 @@ func TestNewMCPHandlerValidation(t *testing.T) {
 	events := NewMockEventsQuerier()
 	metrics := NewMockMetricsQuerier()
 	traces := NewMockTracesQuerier()
+	finops := NewMockFinOpsQuerier()
 
 	tests := []struct {
 		name                 string
@@ -732,20 +841,22 @@ func TestNewMCPHandlerValidation(t *testing.T) {
 		metrics              service.MetricsQuerier
 		alertIncidentService service.AlertIncidentService
 		traces               service.TracesQuerier
+		finops               service.FinOpsQuerier
 		log                  *slog.Logger
 	}{
-		{"nil healthService", nil, logs, events, metrics, alertIncidentSvc, traces, logger},
-		{"nil logsService", healthSvc, nil, events, metrics, alertIncidentSvc, traces, logger},
-		{"nil eventsService", healthSvc, logs, nil, metrics, alertIncidentSvc, traces, logger},
-		{"nil metricsService", healthSvc, logs, events, nil, alertIncidentSvc, traces, logger},
-		{"nil alertIncidentService", healthSvc, logs, events, metrics, nil, traces, logger},
-		{"nil tracesService", healthSvc, logs, events, metrics, alertIncidentSvc, nil, logger},
-		{"nil logger", healthSvc, logs, events, metrics, alertIncidentSvc, traces, nil},
+		{"nil healthService", nil, logs, events, metrics, alertIncidentSvc, traces, finops, logger},
+		{"nil logsService", healthSvc, nil, events, metrics, alertIncidentSvc, traces, finops, logger},
+		{"nil eventsService", healthSvc, logs, nil, metrics, alertIncidentSvc, traces, finops, logger},
+		{"nil metricsService", healthSvc, logs, events, nil, alertIncidentSvc, traces, finops, logger},
+		{"nil alertIncidentService", healthSvc, logs, events, metrics, nil, traces, finops, logger},
+		{"nil tracesService", healthSvc, logs, events, metrics, alertIncidentSvc, nil, finops, logger},
+		{"nil finopsService", healthSvc, logs, events, metrics, alertIncidentSvc, traces, nil, logger},
+		{"nil logger", healthSvc, logs, events, metrics, alertIncidentSvc, traces, finops, nil},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewMCPHandler(tt.health, tt.logs, tt.events, tt.metrics, tt.alertIncidentService, tt.traces, tt.log)
+			_, err := NewMCPHandler(tt.health, tt.logs, tt.events, tt.metrics, tt.alertIncidentService, tt.traces, tt.finops, tt.log)
 			require.Error(t, err, "Expected error for %s", tt.name)
 		})
 	}

--- a/internal/observer/mcp/test_helpers_test.go
+++ b/internal/observer/mcp/test_helpers_test.go
@@ -20,6 +20,7 @@ type handlerTestDeps struct {
 	metrics service.MetricsQuerier
 	alerts  service.AlertIncidentService
 	traces  service.TracesQuerier
+	finops  service.FinOpsQuerier
 }
 
 // newTestMCPHandler builds an MCPHandler with mockery mocks by default; options override individual deps.
@@ -32,6 +33,7 @@ func newTestMCPHandler(t *testing.T, opts ...func(*handlerTestDeps)) *MCPHandler
 		metrics: servicemocks.NewMockMetricsQuerier(t),
 		alerts:  servicemocks.NewMockAlertIncidentService(t),
 		traces:  servicemocks.NewMockTracesQuerier(t),
+		finops:  servicemocks.NewMockFinOpsQuerier(t),
 	}
 	for _, o := range opts {
 		o(&d)
@@ -41,7 +43,7 @@ func newTestMCPHandler(t *testing.T, opts ...func(*handlerTestDeps)) *MCPHandler
 	healthSvc, err := service.NewHealthService(logger)
 	require.NoError(t, err)
 
-	h, err := NewMCPHandler(healthSvc, d.logs, d.events, d.metrics, d.alerts, d.traces, logger)
+	h, err := NewMCPHandler(healthSvc, d.logs, d.events, d.metrics, d.alerts, d.traces, d.finops, logger)
 	require.NoError(t, err)
 	return h
 }
@@ -64,4 +66,8 @@ func withAlertIncidentService(s service.AlertIncidentService) func(*handlerTestD
 
 func withTracesService(s service.TracesQuerier) func(*handlerTestDeps) {
 	return func(d *handlerTestDeps) { d.traces = s }
+}
+
+func withFinOpsService(s service.FinOpsQuerier) func(*handlerTestDeps) {
+	return func(d *handlerTestDeps) { d.finops = s }
 }


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Add two new tools to the Observability MCP server to fetch costs and recommendations.

## Approach
- Added two new tools, `query_costs` and `query_recommendations` to the Observability MCP server
- Added unit tests

## Related Issues
https://github.com/openchoreo/openchoreo/issues/4463

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
