### PR TITLE
fix(controller): unblock RenderedRelease finalizer when Environment is gone

### DIFF
--- a/internal/controller/renderedrelease/controller_finalize.go
+++ b/internal/controller/renderedrelease/controller_finalize.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -75,6 +76,13 @@ func (r *Reconciler) finalizeDataPlane(ctx context.Context, old, release *opench
 	// STEP 2: Get data plane client
 	planeClient, err := r.getDPClient(ctx, release.Namespace, release.Spec.EnvironmentName)
 	if err != nil {
+		// Environment or data plane already gone: nothing left to clean up on the remote plane.
+		if isPlaneLookupGone(err) {
+			logger := log.FromContext(ctx).WithValues("release", release.Name)
+			logger.Info("Environment or data plane not found during finalization, removing finalizer",
+				"environment", release.Spec.EnvironmentName, "error", err.Error())
+			return r.removeFinalizer(ctx, release, DataPlaneCleanupFinalizer)
+		}
 		meta.SetStatusCondition(&release.Status.Conditions, NewRenderedReleaseCleanupFailedCondition(release.Generation, err))
 		if updateErr := controller.UpdateStatusConditions(ctx, r.Client, old, release); updateErr != nil {
 			return ctrl.Result{}, updateErr
@@ -111,13 +119,7 @@ func (r *Reconciler) finalizeDataPlane(ctx context.Context, old, release *opench
 	}
 
 	// STEP 6: All resources cleaned up - remove the finalizer
-	if controllerutil.RemoveFinalizer(release, DataPlaneCleanupFinalizer) {
-		if err := r.Update(ctx, release); err != nil {
-			return ctrl.Result{}, err
-		}
-	}
-
-	return ctrl.Result{}, nil
+	return r.removeFinalizer(ctx, release, DataPlaneCleanupFinalizer)
 }
 
 // finalizeObsPlane cleans up the observability plane resources associated with the release.
@@ -143,6 +145,12 @@ func (r *Reconciler) finalizeObsPlane(ctx context.Context, old, release *opencho
 	// STEP 2: Get observability plane client
 	planeClient, err := r.getOPClient(ctx, release.Namespace, release.Spec.EnvironmentName)
 	if err != nil {
+		if isPlaneLookupGone(err) {
+			logger := log.FromContext(ctx).WithValues("release", release.Name)
+			logger.Info("Environment or plane not found during obs finalization, removing finalizer",
+				"environment", release.Spec.EnvironmentName, "error", err.Error())
+			return r.removeFinalizer(ctx, release, activeFinalizer)
+		}
 		meta.SetStatusCondition(&release.Status.Conditions, NewRenderedReleaseCleanupFailedCondition(release.Generation, err))
 		if updateErr := controller.UpdateStatusConditions(ctx, r.Client, old, release); updateErr != nil {
 			return ctrl.Result{}, updateErr
@@ -178,13 +186,30 @@ func (r *Reconciler) finalizeObsPlane(ctx context.Context, old, release *opencho
 	}
 
 	// STEP 6: All resources cleaned up - remove the finalizer
-	if controllerutil.RemoveFinalizer(release, activeFinalizer) {
+	return r.removeFinalizer(ctx, release, activeFinalizer)
+}
+
+// removeFinalizer drops finalizer from the release once remote cleanup is done or skipped.
+func (r *Reconciler) removeFinalizer(ctx context.Context, release *openchoreov1alpha1.RenderedRelease, finalizer string) (ctrl.Result, error) {
+	if controllerutil.RemoveFinalizer(release, finalizer) {
 		if err := r.Update(ctx, release); err != nil {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("remove finalizer %s from release %s: %w", finalizer, release.Name, err)
 		}
 	}
-
 	return ctrl.Result{}, nil
+}
+
+// isPlaneLookupGone reports whether plane client resolution failed because the
+// Environment, DataPlane, or ObservabilityPlane no longer exists. Transient
+// errors (network, timeout, misconfig) return false so finalization can retry.
+func isPlaneLookupGone(err error) bool {
+	if err == nil {
+		return false
+	}
+	if controller.IgnoreHierarchyNotFoundError(err) == nil {
+		return true
+	}
+	return apierrors.IsNotFound(err)
 }
 
 // intersectObsPlaneGVKs returns the subset of GVKs from the release status that are in

--- a/internal/controller/renderedrelease/controller_integration_test.go
+++ b/internal/controller/renderedrelease/controller_integration_test.go
@@ -785,10 +785,10 @@ var _ = Describe("RenderedRelease Controller", func() {
 	})
 
 	// ─────────────────────────────────────────────────────────────
-	// Finalization: CleanupFailed condition on DP client error
+	// Finalization: Environment already gone
 	// ─────────────────────────────────────────────────────────────
 
-	Context("Finalization sets CleanupFailed condition when DP client cannot be obtained", func() {
+	Context("Finalization when Environment is missing", func() {
 		const (
 			releaseName = "release-finalize-dpfail"
 			envName     = "env-finalize-dpfail"
@@ -799,8 +799,8 @@ var _ = Describe("RenderedRelease Controller", func() {
 			forceDelete(ctx, nn)
 		})
 
-		It("sets CleanupFailed condition and returns error when environment is missing", func() {
-			By("Creating a RenderedRelease with the finalizer and Finalizing condition pre-set")
+		It("removes the finalizer without error when environment is missing", func() {
+			By("Creating a RenderedRelease with the finalizer set")
 			release := makeMinimalRelease(releaseName, envName)
 			release.Finalizers = []string{DataPlaneCleanupFinalizer}
 			Expect(k8sClient.Create(ctx, release)).To(Succeed())
@@ -819,19 +819,13 @@ var _ = Describe("RenderedRelease Controller", func() {
 			r := &Reconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
 			mustReconcile(r, reconcileRequest(releaseName))
 
-			By("Second reconcile: environment does not exist → error + CleanupFailed condition")
-			_, err := r.Reconcile(ctx, reconcileRequest(releaseName))
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(envName))
+			By("Second reconcile: environment does not exist, skip remote cleanup and drop finalizer")
+			mustReconcile(r, reconcileRequest(releaseName))
 
-			By("Verifying the CleanupFailed condition is set")
-			updated := fetchRelease(releaseName)
-			cond := apimeta.FindStatusCondition(updated.Status.Conditions, string(ConditionFinalizing))
-			Expect(cond).NotTo(BeNil())
-			Expect(cond.Reason).To(Equal(string(ReasonCleanupFailed)))
-
-			By("Verifying the finalizer is still present (cleanup did not complete)")
-			Expect(updated.Finalizers).To(ContainElement(DataPlaneCleanupFinalizer))
+			By("Release is fully deleted once the finalizer is gone")
+			Eventually(func() bool {
+				return apierrors.IsNotFound(k8sClient.Get(ctx, nn, &openchoreov1alpha1.RenderedRelease{}))
+			}, testTimeout, testInterval).Should(BeTrue())
 		})
 	})
 

--- a/internal/controller/renderedrelease/controller_integration_test.go
+++ b/internal/controller/renderedrelease/controller_integration_test.go
@@ -306,22 +306,26 @@ var _ = Describe("RenderedRelease Controller", func() {
 			Expect(cond.Reason).To(Equal(string(ReasonCleanupInProgress)))
 		})
 
-		It("should return error on second finalize reconcile when environment does not exist", func() {
+		It("should remove finalizer when environment does not exist", func() {
 			r := &Reconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
 
 			By("first reconcile: sets Finalizing condition")
 			_, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("second reconcile: Finalizing condition already set, tries to get DP client")
+			By("second reconcile: environment missing, skip remote cleanup and drop finalizer")
 			_, err = r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("my-env"))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("release is fully deleted once the finalizer is gone")
+			Eventually(func() bool {
+				return apierrors.IsNotFound(k8sClient.Get(ctx, nn, &openchoreov1alpha1.RenderedRelease{}))
+			}, "5s", "100ms").Should(BeTrue())
 		})
 
-		It("should keep the finalizer while cleanup is pending", func() {
+		It("should keep the finalizer after first reconcile while Finalizing is set", func() {
 			r := &Reconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
-			// After one reconcile the finalizer should still be present (cleanup didn't succeed)
+			// First reconcile only persists the Finalizing condition and returns early.
 			_, _ = r.Reconcile(ctx, reconcile.Request{NamespacedName: nn})
 
 			got := &openchoreov1alpha1.RenderedRelease{}

--- a/internal/controller/renderedrelease/controller_unit_test.go
+++ b/internal/controller/renderedrelease/controller_unit_test.go
@@ -13,15 +13,19 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/controller"
 	"github.com/openchoreo/openchoreo/internal/labels"
 )
 
@@ -1696,6 +1700,147 @@ func TestFinalizeObsPlane_NoFinalizersIsNoOp(t *testing.T) {
 	}
 	if result.Requeue || result.RequeueAfter != 0 {
 		t.Errorf("expected empty Result for no-op path, got Requeue=%v RequeueAfter=%v", result.Requeue, result.RequeueAfter)
+	}
+}
+
+func TestIsPlaneLookupGone(t *testing.T) {
+	if isPlaneLookupGone(nil) {
+		t.Fatal("nil should not be gone")
+	}
+	if !isPlaneLookupGone(apierrors.NewNotFound(schema.GroupResource{Resource: "environments"}, "dev")) {
+		t.Fatal("IsNotFound should be gone")
+	}
+	wrapped := fmt.Errorf("failed to get environment dev: %w", apierrors.NewNotFound(schema.GroupResource{Resource: "environments"}, "dev"))
+	if !isPlaneLookupGone(wrapped) {
+		t.Fatal("wrapped IsNotFound should be gone")
+	}
+	if !isPlaneLookupGone(controller.NewHierarchyNotFoundError(
+		&openchoreov1alpha1.Environment{},
+		&openchoreov1alpha1.DataPlane{},
+	)) {
+		t.Fatal("HierarchyNotFoundError should be gone")
+	}
+	if isPlaneLookupGone(fmt.Errorf("connection refused")) {
+		t.Fatal("transient error should not be gone")
+	}
+}
+
+func TestFinalizeDataPlane_RemovesFinalizerWhenEnvironmentMissing(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := openchoreov1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	now := metav1.Now()
+	release := &openchoreov1alpha1.RenderedRelease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-release",
+			Namespace:         "default",
+			Finalizers:        []string{DataPlaneCleanupFinalizer},
+			DeletionTimestamp: &now,
+		},
+		Spec: openchoreov1alpha1.RenderedReleaseSpec{
+			EnvironmentName: "missing-env",
+		},
+		Status: openchoreov1alpha1.RenderedReleaseStatus{
+			Conditions: []metav1.Condition{
+				NewRenderedReleaseFinalizingCondition(1),
+			},
+		},
+	}
+	// Status must already have Finalizing so finalize does not return early on condition write.
+	release.Generation = 1
+	release.Status.Conditions[0].ObservedGeneration = 1
+
+	fakeClient := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(release).
+		WithStatusSubresource(&openchoreov1alpha1.RenderedRelease{}).
+		Build()
+	r := &Reconciler{Client: fakeClient}
+
+	// Reload live object (fake client may normalize)
+	live := &openchoreov1alpha1.RenderedRelease{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-release", Namespace: "default"}, live); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	// Ensure Finalizing is already recorded so we hit getDPClient path
+	if meta.SetStatusCondition(&live.Status.Conditions, NewRenderedReleaseFinalizingCondition(live.Generation)) {
+		if err := fakeClient.Status().Update(context.Background(), live); err != nil {
+			t.Fatalf("status update: %v", err)
+		}
+	}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-release", Namespace: "default"}, live); err != nil {
+		t.Fatalf("get after status: %v", err)
+	}
+
+	_, err := r.finalizeDataPlane(context.Background(), live.DeepCopy(), live)
+	if err != nil {
+		t.Fatalf("finalizeDataPlane: %v", err)
+	}
+
+	got := &openchoreov1alpha1.RenderedRelease{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "test-release", Namespace: "default"}, got)
+	if apierrors.IsNotFound(err) {
+		return
+	}
+	if err != nil {
+		t.Fatalf("get after finalize: %v", err)
+	}
+	if controllerutil.ContainsFinalizer(got, DataPlaneCleanupFinalizer) {
+		t.Fatal("expected data plane cleanup finalizer removed when environment is missing")
+	}
+}
+
+func TestFinalizeObsPlane_RemovesFinalizerWhenEnvironmentMissing(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := openchoreov1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	now := metav1.Now()
+	release := &openchoreov1alpha1.RenderedRelease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "obs-release",
+			Namespace:         "default",
+			Finalizers:        []string{ObsPlaneCleanupFinalizer},
+			DeletionTimestamp: &now,
+			Generation:        1,
+		},
+		Spec: openchoreov1alpha1.RenderedReleaseSpec{
+			EnvironmentName: "missing-env",
+			TargetPlane:     targetPlaneObservabilityPlane,
+		},
+		Status: openchoreov1alpha1.RenderedReleaseStatus{
+			Conditions: []metav1.Condition{
+				NewRenderedReleaseFinalizingCondition(1),
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(release).
+		WithStatusSubresource(&openchoreov1alpha1.RenderedRelease{}).
+		Build()
+	r := &Reconciler{Client: fakeClient}
+
+	live := &openchoreov1alpha1.RenderedRelease{}
+	if err := fakeClient.Get(context.Background(), types.NamespacedName{Name: "obs-release", Namespace: "default"}, live); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	_, err := r.finalizeObsPlane(context.Background(), live.DeepCopy(), live)
+	if err != nil {
+		t.Fatalf("finalizeObsPlane: %v", err)
+	}
+
+	got := &openchoreov1alpha1.RenderedRelease{}
+	err = fakeClient.Get(context.Background(), types.NamespacedName{Name: "obs-release", Namespace: "default"}, got)
+	if apierrors.IsNotFound(err) {
+		return
+	}
+	if err != nil {
+		t.Fatalf("get after finalize: %v", err)
+	}
+	if controllerutil.ContainsFinalizer(got, ObsPlaneCleanupFinalizer) {
+		t.Fatal("expected obs plane cleanup finalizer removed when environment is missing")
 	}
 }
 


### PR DESCRIPTION
## Purpose
RenderedRelease finalization always needs a dataplane client resolved through the Environment. If the Environment was deleted first, that lookup fails on every reconcile with CleanupFailed and the finalizer is never removed, so the object stays stuck forever.

The Environment controller already skips remote cleanup when the data plane is missing. RenderedRelease did not have the same escape path.

Fixes #2753

## Approach
When getDPClient or getOPClient fails because the Environment, DataPlane, or ObservabilityPlane is not found (apierrors.IsNotFound or HierarchyNotFoundError), skip remote cleanup and remove the cleanup finalizer. Other errors still set CleanupFailed and requeue.

Covered with unit tests for isPlaneLookupGone and both data plane and observability plane finalization when the Environment is missing. Updated the envtest case that previously expected an error on the missing Environment path.

## Related Issues
- Fixes #2753

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [ ] This PR includes AI-generated code or content

## Remarks
Transient client failures (network, timeouts) are not treated as gone, so a temporary outage does not drop the finalizer without cleanup.