### PR TITLE
refactor: simplify git basic auth handling in checkout template

### DIFF
--- a/samples/getting-started/workflow-templates/checkout-source.yaml
+++ b/samples/getting-started/workflow-templates/checkout-source.yaml
@@ -108,27 +108,24 @@ spec:
                 # Basic auth (kubernetes.io/basic-auth)
                 elif [ -f "$GIT_SECRET_PATH/password" ]; then
                     echo ">> Authentication: Basic Authentication"
-                    PASSWORD=$(cat "$GIT_SECRET_PATH/password")
 
-                    if [ -f "$GIT_SECRET_PATH/username" ]; then
-                        USERNAME=$(cat "$GIT_SECRET_PATH/username")
-                    else
-                        USERNAME="git"
-                    fi
-
-                    if echo "$REPO" | grep -q "^https://"; then
-                        PROTOCOL=$(echo "$REPO" | cut -d: -f1)
-                        DOMAIN_PATH=$(echo "$REPO" | cut -d/ -f3-)
-
-                        USERNAME_ENCODED=$(echo -n "$USERNAME" | sed 's/%/%25/g; s/ /%20/g; s/!/%21/g; s/"/%22/g; s/#/%23/g; s/\$/%24/g; s/&/%26/g; s/'\''/%27/g; s/(/%28/g; s/)/%29/g; s/\*/%2A/g; s/+/%2B/g; s/,/%2C/g; s/\//%2F/g; s/:/%3A/g; s/;/%3B/g; s/=/%3D/g; s/?/%3F/g; s/@/%40/g; s/\[/%5B/g; s/\]/%5D/g')
-                        PASSWORD_ENCODED=$(echo -n "$PASSWORD" | sed 's/%/%25/g; s/ /%20/g; s/!/%21/g; s/"/%22/g; s/#/%23/g; s/\$/%24/g; s/&/%26/g; s/'\''/%27/g; s/(/%28/g; s/)/%29/g; s/\*/%2A/g; s/+/%2B/g; s/,/%2C/g; s/\//%2F/g; s/:/%3A/g; s/;/%3B/g; s/=/%3D/g; s/?/%3F/g; s/@/%40/g; s/\[/%5B/g; s/\]/%5D/g')
-
-                        REPO="$PROTOCOL://${USERNAME_ENCODED}:${PASSWORD_ENCODED}@${DOMAIN_PATH}"
-                    else
+                    if ! echo "$REPO" | grep -q "^https://"; then
                         echo ">> Warning: REPO is not an HTTPS URL, basic auth may not work"
                     fi
 
-                    git config --global credential.helper store
+                    # Supply credentials via GIT_ASKPASS instead of embedding them in the
+                    # clone URL. The helper reads the mounted secret on demand.
+                    export GIT_SECRET_PATH
+                    cat > /tmp/git-askpass.sh <<'EOF'
+            #!/bin/sh
+            case "$1" in
+                Username*) cat "$GIT_SECRET_PATH/username" 2>/dev/null || echo git ;;
+                Password*) cat "$GIT_SECRET_PATH/password" ;;
+            esac
+            EOF
+                    chmod 700 /tmp/git-askpass.sh
+                    export GIT_ASKPASS=/tmp/git-askpass.sh
+                    export GIT_TERMINAL_PROMPT=0
                 else
                     echo ">> Error: Git credentials secret was provided but does not contain recognized authentication data."
                     echo ">> Hint: The secret should contain either an SSH private key (ssh-privatekey) or username/password."

--- a/test/workflowtemplates/checkout_behavior_test.go
+++ b/test/workflowtemplates/checkout_behavior_test.go
@@ -73,6 +73,8 @@ type checkoutResult struct {
 	gitCalls  []string
 	cloneRepo string // the repo URL passed to `git clone`, after transformation
 	root      string
+	askpass   string // path to the GIT_ASKPASS helper the script wrote
+	secretDir string // the mounted git-secret dir the helper reads from
 }
 
 // runCheckout prepares an isolated environment and runs the checkout script.
@@ -89,6 +91,7 @@ func runCheckout(t *testing.T, in checkoutInput) checkoutResult {
 	stubDir := filepath.Join(root, "bin")
 	revFile := filepath.Join(root, "git-revision.txt")
 	gitCalls := filepath.Join(root, "git-calls.log")
+	askpass := filepath.Join(root, "git-askpass.sh")
 	require.NoError(t, os.MkdirAll(home, 0o755))
 	require.NoError(t, os.MkdirAll(stubDir, 0o755))
 
@@ -115,6 +118,7 @@ func runCheckout(t *testing.T, in checkoutInput) checkoutResult {
 		"/etc/secrets/git-secret", secretDir,
 		"/mnt/vol/source", source,
 		"/tmp/git-revision.txt", revFile,
+		"/tmp/git-askpass.sh", askpass,
 	}
 	script = strings.NewReplacer(replacements...).Replace(script)
 
@@ -132,7 +136,7 @@ func runCheckout(t *testing.T, in checkoutInput) checkoutResult {
 	cmd.Env = env
 	out, err := cmd.CombinedOutput()
 
-	res := checkoutResult{output: string(out), root: root}
+	res := checkoutResult{output: string(out), root: root, askpass: askpass, secretDir: secretDir}
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
@@ -342,7 +346,18 @@ func TestCheckout_SSH_CodeCommitNotRewrittenToScpSyntax(t *testing.T) {
 
 // --- Basic auth: credential percent-encoding (scenario 1) ---
 
-func TestCheckout_BasicAuth_PercentEncodesCredentials(t *testing.T) {
+// runAskpass invokes the GIT_ASKPASS helper the script wrote, the way git
+// would: prompt text as the sole argument, answer read from stdout.
+func runAskpass(t *testing.T, res checkoutResult, prompt string) string {
+	t.Helper()
+	cmd := exec.Command("sh", res.askpass, prompt)
+	cmd.Env = append(os.Environ(), "GIT_SECRET_PATH="+res.secretDir)
+	out, err := cmd.Output()
+	require.NoError(t, err, "askpass helper should be executable and succeed")
+	return strings.TrimSpace(string(out))
+}
+
+func TestCheckout_BasicAuth_KeepsCredentialsOutOfCloneURL(t *testing.T) {
 	res := runCheckout(t, checkoutInput{
 		repo:   "https://github.com/org/repo.git",
 		branch: "main",
@@ -351,11 +366,16 @@ func TestCheckout_BasicAuth_PercentEncodesCredentials(t *testing.T) {
 			"password": "p@ss:w0rd",
 		},
 	})
-	requireCheckoutSuccess(t, res, "Basic auth should percent-encode credentials before clone")
-	requireCloneRepo(t, res, "https://my-user:p%40ss%3Aw0rd@github.com/org/repo.git",
-		"basic auth should embed percent-encoded credentials in the HTTPS clone URL")
+	requireCheckoutSuccess(t, res, "Basic auth should clone without rewriting the repo URL")
+	requireCloneRepo(t, res, "https://github.com/org/repo.git",
+		"basic auth should leave the clone URL unmodified, since git persists it into .git/config")
 	requireCheckoutOutputContains(t, res, "Basic Authentication",
 		"checkout output should report basic authentication path")
+
+	require.Equal(t, "my-user", runAskpass(t, res, "Username for 'https://github.com': "),
+		"askpass helper should return the username from the mounted secret")
+	require.Equal(t, "p@ss:w0rd", runAskpass(t, res, "Password for 'https://my-user@github.com': "),
+		"askpass helper should return the password verbatim, with no encoding applied")
 }
 
 func TestCheckout_BasicAuth_DefaultsUsernameToGit(t *testing.T) {
@@ -364,9 +384,13 @@ func TestCheckout_BasicAuth_DefaultsUsernameToGit(t *testing.T) {
 		branch:      "main",
 		secretFiles: map[string]string{"password": "token123"},
 	})
-	requireCheckoutSuccess(t, res, "Basic auth should default username to git before clone")
-	requireCloneRepo(t, res, "https://git:token123@github.com/org/repo.git",
-		"basic auth should default username to git when username secret is absent")
+	requireCheckoutSuccess(t, res, "Basic auth should default username to git")
+	requireCloneRepo(t, res, "https://github.com/org/repo.git",
+		"basic auth should leave the clone URL unmodified")
+	require.Equal(t, "git", runAskpass(t, res, "Username for 'https://github.com': "),
+		"askpass helper should default the username to git when the secret has no username key")
+	require.Equal(t, "token123", runAskpass(t, res, "Password for 'https://git@github.com': "),
+		"askpass helper should still return the password when the username is defaulted")
 }
 
 // --- Auth-type precedence and edge cases (scenario 5) ---

--- a/test/workflowtemplates/static_test.go
+++ b/test/workflowtemplates/static_test.go
@@ -193,10 +193,19 @@ func TestCheckoutSource_AuthAndProviderContract(t *testing.T) {
 		requireContains(t, s, "git-codecommit", "${SSH_KEY_ID}@")
 	})
 
-	t.Run("basic-auth percent-encodes credentials", func(t *testing.T) {
-		// %40 == '@', %3A == ':' — sentinel of the URL-encoding sed.
-		requireContains(t, s, "USERNAME_ENCODED", "PASSWORD_ENCODED", "%40", "%3A")
-		requireContains(t, s, "credential.helper store")
+	t.Run("basic-auth supplies credentials via askpass", func(t *testing.T) {
+		requireContains(t, s,
+			"export GIT_SECRET_PATH",
+			"chmod 700 /tmp/git-askpass.sh",
+			"export GIT_ASKPASS=/tmp/git-askpass.sh",
+			"export GIT_TERMINAL_PROMPT=0",
+		)
+		requireNotContains(t, s, "USERNAME_ENCODED",
+			"basic auth must not build a credential-bearing clone URL")
+		requireNotContains(t, s, "PASSWORD_ENCODED",
+			"basic auth must not build a credential-bearing clone URL")
+		requireNotContains(t, s, "credential.helper",
+			"basic auth must not configure a git credential helper")
 	})
 
 	t.Run("checkout by branch and by commit", func(t *testing.T) {


### PR DESCRIPTION
## Purpose
The basic-auth path in the `checkout-source` workflow template builds an
authenticated clone URL by embedding the username and password into it. That
requires percent-encoding both values by hand, and the encoded URL is what git
records as the remote.

## Approach
Supply the credentials through `GIT_ASKPASS` instead. Git invokes the helper only
when the remote asks for authentication, and the helper reads the mounted secret
on demand, so `$REPO` is left as the plain URL.

This lets two things go:

- The hand-rolled percent-encoder. Basic auth is sent as an `Authorization`
  header, so there are no reserved characters to escape. The previous `sed`
  covered around twenty characters but missed `< > ^ | { } ~ \` and backtick,
  which would have produced a malformed URL.
- `credential.helper store`, which caused git to write a second copy of the
  credential to `~/.git-credentials` after a successful fetch.

The SSH authentication path is untouched.

## Related Issues
_None._

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks
Verified against a private repository on a local k3d cluster: the clone succeeds
and the credential round-trips correctly, including a password containing
`@ : / #`, which the previous encoder had to escape by hand.

One behavioural change worth noting for reviewers: nothing persists a credential
any more, so a later step running its own authenticated `git fetch` against the
clone will fail rather than reusing a stored token.

