### PR TITLE
refactor: simplify git basic auth handling in checkout template

### DIFF
--- a/samples/getting-started/workflow-templates/checkout-source.yaml
+++ b/samples/getting-started/workflow-templates/checkout-source.yaml
@@ -115,27 +115,24 @@ spec:
                 # Basic auth (kubernetes.io/basic-auth)
                 elif [ -f "$GIT_SECRET_PATH/password" ]; then
                     echo ">> Authentication: Basic Authentication"
-                    PASSWORD=$(cat "$GIT_SECRET_PATH/password")
 
-                    if [ -f "$GIT_SECRET_PATH/username" ]; then
-                        USERNAME=$(cat "$GIT_SECRET_PATH/username")
-                    else
-                        USERNAME="git"
-                    fi
-
-                    if echo "$REPO" | grep -q "^https://"; then
-                        PROTOCOL=$(echo "$REPO" | cut -d: -f1)
-                        DOMAIN_PATH=$(echo "$REPO" | cut -d/ -f3-)
-
-                        USERNAME_ENCODED=$(echo -n "$USERNAME" | sed 's/%/%25/g; s/ /%20/g; s/!/%21/g; s/"/%22/g; s/#/%23/g; s/\$/%24/g; s/&/%26/g; s/'\''/%27/g; s/(/%28/g; s/)/%29/g; s/\*/%2A/g; s/+/%2B/g; s/,/%2C/g; s/\//%2F/g; s/:/%3A/g; s/;/%3B/g; s/=/%3D/g; s/?/%3F/g; s/@/%40/g; s/\[/%5B/g; s/\]/%5D/g')
-                        PASSWORD_ENCODED=$(echo -n "$PASSWORD" | sed 's/%/%25/g; s/ /%20/g; s/!/%21/g; s/"/%22/g; s/#/%23/g; s/\$/%24/g; s/&/%26/g; s/'\''/%27/g; s/(/%28/g; s/)/%29/g; s/\*/%2A/g; s/+/%2B/g; s/,/%2C/g; s/\//%2F/g; s/:/%3A/g; s/;/%3B/g; s/=/%3D/g; s/?/%3F/g; s/@/%40/g; s/\[/%5B/g; s/\]/%5D/g')
-
-                        REPO="$PROTOCOL://${USERNAME_ENCODED}:${PASSWORD_ENCODED}@${DOMAIN_PATH}"
-                    else
+                    if ! echo "$REPO" | grep -q "^https://"; then
                         echo ">> Warning: REPO is not an HTTPS URL, basic auth may not work"
                     fi
 
-                    git config --global credential.helper store
+                    # Supply credentials via GIT_ASKPASS instead of embedding them in the
+                    # clone URL. The helper reads the mounted secret on demand.
+                    export GIT_SECRET_PATH
+                    cat > /tmp/git-askpass.sh <<'EOF'
+            #!/bin/sh
+            case "$1" in
+                Username*) cat "$GIT_SECRET_PATH/username" 2>/dev/null || echo git ;;
+                Password*) cat "$GIT_SECRET_PATH/password" ;;
+            esac
+            EOF
+                    chmod 700 /tmp/git-askpass.sh
+                    export GIT_ASKPASS=/tmp/git-askpass.sh
+                    export GIT_TERMINAL_PROMPT=0
                 else
                     echo ">> Error: Git credentials secret was provided but does not contain recognized authentication data."
                     echo ">> Hint: The secret should contain either an SSH private key (ssh-privatekey) or username/password."


### PR DESCRIPTION
## Purpose
Backport of #4490 to this release branch.

## Approach
Supply git basic-auth credentials through `GIT_ASKPASS` rather than building an
authenticated clone URL, which removes the hand-rolled percent-encoding and the
redundant `credential.helper store`. The SSH authentication path is unchanged.

The workflow-template change is byte-identical to #4490. The accompanying test
updates are **not** included: `test/workflowtemplates/` does not exist on this
branch, so there is no contract-test suite here to update.

## Related Issues
Backport of #4490.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks
No automated coverage exists for this template on this branch, so the change was
validated by hand: the extracted script parses as YAML and passes `sh -n`, and
the equivalent change on `main` is covered by the contract tests in #4490.
