### PR TITLE
fix(controller): report Degraded health for failed Flux HelmRelease resources

### DIFF
--- a/internal/controller/renderedrelease/controller.go
+++ b/internal/controller/renderedrelease/controller.go
@@ -37,6 +37,9 @@ const (
 	deploymentKind  = "Deployment"
 	statefulSetKind = "StatefulSet"
 
+	fluxHelmAPIGroup = "helm.toolkit.fluxcd.io"
+	helmReleaseKind  = "HelmRelease"
+
 	// ConditionResourcesApplied indicates whether resources were successfully applied to the target plane.
 	// When False, it contains the error message from the failed apply operation.
 	ConditionResourcesApplied = "ResourcesApplied"

--- a/internal/controller/renderedrelease/controller_status.go
+++ b/internal/controller/renderedrelease/controller_status.go
@@ -211,6 +211,8 @@ func GetHealthCheckFunc(gvk schema.GroupVersionKind) func(obj *unstructured.Unst
 		return getPodHealth
 	case gvk.Group == "batch" && gvk.Kind == "CronJob":
 		return getCronJobHealth
+	case gvk.Group == fluxHelmAPIGroup && gvk.Kind == helmReleaseKind:
+		return getHelmReleaseHealth
 		// TODO: Add gateway http route health check, and other resources as needed
 	}
 	return getUnknownResourceHealth
@@ -419,6 +421,50 @@ func getCronJobHealth(obj *unstructured.Unstructured) (openchoreov1alpha1.Health
 	}
 
 	// CronJob hasn't run yet - could be newly created or waiting for schedule
+	return openchoreov1alpha1.HealthStatusProgressing, nil
+}
+
+// getHelmReleaseHealth evaluates the health of a Flux HelmRelease based on its status
+// conditions. Flux surfaces the outcome of the underlying Helm install/upgrade through the
+// "Ready" and "Stalled" conditions, so a HelmRelease that has stalled (e.g. install failed and
+// remediation exhausted its retries) or currently reports Ready=False must be reported as
+// Degraded instead of falling through to the default "Healthy" for unknown kinds. A Stalled=True
+// condition always wins over Ready, since Flux keeps Stalled set once remediation gives up even
+// if Ready briefly flips back.
+func getHelmReleaseHealth(obj *unstructured.Unstructured) (openchoreov1alpha1.HealthStatus, error) {
+	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil {
+		return openchoreov1alpha1.HealthStatusUnknown, fmt.Errorf("failed to read helmrelease status.conditions: %w", err)
+	}
+	if !found {
+		// No status observed yet -> still progressing
+		return openchoreov1alpha1.HealthStatusProgressing, nil
+	}
+
+	var readyStatus, stalledStatus string
+	for _, c := range conditions {
+		condition, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _ := condition["type"].(string)
+		condStatus, _ := condition["status"].(string)
+		switch condType {
+		case "Ready":
+			readyStatus = condStatus
+		case "Stalled":
+			stalledStatus = condStatus
+		}
+	}
+
+	// Stalled (e.g. remediation retries exceeded) or a terminal Ready=False -> Degraded
+	if stalledStatus == string(metav1.ConditionTrue) || readyStatus == string(metav1.ConditionFalse) {
+		return openchoreov1alpha1.HealthStatusDegraded, nil
+	}
+	if readyStatus == string(metav1.ConditionTrue) {
+		return openchoreov1alpha1.HealthStatusHealthy, nil
+	}
+	// Ready condition not yet reported -> reconciliation still in progress
 	return openchoreov1alpha1.HealthStatusProgressing, nil
 }
 

--- a/internal/controller/renderedrelease/controller_unit_test.go
+++ b/internal/controller/renderedrelease/controller_unit_test.go
@@ -517,6 +517,11 @@ func TestGetHealthCheckFunc(t *testing.T) {
 			wantNonNil: true,
 		},
 		{
+			name:       "helm.toolkit.fluxcd.io/HelmRelease",
+			gvk:        schema.GroupVersionKind{Group: fluxHelmAPIGroup, Version: "v2", Kind: helmReleaseKind},
+			wantNonNil: true,
+		},
+		{
 			name:        "unknown resource returns non-nil health function",
 			gvk:         schema.GroupVersionKind{Group: "custom.io", Version: "v1", Kind: "Widget"},
 			wantNonNil:  true,
@@ -1036,6 +1041,91 @@ func TestGetCronJobHealth(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			obj := makeCJ(tt.cronJob)
 			got, err := getCronJobHealth(obj)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("expected %s, got %s", tt.want, got)
+			}
+		})
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// getHelmReleaseHealth
+// ─────────────────────────────────────────────────────────────
+
+func TestGetHelmReleaseHealth(t *testing.T) {
+	makeHelmRelease := func(conditions []interface{}) *unstructured.Unstructured {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: fluxHelmAPIGroup, Version: "v2", Kind: helmReleaseKind})
+		obj.SetName("test-helmrelease")
+		if conditions != nil {
+			if err := unstructured.SetNestedSlice(obj.Object, conditions, "status", "conditions"); err != nil {
+				t.Fatalf("failed to set conditions: %v", err)
+			}
+		}
+		return obj
+	}
+
+	condition := func(condType, status string) map[string]interface{} {
+		return map[string]interface{}{"type": condType, "status": status}
+	}
+
+	tests := []struct {
+		name       string
+		conditions []interface{}
+		want       openchoreov1alpha1.HealthStatus
+	}{
+		{
+			name:       "no status observed yet is Progressing",
+			conditions: nil,
+			want:       openchoreov1alpha1.HealthStatusProgressing,
+		},
+		{
+			name: "Ready=True is Healthy",
+			conditions: []interface{}{
+				condition("Ready", "True"),
+			},
+			want: openchoreov1alpha1.HealthStatusHealthy,
+		},
+		{
+			name: "install failed and stalled after uninstall remediation is Degraded",
+			conditions: []interface{}{
+				condition("Remediated", "True"),
+				condition("Stalled", "True"),
+				condition("Ready", "False"),
+			},
+			want: openchoreov1alpha1.HealthStatusDegraded,
+		},
+		{
+			name: "terminal Ready=False without an explicit Stalled condition is Degraded",
+			conditions: []interface{}{
+				condition("Ready", "False"),
+			},
+			want: openchoreov1alpha1.HealthStatusDegraded,
+		},
+		{
+			name: "install in progress with Ready=Unknown is Progressing",
+			conditions: []interface{}{
+				condition("Ready", "Unknown"),
+			},
+			want: openchoreov1alpha1.HealthStatusProgressing,
+		},
+		{
+			name: "Stalled=True takes precedence even if Ready=True",
+			conditions: []interface{}{
+				condition("Ready", "True"),
+				condition("Stalled", "True"),
+			},
+			want: openchoreov1alpha1.HealthStatusDegraded,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := makeHelmRelease(tt.conditions)
+			got, err := getHelmReleaseHealth(obj)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/internal/controller/renderedrelease/controller_unit_test.go
+++ b/internal/controller/renderedrelease/controller_unit_test.go
@@ -491,10 +491,11 @@ func TestHasResurrectableWorkload(t *testing.T) {
 
 func TestGetHealthCheckFunc(t *testing.T) {
 	tests := []struct {
-		name        string
-		gvk         schema.GroupVersionKind
-		wantNonNil  bool
-		wantUnknown bool // if true, the result fn should be getUnknownResourceHealth
+		name             string
+		gvk              schema.GroupVersionKind
+		wantNonNil       bool
+		wantUnknown      bool // if true, the result fn should be getUnknownResourceHealth
+		wantHelmDispatch bool // if true, the result fn should be getHelmReleaseHealth
 	}{
 		{
 			name:       "apps/Deployment",
@@ -517,9 +518,10 @@ func TestGetHealthCheckFunc(t *testing.T) {
 			wantNonNil: true,
 		},
 		{
-			name:       "helm.toolkit.fluxcd.io/HelmRelease",
-			gvk:        schema.GroupVersionKind{Group: fluxHelmAPIGroup, Version: "v2", Kind: helmReleaseKind},
-			wantNonNil: true,
+			name:             "helm.toolkit.fluxcd.io/HelmRelease",
+			gvk:              schema.GroupVersionKind{Group: fluxHelmAPIGroup, Version: "v2", Kind: helmReleaseKind},
+			wantNonNil:       true,
+			wantHelmDispatch: true,
 		},
 		{
 			name:        "unknown resource returns non-nil health function",
@@ -552,6 +554,25 @@ func TestGetHealthCheckFunc(t *testing.T) {
 				}
 				if health != openchoreov1alpha1.HealthStatusHealthy {
 					t.Errorf("unknown resource health: expected Healthy, got %s", health)
+				}
+			}
+
+			if tt.wantHelmDispatch && fn != nil {
+				// Dispatched function should behave like getHelmReleaseHealth, not
+				// getUnknownResourceHealth (which would also report Healthy here).
+				obj := &unstructured.Unstructured{}
+				obj.SetGroupVersionKind(tt.gvk)
+				if err := unstructured.SetNestedSlice(obj.Object, []interface{}{
+					map[string]interface{}{"type": "Ready", "status": "False"},
+				}, "status", "conditions"); err != nil {
+					t.Fatalf("failed to set conditions: %v", err)
+				}
+				health, err := fn(obj)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if health != openchoreov1alpha1.HealthStatusDegraded {
+					t.Errorf("HelmRelease with Ready=False: expected Degraded, got %s", health)
 				}
 			}
 		})


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
`RenderedRelease.status.resources[]` health evaluation (`GetHealthCheckFunc` in
`internal/controller/renderedrelease/controller_status.go`) has no case for Flux's
`HelmRelease` (`helm.toolkit.fluxcd.io`) kind, so it falls through to
`getUnknownResourceHealth`, which unconditionally reports `Healthy`. When a Helm-backed
ComponentType's `HelmRelease` fails to install and Flux completes uninstall remediation
(`Ready=False`, `Stalled=True`), the `RenderedRelease` resource entry for that
`HelmRelease` still shows `healthStatus=Healthy`, masking the failure.

This is the short-term fix #1 called out in the issue ("Add HelmRelease health
evaluation in `renderedrelease` (map `Stalled`/terminal `Ready=False` → `Degraded`)").

Note on scope: this PR only fixes the `RenderedRelease.status.resources[].healthStatus`
reporting for the `HelmRelease` kind. It does **not** change `ReleaseBinding` readiness
aggregation (the primary-workload-selection-off-the-stub-Deployment problem described in
the issue's root-cause chain, items 2 and 4), which is a separate, larger change. This PR
does not by itself make the full repro in the issue yield `ReleaseBinding Ready=False`.

## Approach
Added a `getHelmReleaseHealth` function that reads a `HelmRelease` object's
`status.conditions` (via `unstructured.NestedSlice`, since the controller doesn't import
the Flux Helm controller API types) and maps:
- no conditions observed yet → `Progressing`
- `Stalled=True` (remediation exhausted retries) or `Ready=False` → `Degraded`
- `Ready=True` → `Healthy`
- otherwise (e.g. `Ready=Unknown`, mid-reconciliation) → `Progressing`

`Stalled=True` takes precedence over `Ready`, since Flux can leave `Stalled` set even if
`Ready` transiently flips.

Wired this into `GetHealthCheckFunc` via a new case for GVK
`helm.toolkit.fluxcd.io/HelmRelease`, following the same dispatch pattern as the existing
Deployment/StatefulSet/Pod/CronJob handlers. Added two constants (`fluxHelmAPIGroup`,
`helmReleaseKind`) alongside the existing `appsAPIGroup`/`deploymentKind`/`statefulSetKind`
constants in `controller.go`.

## Related Issues
Report: https://github.com/openchoreo/openchoreo/issues/4336

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
Validation performed locally:
- `go build ./...` — whole repo builds.
- `go test ./internal/controller/renderedrelease/...` — full package suite passes,
  including the envtest-backed Ginkgo suite (`make envtest` +
  `KUBEBUILDER_ASSETS=.../bin/tools/k8s/k8s/1.36.0-darwin-arm64`), which is the same `go
  test` invocation `make go.test` uses per package. New table tests
  (`TestGetHelmReleaseHealth`, plus a case added to `TestGetHealthCheckFunc`) cover: no
  conditions, `Ready=True`, `Stalled=True`+`Ready=False` (the issue's repro scenario),
  `Ready=False` alone, `Ready=Unknown`, and `Stalled=True`+`Ready=True` (precedence).
- `make lint` (golangci-lint + license-check + newline-check, full repo) — 0 issues.
- `gofmt -l` on the changed files — clean.
- Did **not** run `make code.gen-check` (manifests/openapi/helm/mockery regeneration):
  this change only touches hand-written controller logic, no CRD/API types or mocked
  interfaces, so it should not affect generated output. Flagging this as disclosure per
  repo convention rather than a skipped requirement.
- Verified base branch CI is currently green (`gh run list --branch main`) and this
  branch is cut from `upstream/main`'s current tip.
- Did not run against a live cluster / Flux install; the fix is validated at the unit
  level against synthetic `HelmRelease` status conditions matching the shapes described
  in the issue (`InstallFailed`, `Stalled=True`, `Remediated=True`).

Fixes #4336