### PR TITLE
fix(controller): honor Ready condition in unknown resource health check

### DIFF
--- a/internal/controller/renderedrelease/controller_status.go
+++ b/internal/controller/renderedrelease/controller_status.go
@@ -423,8 +423,38 @@ func getCronJobHealth(obj *unstructured.Unstructured) (openchoreov1alpha1.Health
 }
 
 func getUnknownResourceHealth(obj *unstructured.Unstructured) (openchoreov1alpha1.HealthStatus, error) {
-	// For unknown resources, we can't determine health status reliably
+	// For unknown resources, we can't determine health status reliably in general.
 	// Resources like ConfigMaps, Secrets, Services, etc. don't have meaningful health states
-	// They are either present or not, so if we got here, they exist
+	// They are either present or not, so if we got here, they exist.
+	//
+	// However, many foreign CRDs (e.g. ExternalSecret, cert-manager Certificate) follow the
+	// Kubernetes API convention of publishing a "Ready" status condition. When one is present,
+	// use it instead of unconditionally reporting Healthy, so a foreign resource that is still
+	// provisioning is classified as transitioning and re-checked on the faster progressing
+	// requeue interval rather than the 5 minute stable one.
+	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil || !found {
+		return openchoreov1alpha1.HealthStatusHealthy, nil
+	}
+
+	for _, c := range conditions {
+		condition, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if condType, _, _ := unstructured.NestedString(condition, "type"); condType != "Ready" {
+			continue
+		}
+		status, _, _ := unstructured.NestedString(condition, "status")
+		switch corev1.ConditionStatus(status) {
+		case corev1.ConditionTrue:
+			return openchoreov1alpha1.HealthStatusHealthy, nil
+		case corev1.ConditionFalse:
+			return openchoreov1alpha1.HealthStatusProgressing, nil
+		default:
+			return openchoreov1alpha1.HealthStatusUnknown, nil
+		}
+	}
+
 	return openchoreov1alpha1.HealthStatusHealthy, nil
 }

--- a/internal/controller/renderedrelease/controller_unit_test.go
+++ b/internal/controller/renderedrelease/controller_unit_test.go
@@ -1064,6 +1064,84 @@ func TestGetUnknownResourceHealth(t *testing.T) {
 	}
 }
 
+func TestGetUnknownResourceHealth_ReadyCondition(t *testing.T) {
+	newForeignCRD := func(conditions []interface{}) *unstructured.Unstructured {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "postgresql.cnpg.io", Version: "v1", Kind: "Cluster"})
+		obj.SetName("test")
+		if conditions != nil {
+			_ = unstructured.SetNestedSlice(obj.Object, conditions, "status", "conditions")
+		}
+		return obj
+	}
+
+	tests := []struct {
+		name       string
+		conditions []interface{}
+		want       openchoreov1alpha1.HealthStatus
+	}{
+		{
+			name:       "no status.conditions falls back to Healthy",
+			conditions: nil,
+			want:       openchoreov1alpha1.HealthStatusHealthy,
+		},
+		{
+			name: "no Ready condition falls back to Healthy",
+			conditions: []interface{}{
+				map[string]interface{}{"type": "SomeOtherCondition", "status": "False"},
+			},
+			want: openchoreov1alpha1.HealthStatusHealthy,
+		},
+		{
+			name: "Ready=True is Healthy",
+			conditions: []interface{}{
+				map[string]interface{}{"type": "Ready", "status": "True"},
+			},
+			want: openchoreov1alpha1.HealthStatusHealthy,
+		},
+		{
+			name: "Ready=False is Progressing, not Healthy",
+			conditions: []interface{}{
+				map[string]interface{}{"type": "Ready", "status": "False"},
+			},
+			want: openchoreov1alpha1.HealthStatusProgressing,
+		},
+		{
+			name: "Ready=Unknown is Unknown",
+			conditions: []interface{}{
+				map[string]interface{}{"type": "Ready", "status": "Unknown"},
+			},
+			want: openchoreov1alpha1.HealthStatusUnknown,
+		},
+		{
+			name: "Ready condition missing status field is Unknown",
+			conditions: []interface{}{
+				map[string]interface{}{"type": "Ready"},
+			},
+			want: openchoreov1alpha1.HealthStatusUnknown,
+		},
+		{
+			name: "malformed non-map condition entry is skipped, falls back to Healthy",
+			conditions: []interface{}{
+				"not-a-condition-map",
+			},
+			want: openchoreov1alpha1.HealthStatusHealthy,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			health, err := getUnknownResourceHealth(newForeignCRD(tt.conditions))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if health != tt.want {
+				t.Errorf("expected %s, got %s", tt.want, health)
+			}
+		})
+	}
+}
+
 // ─────────────────────────────────────────────────────────────
 // makeDesiredResources
 // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Purpose
When a `Resource` is backed by a foreign/third-party CRD that the `renderedrelease` controller has no dedicated health check for (e.g. `ExternalSecret`, CloudNativePG `Cluster`), `getUnknownResourceHealth` unconditionally reports `HealthStatusHealthy`, even while the resource is still provisioning. Because a `Healthy` resource is classified as "stable" (not "transitioning") by `hasTransitioningResources`, the controller falls back to its slow 5-minute stable requeue interval instead of the 10-second progressing interval, so the RenderedRelease (and any `ResourceReleaseBinding` gated on its status) can take up to ~5 minutes to observe the resource's real, already-ready status.

## Approach
`getUnknownResourceHealth` now inspects `status.conditions` on the unstructured object. If a condition with `type == "Ready"` is present (the standard Kubernetes API convention followed by many controllers, e.g. `external-secrets`'s `ExternalSecret`, cert-manager's `Certificate`), its `status` (`True`/`False`/`Unknown`) is used to report `Healthy`/`Progressing`/`Unknown` respectively. If there is no `status.conditions` field, or no condition of type `Ready`, behavior is unchanged (`Healthy`) — this preserves existing behavior for `ConfigMap`, `Secret`, `Service`, and any other resource kind without a `Ready` condition.

This is a generic, convention-based version of "Proposed fix 1" in the issue (add health checks for CRD kinds OpenChoreo provisions), without hardcoding specific CRD kinds. It does **not** fully close the issue for CRDs that don't expose a `Ready` condition (e.g. resources whose readiness is only exposed via `status.phase`) — that would need per-kind health checks or watching data-plane objects, which are the other options the issue lists.

Repos's own `samples/getting-started/cluster-resource-types/{postgres,nats,valkey}.yaml` render `ExternalSecret` resources without a `readyWhen`, so this also fixes a latent correctness gap there: those entries will now correctly show `Progressing` until External Secrets Operator syncs the secret, instead of always reporting `Healthy` immediately after apply.

## Related Issues
Report: https://github.com/openchoreo/openchoreo/issues/4323

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [ ] This PR includes AI-generated code or content

## Remarks
Validation performed:
- `go build ./...` passes.
- `go test ./internal/controller/renderedrelease/...` passes, including the full envtest/Ginkgo integration suite (36 specs) with `KUBEBUILDER_ASSETS` pointed at downloaded envtest binaries — added unit test `TestGetUnknownResourceHealth_ReadyCondition` (7 subtests: no conditions, non-Ready condition, Ready=True, Ready=False, Ready=Unknown, Ready with missing status field, malformed condition entry) plus confirmed the existing `TestGetUnknownResourceHealth` (bare `ConfigMap`, no conditions) still returns `Healthy`.
- `make lint` passes using the repo-pinned golangci-lint v2.8.0 (0 issues) — note a locally-installed newer golangci-lint version produced unrelated pre-existing `goconst` false positives across this test file on `main` itself; not introduced by this change and not reproducible with the pinned version.
- Did not run `make code.gen-check` — this change touches no API types, CRDs, OpenAPI specs, Helm templates, or samples inputs, so it cannot affect generated output.
- Base branch (`main`) CI is currently green (`Build and Test` succeeded on the latest push).

Fixes #4323