### PR TITLE
feat(helm): add logLevel value for controller-manager

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
@@ -75,6 +75,9 @@ spec:
         {{- if .Values.controllerManager.manager.maxConcurrentReconciles }}
         - --max-concurrent-reconciles={{ .Values.controllerManager.manager.maxConcurrentReconciles }}
         {{- end }}
+        {{- if .Values.controllerManager.manager.logLevel }}
+        - --zap-log-level={{ .Values.controllerManager.manager.logLevel }}
+        {{- end }}
         env:
         - name: ENABLE_WEBHOOKS
           value: {{ quote .Values.controllerManager.manager.env.enableWebhooks }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -1948,7 +1948,7 @@
             },
             "logLevel": {
               "default": "",
-              "description": "Log verbosity level for the controller-manager, passed as --zap-log-level.\nEmpty string leaves controller-runtime's zap default (info) in place.\n",
+              "description": "Log verbosity level for the controller-manager, passed as --zap-log-level.\nEmpty string leaves controller-runtime's zap default (debug) in place.\n",
               "enum": [
                 "",
                 "debug",

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -1946,6 +1946,19 @@
               "title": "env",
               "type": "object"
             },
+            "logLevel": {
+              "default": "",
+              "description": "Log verbosity level for the controller-manager, passed as --zap-log-level.\nEmpty string leaves controller-runtime's zap default (info) in place.\n",
+              "enum": [
+                "",
+                "debug",
+                "info",
+                "error",
+                "panic"
+              ],
+              "required": [],
+              "title": "logLevel"
+            },
             "maxConcurrentReconciles": {
               "default": 1,
               "description": "Max concurrent reconciles per controller (manager-wide); raise (e.g. 10) to increase reconcile throughput at scale.",

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -764,6 +764,14 @@ controllerManager:
     # @schema
     maxConcurrentReconciles: 1
     # @schema
+    # description: |
+    #   Log verbosity level for the controller-manager, passed as --zap-log-level.
+    #   Empty string leaves controller-runtime's zap default (info) in place.
+    # enum: ["", "debug", "info", "error", "panic"]
+    # default: ""
+    # @schema
+    logLevel: ""
+    # @schema
     # type: object
     # description: Environment variables for the controller-manager
     # @schema

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -766,7 +766,7 @@ controllerManager:
     # @schema
     # description: |
     #   Log verbosity level for the controller-manager, passed as --zap-log-level.
-    #   Empty string leaves controller-runtime's zap default (info) in place.
+    #   Empty string leaves controller-runtime's zap default (debug) in place.
     # enum: ["", "debug", "info", "error", "panic"]
     # default: ""
     # @schema


### PR DESCRIPTION
## Purpose
The controller-manager binary already supports runtime log verbosity via controller-runtime's zap flags (`--zap-log-level=debug|info|error|panic`, bound in `cmd/main.go` via `opts.BindFlags(flag.CommandLine)`), but the Helm chart exposed no dedicated value for it. The only way to change it was to override the entire `controllerManager.manager.args` array, which is error-prone: the user has to repeat every default arg, and a mistake can silently break leader election, metrics, or health probes.

## Approach
Added a new `controllerManager.manager.logLevel` value (default `""`) to the `openchoreo-control-plane` chart, following the exact pattern already used for `maxConcurrentReconciles`:
- `install/helm/openchoreo-control-plane/values.yaml`: new `logLevel` value with `@schema` annotations (`enum: ["", "debug", "info", "error", "panic"]`, matching the exact set controller-runtime's `zap.Options.BindFlags` accepts for `--zap-log-level`).
- `install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml`: conditionally appends `--zap-log-level={{ .Values.controllerManager.manager.logLevel }}` only when the value is non-empty, so the default (unset) behavior is unchanged.
- `install/helm/openchoreo-control-plane/values.schema.json`: regenerated via the repo's `helm-schema` tool.

Users can now run `--set controllerManager.manager.logLevel=debug` instead of overriding the full args array.

## Related Issues
Report: https://github.com/openchoreo/openchoreo/issues/4488

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [ ] This PR includes AI-generated code or content

## Remarks
Validation performed (no Go code changed, so no `go test` target is affected):
- `helm lint install/helm/openchoreo-control-plane` — 0 chart(s) failed. A pre-existing INFO notice about placeholder `.invalid` hostnames in default values is unrelated to this change (confirmed via `git stash`, byte-for-byte identical before/after, and it references unrelated fields: `openchoreoApi`, `backstage`, `gateway`, `security.oidc`).
- `helm template` with `--set controllerManager.manager.logLevel=debug` confirms `--zap-log-level=debug` is appended to the deployment's container args; with no override, the rendered deployment args are byte-for-byte identical to before this change (default behavior unchanged).
- `make helm-generate.openchoreo-control-plane` (the full chart regen target used by CI's `make code.gen`/`code.gen-check`: controller-gen manifests, kubebuilder-helm-gen, `helm-schema`, `helm lint`) run fresh from a clean tree — the resulting diff is exactly the 3 files in this PR, with no other drift.
- `make license-check` and `make newline-check` passed.
- `go build ./...` passed.
- Base branch (`upstream/main`) CI is green as of this PR (`gh run list --branch main` shows recent `Build and Test` / `Lint PR` / `CodeQL` runs all successful).

This is an additive, backward-compatible Helm value: users who don't set `logLevel` see no change in rendered output.

Fixes #4488