### PR TITLE
fix(helm): remove unused Jenkins secret reference

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/configmap-ci.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/configmap-ci.yaml
@@ -14,11 +14,13 @@ data:
     # are activated by setting the corresponding `backstage.externalCI.<provider>.enabled`
     # value to true and by populating the matching keys in the Secret referenced
     # by `backstage.secretName`.
+{{- if .Values.backstage.externalCI.jenkins.enabled }}
     # Jenkins: requires the `jenkins.io/job-full-name` annotation on the Component.
     jenkins:
       baseUrl: ${JENKINS_BASE_URL}
       username: ${JENKINS_USERNAME}
       apiKey: ${JENKINS_API_KEY}
+{{- end }}
 {{- if .Values.backstage.externalCI.githubActions.enabled }}
     # GitHub Actions: requires the `github.com/project-slug` annotation on the Component.
     # See https://backstage.io/docs/integrations/github/locations for the Backstage GitHub

--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -164,6 +164,7 @@ spec:
           value: {{ .Values.backstage.observability.wirelogs.streamTimeoutSeconds | default 900 | quote }}
         # External CI Platform Integrations
         # Jenkins: requires jenkins.io/job-full-name annotation on entity
+        {{- if .Values.backstage.externalCI.jenkins.enabled }}
         - name: JENKINS_BASE_URL
           value: {{ .Values.backstage.externalCI.jenkins.baseUrl | quote }}
         - name: JENKINS_USERNAME
@@ -173,6 +174,7 @@ spec:
             secretKeyRef:
               name: {{ .Values.backstage.secretName }}
               key: jenkins-api-key
+        {{- end }}
         # GitHub Actions: requires github.com/project-slug annotation on entity.
         # Only injected when the integration is enabled, so a disabled provider
         # leaves no GitHub footprint in the Backstage config. GITHUB_TOKEN is

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -1003,7 +1003,7 @@
         },
         "secretName": {
           "default": "",
-          "description": "Name of a Secret containing backstage credentials. Required keys: backend-secret, client-secret, jenkins-api-key. Optional keys: github-actions-token (required when externalCI.githubActions.enabled=true), service-client-secret (if backstage.auth.serviceClientSecretKey is set to a different key). When database.type=postgresql, also requires: postgres-host, postgres-port, postgres-user, postgres-password, postgres-db.",
+          "description": "Name of a Secret containing backstage credentials. Required keys: backend-secret, client-secret. Optional keys: jenkins-api-key (required when externalCI.jenkins.enabled=true), github-actions-token (required when externalCI.githubActions.enabled=true), service-client-secret (if backstage.auth.serviceClientSecretKey is set to a different key). When database.type=postgresql, also requires: postgres-host, postgres-port, postgres-user, postgres-password, postgres-db.",
           "title": "secretName",
           "type": "string"
         },

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -2374,7 +2374,7 @@ backstage:
 
   # @schema
   # type: string
-  # description: "Name of a Secret containing backstage credentials. Required keys: backend-secret, client-secret, jenkins-api-key. Optional keys: github-actions-token (required when externalCI.githubActions.enabled=true), service-client-secret (if backstage.auth.serviceClientSecretKey is set to a different key). When database.type=postgresql, also requires: postgres-host, postgres-port, postgres-user, postgres-password, postgres-db."
+  # description: "Name of a Secret containing backstage credentials. Required keys: backend-secret, client-secret. Optional keys: jenkins-api-key (required when externalCI.jenkins.enabled=true), github-actions-token (required when externalCI.githubActions.enabled=true), service-client-secret (if backstage.auth.serviceClientSecretKey is set to a different key). When database.type=postgresql, also requires: postgres-host, postgres-port, postgres-user, postgres-password, postgres-db."
   # default: ""
   # @schema
   secretName: ""

--- a/install/k3d/common/values-openbao.yaml
+++ b/install/k3d/common/values-openbao.yaml
@@ -49,7 +49,6 @@ server:
       # Backstage (web console)
       bao kv put secret/backstage-backend-secret value="local-dev-backend-secret"
       bao kv put secret/backstage-client-secret value="backstage-portal-secret"
-      bao kv put secret/backstage-jenkins-api-key value="placeholder-not-in-use"
       bao kv put secret/backstage-github-actions-token value="placeholder-not-in-use"
       bao kv put secret/backstage-github-oauth-client-secret value="placeholder-not-in-use"
       # Observer (observability)

--- a/install/k3d/k3d-install.sh
+++ b/install/k3d/k3d-install.sh
@@ -246,8 +246,6 @@ spec:
       remoteRef: { key: backstage-backend-secret, property: value }
     - secretKey: client-secret
       remoteRef: { key: backstage-client-secret, property: value }
-    - secretKey: jenkins-api-key
-      remoteRef: { key: backstage-jenkins-api-key, property: value }
     - secretKey: github-actions-token
       remoteRef: { key: backstage-github-actions-token, property: value }
     - secretKey: github-oauth-client-secret

--- a/install/k3d/multi-cluster/README.md
+++ b/install/k3d/multi-cluster/README.md
@@ -93,7 +93,6 @@ kubectl --context k3d-openchoreo-cp create secret generic backstage-secrets \
   -n openchoreo-control-plane \
   --from-literal=backend-secret="$(head -c 32 /dev/urandom | base64)" \
   --from-literal=client-secret="backstage-portal-secret" \
-  --from-literal=jenkins-api-key="placeholder-not-in-use" \
   --from-literal=github-actions-token="placeholder-not-in-use" \
   --from-literal=github-oauth-client-secret="placeholder-not-in-use"
 ```

--- a/install/k3d/single-cluster/README.md
+++ b/install/k3d/single-cluster/README.md
@@ -105,7 +105,6 @@ kubectl create secret generic backstage-secrets \
   -n openchoreo-control-plane \
   --from-literal=backend-secret="$(head -c 32 /dev/urandom | base64)" \
   --from-literal=client-secret="backstage-portal-secret" \
-  --from-literal=jenkins-api-key="placeholder-not-in-use" \
   --from-literal=github-actions-token="placeholder-not-in-use" \
   --from-literal=github-oauth-client-secret="placeholder-not-in-use"
 ```

--- a/install/prerequisites/openbao/setup.sh
+++ b/install/prerequisites/openbao/setup.sh
@@ -160,7 +160,6 @@ if [[ "$SEED_DEV_SECRETS" == "true" ]]; then
 
         bao kv put secret/backstage-backend-secret value='local-dev-backend-secret'
         bao kv put secret/backstage-client-secret value='backstage-portal-secret'
-        bao kv put secret/backstage-jenkins-api-key value='placeholder-not-in-use'
         bao kv put secret/backstage-github-actions-token value='placeholder-not-in-use'
         bao kv put secret/backstage-github-oauth-client-secret value='placeholder-not-in-use'
 

--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -397,8 +397,7 @@ _e2e.prepare-backstage-secret:
 		BACKEND_SECRET=$$(head -c 32 /dev/urandom | base64 | tr -d '\n'); \
 		$(E2E_KUBECTL) -n $(E2E_CP_NS) create secret generic backstage-secrets \
 			--from-literal=backend-secret="$$BACKEND_SECRET" \
-			--from-literal=client-secret="backstage-portal-secret" \
-			--from-literal=jenkins-api-key="placeholder-not-in-use"; \
+			--from-literal=client-secret="backstage-portal-secret"; \
 	else \
 		echo "backstage-secrets already exists, leaving in place"; \
 	fi


### PR DESCRIPTION
## Purpose

When Jenkins is not used, Backstage still requires a `jenkins-api-key` entry in `backstage-secrets`, forcing users to provide a dummy value.

This PR removes that unnecessary requirement.

## Approach

- Render Jenkins environment variables only when Jenkins integration is enabled.
- Render Jenkins configuration only when `backstage.externalCI.jenkins.enabled` is true.
- Remove dummy Jenkins secret provisioning from K3d, OpenBao, README, and E2E setup.
- Update Helm values documentation and schema.

## Related Issues

Closes #2142

## Checklist

- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported
- [x] This PR includes AI-generated code or content

## Remarks

Verified successfully with:

- `helm lint`
- Jenkins-enabled and Jenkins-disabled Helm template rendering
- Shell syntax checks
- `make lint`
- `make go.test`
- `make python.test`
- `git diff --check`

No unrelated generated changes were introduced.