### PR TITLE
fix: reduce remediation agent token usage in sre-agent

### DIFF
--- a/agents/sre-agent/src/agent/agent.py
+++ b/agents/sre-agent/src/agent/agent.py
@@ -145,6 +145,7 @@ REMED_AGENT = Agent(
     ],
     response_format=RemediationResult,
     recursion_limit=50,
+    use_summarization=True,
 )
 
 CHAT_AGENT = Agent(

--- a/agents/sre-agent/src/agent/middleware/output_transformer.py
+++ b/agents/sre-agent/src/agent/middleware/output_transformer.py
@@ -337,7 +337,7 @@ def _extract_content(content: Any) -> dict[str, Any] | None:
                     parsed = json.loads(block["text"])
                     if isinstance(parsed, dict):
                         return parsed
-                except json.JSONDecodeError, KeyError, TypeError:
+                except (json.JSONDecodeError, KeyError, TypeError):
                     continue
 
     return None

--- a/agents/sre-agent/src/agent/tool_registry.py
+++ b/agents/sre-agent/src/agent/tool_registry.py
@@ -137,6 +137,17 @@ class _ListComponentsInput(BaseModel):
     project: str = Field(..., description="Project name")
 
 
+_K8S_NOISE_KEYS = {"managedFields", "resourceVersion", "uid", "generation", "creationTimestamp"}
+
+
+def _strip_k8s_noise(obj):
+    if isinstance(obj, dict):
+        return {k: _strip_k8s_noise(v) for k, v in obj.items() if k not in _K8S_NOISE_KEYS}
+    if isinstance(obj, list):
+        return [_strip_k8s_noise(item) for item in obj]
+    return obj
+
+
 def create_list_release_bindings_tool(auth: httpx.Auth) -> StructuredTool:
     async def _run(namespace: str, component: str) -> str:
         result = await get(
@@ -144,7 +155,7 @@ def create_list_release_bindings_tool(auth: httpx.Auth) -> StructuredTool:
             auth,
             params={"component": component},
         )
-        return json.dumps(result)
+        return json.dumps(_strip_k8s_noise(result))
 
     return StructuredTool.from_function(
         coroutine=_run,


### PR DESCRIPTION
## Purpose
Fixes a syntax error blocking module imports and a 413 token-limit error
that was preventing the remediation agent from completing after RCA
analysis.

## Approach
- Fixed a Python 2 style except clause causing a SyntaxError on import
- Added `use_summarization=True` to REMED_AGENT, consistent with the
  other agents, to keep conversation size under Groq's 8000 TPM limit
- Stripped noisy Kubernetes metadata fields (managedFields,
  resourceVersion, uid, generation, creationTimestamp) from
  `list_release_bindings` tool output before it reaches the model

## Related Issues
N/A

## Testing
Reproduced the 413 error on a real OOM-kill incident scenario where
remediation consistently failed after RCA completion. Verified the fix
resolves both the import error and the token-limit error.