### PR TITLE
fix(api): include component in exec authorization hierarchy

### DIFF
--- a/internal/openchoreo-api/api/handlers/exec.go
+++ b/internal/openchoreo-api/api/handlers/exec.go
@@ -105,6 +105,7 @@ func (h *ExecHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Hierarchy: authz.ResourceHierarchy{
 			Namespace: namespace,
 			Project:   project,
+			Component: componentName,
 		},
 		Context: authz.Context{
 			Resource: authz.ResourceAttribute{

--- a/internal/openchoreo-api/api/handlers/exec_test.go
+++ b/internal/openchoreo-api/api/handlers/exec_test.go
@@ -46,7 +46,7 @@ func TestExecHandler_AuthzEnvironmentContext_ExplicitEnv(t *testing.T) {
 	require.Len(t, pdp.Captured, 1, "authz check should run before pod resolution")
 	testutil.RequireEvalRequest(t, pdp.Captured[0],
 		authz.ActionExecComponent, "component", "greeter-service",
-		authz.ResourceHierarchy{Namespace: "default", Project: "default"})
+		authz.ResourceHierarchy{Namespace: "default", Project: "default", Component: "greeter-service"})
 	require.Equal(t,
 		services.FormatDualScopedResourceName("default", "development", false),
 		pdp.Captured[0].Context.Resource.Environment)


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
> Briefly describe the problem or need driving this PR and how it resolves the issue. Include links to related issues if applicable.

When a role binding's scope is restricted to a specific component, the bound role cannot exec into that component, even though the binding explicitly grants access to it. `ExecHandler.ServeHTTP` builds the authorization `ResourceHierarchy` with only `Namespace` and `Project` set, omitting `Component`, even though the component name is already known at that point in the handler.

The Casbin policy matcher (`resourceMatch` in `internal/authz/casbin/helpers.go`) only allows a policy path to match a request path when the policy path is an exact match or a strict prefix of it. Because the exec request's hierarchy path omits the `component/<name>` segment, it is shorter than a component-scoped policy's path, so a component-scoped binding's policy path can never be a prefix of (or equal to) the request path — it can never match, and exec is denied. Namespace- and project-scoped bindings are unaffected because their (shorter) policy path is still a valid prefix of the request path.

## Approach
> Summarize the solution and implementation details.

Set `Component: componentName` in the `authz.ResourceHierarchy` literal built by `ExecHandler.ServeHTTP` in `internal/openchoreo-api/api/handlers/exec.go`, matching the convention already used by every other component-scoped authorization check in the codebase (e.g. `internal/openchoreo-api/services/component/service_authz.go`, `internal/openchoreo-api/api/handlers/wirelogs.go`).

Updated the existing unit test `TestExecHandler_AuthzEnvironmentContext_ExplicitEnv` in `internal/openchoreo-api/api/handlers/exec_test.go` to assert the corrected hierarchy (`Component: "greeter-service"`), since it previously encoded the buggy (missing-Component) hierarchy as the expected value.

## Related Issues
> Include any related issues that are resolved by this PR.

Report: https://github.com/openchoreo/openchoreo/issues/4504

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.

Validation: confirmed the fix with a targeted unit test. Before the fix, `go test ./internal/openchoreo-api/api/handlers/... -run TestExecHandler_AuthzEnvironmentContext_ExplicitEnv` fails with a hierarchy mismatch (`Component` empty instead of `"greeter-service"`); after the fix, it passes. Also ran `go build ./...`, `go test ./internal/openchoreo-api/... ./internal/authz/...` (all pass), and `make lint` (0 issues) locally. Did not run a live cluster / e2e exec reproduction; the defect and fix are fully provable at the unit-test level since the Casbin policy-path matcher (`resourceMatch`/`resourceHierarchyToPath` in `internal/authz/casbin/helpers.go`) is exercised directly by the handler's authz check request, with no live-cluster dependency.

Fixes #4504