### PR TITLE
fix(helm): prune authz bootstrap resources

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/authz/_authz-bootstrap.tpl
+++ b/install/helm/openchoreo-control-plane/templates/authz/_authz-bootstrap.tpl
@@ -17,6 +17,20 @@ Bootstrap resource name prefix (cluster-scoped and namespaced hook resources).
 {{- end }}
 
 {{/*
+Label applied to every authorization CR managed by the bootstrap Job.
+*/}}
+{{- define "openchoreo-control-plane.authz.bootstrapManagedBy" -}}
+{{- include "openchoreo-control-plane.authz.bootstrapName" . }}
+{{- end }}
+
+{{/*
+Kubectl label selector for pruning authorization CRs managed by the bootstrap Job.
+*/}}
+{{- define "openchoreo-control-plane.authz.bootstrapPruneSelector" -}}
+openchoreo.dev/managed-by={{ include "openchoreo-control-plane.authz.bootstrapManagedBy" . }}
+{{- end }}
+
+{{/*
 Render a single AuthzRole/ClusterAuthzRole document.
 Usage: include "openchoreo-control-plane.authz.roleManifest" (dict "role" $role "root" $root)
 */}}
@@ -31,6 +45,7 @@ metadata:
   labels:
     {{- include "openchoreo-control-plane.labels" $root | nindent 4 }}
     openchoreo.io/bootstrap: "true"
+    openchoreo.dev/managed-by: {{ include "openchoreo-control-plane.authz.bootstrapManagedBy" $root | quote }}
     {{- if $role.system }}
     openchoreo.io/system: "true"
     {{- end }}
@@ -51,6 +66,7 @@ metadata:
   labels:
     {{- include "openchoreo-control-plane.labels" $root | nindent 4 }}
     openchoreo.io/bootstrap: "true"
+    openchoreo.dev/managed-by: {{ include "openchoreo-control-plane.authz.bootstrapManagedBy" $root | quote }}
     {{- if $role.system }}
     openchoreo.io/system: "true"
     {{- end }}
@@ -81,6 +97,7 @@ metadata:
   labels:
     {{- include "openchoreo-control-plane.labels" $root | nindent 4 }}
     openchoreo.io/bootstrap: "true"
+    openchoreo.dev/managed-by: {{ include "openchoreo-control-plane.authz.bootstrapManagedBy" $root | quote }}
     {{- if $m.system }}
     openchoreo.io/system: "true"
     {{- end }}
@@ -116,6 +133,7 @@ metadata:
   labels:
     {{- include "openchoreo-control-plane.labels" $root | nindent 4 }}
     openchoreo.io/bootstrap: "true"
+    openchoreo.dev/managed-by: {{ include "openchoreo-control-plane.authz.bootstrapManagedBy" $root | quote }}
     {{- if $m.system }}
     openchoreo.io/system: "true"
     {{- end }}

--- a/install/helm/openchoreo-control-plane/templates/authz/bootstrap-job.yaml
+++ b/install/helm/openchoreo-control-plane/templates/authz/bootstrap-job.yaml
@@ -41,6 +41,17 @@ spec:
           command:
             - kubectl
             - apply
+            - --prune
+            - --selector
+            - {{ include "openchoreo-control-plane.authz.bootstrapPruneSelector" . | quote }}
+            - --prune-allowlist
+            - openchoreo.dev/v1alpha1/ClusterAuthzRole
+            - --prune-allowlist
+            - openchoreo.dev/v1alpha1/ClusterAuthzRoleBinding
+            - --prune-allowlist
+            - openchoreo.dev/v1alpha1/AuthzRole
+            - --prune-allowlist
+            - openchoreo.dev/v1alpha1/AuthzRoleBinding
             - -f
             - /bootstrap/manifests.yaml
           env:

--- a/install/helm/openchoreo-control-plane/templates/authz/bootstrap-rbac.yaml
+++ b/install/helm/openchoreo-control-plane/templates/authz/bootstrap-rbac.yaml
@@ -32,8 +32,10 @@ rules:
       - authzrolebindings
     verbs:
       - get
+      - list
       - create
       - patch
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/install/helm/openchoreo-control-plane/tests/verify-authz-bootstrap-prune.sh
+++ b/install/helm/openchoreo-control-plane/tests/verify-authz-bootstrap-prune.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright 2026 The OpenChoreo Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+chart_dir="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+rendered="$(mktemp)"
+trap 'rm -f "$rendered"' EXIT
+
+helm template openchoreo-control-plane "$chart_dir" \
+  --namespace openchoreo-control-plane \
+  --set-string openchoreoApi.http.hostnames[0]=api.example.com \
+  --set-string backstage.http.hostnames[0]=backstage.example.com \
+  --set-string backstage.baseUrl=https://backstage.example.com \
+  --set-string gateway.tls.hostname=gateway.example.com \
+  --set-string security.oidc.issuer=https://issuer.example.com \
+  --set-string backstage.secretName=backstage-secrets > "$rendered"
+
+require_rendered() {
+  local expected="$1"
+  if ! grep -Fq -- "$expected" "$rendered"; then
+    echo "missing rendered content: $expected" >&2
+    exit 1
+  fi
+}
+
+require_rendered "- --prune"
+require_rendered "- --selector"
+require_rendered "- \"openchoreo.dev/managed-by=openchoreo-authz-bootstrap\""
+require_rendered "- --prune-allowlist"
+require_rendered "- openchoreo.dev/v1alpha1/ClusterAuthzRole"
+require_rendered "- openchoreo.dev/v1alpha1/ClusterAuthzRoleBinding"
+require_rendered "- openchoreo.dev/v1alpha1/AuthzRole"
+require_rendered "- openchoreo.dev/v1alpha1/AuthzRoleBinding"
+require_rendered "openchoreo.dev/managed-by: \"openchoreo-authz-bootstrap\""
+require_rendered "- list"
+require_rendered "- delete"


### PR DESCRIPTION
## Summary
- label generated AuthzRole/AuthzRoleBinding CRs with bootstrap ownership using the canonical openchoreo.dev label domain
- run kubectl apply with --prune, a dedicated selector, and CRD allowlists
- grant list/delete to the bootstrap service account for pruning
- add a chart render verification script for prune behavior

## Tests
- install/helm/openchoreo-control-plane/tests/verify-authz-bootstrap-prune.sh
- git diff --check