### PR TITLE
fix(api): require service identity for analyze

### DIFF
--- a/agents/sre-agent/openapi.yaml
+++ b/agents/sre-agent/openapi.yaml
@@ -46,6 +46,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized - invalid or missing authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: Forbidden - service account identity required
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Internal server error
           content:

--- a/agents/sre-agent/src/api/agent_routes.py
+++ b/agents/sre-agent/src/api/agent_routes.py
@@ -10,7 +10,7 @@ from pydantic import Field
 
 from common.auth.authz_models import SubjectContext
 from src.agent import run_analysis, stream_chat
-from src.auth import require_authn, require_chat_authz
+from src.auth import require_authn, require_chat_authz, require_service_identity
 from src.clients import get_report_backend
 from src.helpers import resolve_component_scope, resolve_project_scope
 from src.models import BaseModel, get_current_utc
@@ -76,6 +76,8 @@ class ChatRequest(BaseModel):
 async def analyze(
     request: AnalyzeRequest,
     background_tasks: BackgroundTasks,
+    _auth: Annotated[SubjectContext, Depends(require_authn)],
+    _service_identity: Annotated[SubjectContext, Depends(require_service_identity)],
 ):
     if logger.isEnabledFor(logging.DEBUG):
         body = request.model_dump_json(by_alias=True)

--- a/agents/sre-agent/src/auth.py
+++ b/agents/sre-agent/src/auth.py
@@ -1,6 +1,11 @@
 # Copyright 2026 The OpenChoreo Authors
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Annotated
+
+from fastapi import Depends, HTTPException
+
+from common.auth.authz_models import SubjectContext
 from common.auth.runtime import (
     AuthRuntime,
     hierarchy_from_body,
@@ -15,6 +20,21 @@ get_authz_client = auth.get_authz_client
 get_oauth2_auth = auth.get_oauth2_auth
 check_oauth2_connection = auth.check_oauth2_connection
 require_authn = auth.require_authn
+
+
+async def require_service_identity(
+    subject: Annotated[SubjectContext, Depends(require_authn)],
+) -> SubjectContext:
+    if subject.type != "service_account":
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error": "FORBIDDEN",
+                "message": "Service account identity required",
+            },
+        )
+    return subject
+
 
 require_chat_authz = auth.checker(
     "rcareport:view",

--- a/agents/sre-agent/tests/test_agent_routes.py
+++ b/agents/sre-agent/tests/test_agent_routes.py
@@ -16,7 +16,7 @@ from fastapi.testclient import TestClient
 
 from common.auth.authz_models import SubjectContext
 from src.api.agent_routes import router as agent_router
-from src.auth import require_authn, require_chat_authz
+from src.auth import require_authn, require_chat_authz, require_service_identity
 from src.helpers import AlertScope
 
 SCOPE = AlertScope(
@@ -62,7 +62,16 @@ def _subject():
     return SubjectContext(type="user", entitlementClaim="sub", entitlementValues=["u1"])
 
 
+def _service_subject():
+    return SubjectContext(
+        type="service_account", entitlementClaim="sub", entitlementValues=["rca-agent"]
+    )
+
+
 def test_analyze_returns_pending_and_schedules_task(app):
+    app.dependency_overrides[require_authn] = _service_subject
+    app.dependency_overrides[require_service_identity] = _service_subject
+
     backend = MagicMock()
     backend.upsert_rca_report = AsyncMock()
 
@@ -91,6 +100,9 @@ def test_analyze_returns_pending_and_schedules_task(app):
 
 
 def test_analyze_returns_500_when_backend_fails(app):
+    app.dependency_overrides[require_authn] = _service_subject
+    app.dependency_overrides[require_service_identity] = _service_subject
+
     backend = MagicMock()
     backend.upsert_rca_report = AsyncMock(side_effect=RuntimeError("db down"))
 
@@ -106,8 +118,19 @@ def test_analyze_returns_500_when_backend_fails(app):
 
 
 def test_analyze_rejects_malformed_body(app):
+    app.dependency_overrides[require_authn] = _service_subject
+    app.dependency_overrides[require_service_identity] = _service_subject
+
     resp = TestClient(app).post("/api/v1alpha1/rca-agent/analyze", json={"namespace": "ns"})
     assert resp.status_code == 422
+
+
+def test_analyze_rejects_non_service_identity(app):
+    app.dependency_overrides[require_authn] = _subject
+
+    resp = TestClient(app).post("/api/v1alpha1/rca-agent/analyze", json=ANALYZE_BODY)
+
+    assert resp.status_code == 403
 
 
 def test_chat_streams_when_report_exists(app):

--- a/agents/sre-agent/tests/test_auth.py
+++ b/agents/sre-agent/tests/test_auth.py
@@ -37,6 +37,7 @@ from src.auth import (
     get_jwt_validator,
     require_authn,
     require_reports_authz,
+    require_service_identity,
 )
 from src.config import settings
 
@@ -164,6 +165,22 @@ async def test_require_authn_success_returns_subject(monkeypatch):
     ctx = await require_authn(req)
     assert ctx.entitlement_values == ["u1"]
     assert req.state.bearer_token == "tok"
+
+
+@pytest.mark.asyncio
+async def test_require_service_identity_allows_service_account():
+    subject = SubjectContext(
+        type="service_account", entitlementClaim="sub", entitlementValues=["agent-client"]
+    )
+    assert await require_service_identity(subject) is subject
+
+
+@pytest.mark.asyncio
+async def test_require_service_identity_rejects_user():
+    subject = SubjectContext(type="user", entitlementClaim="sub", entitlementValues=["u1"])
+    with pytest.raises(HTTPException) as exc:
+        await require_service_identity(subject)
+    assert exc.value.status_code == 403
 
 
 # ----------------------------------------------- authorization checker


### PR DESCRIPTION
## Summary
- require JWT authentication on POST /api/v1alpha1/rca-agent/analyze
- add a service-account identity dependency and reject non-service subjects
- document 401/403 responses for analyze

## Tests
- cd agents/sre-agent && uv run pytest
- cd agents/sre-agent && uvx ruff check src/api/agent_routes.py src/auth.py tests/test_agent_routes.py tests/test_auth.py
- cd agents/sre-agent && uvx ruff format --check src/api/agent_routes.py src/auth.py tests/test_agent_routes.py tests/test_auth.py