### PR TITLE
fix: harden cluster-agent RBAC

### DIFF
--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
@@ -2,29 +2,137 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}-{{ .Release.Namespace }}
+  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}
   labels:
     {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
     app.kubernetes.io/component: cluster-agent
 rules:
-# Cluster-scoped resources only. Namespaced workload permissions live in role.yaml.
+# The data-plane agent applies rendered releases into Cell namespaces
+# (dp-<ns>-<project>-<environment>-<hash>) that are created at runtime, one per
+# Project x Environment. A namespaced Role cannot cover a namespace that does
+# not exist yet, so these grants have to be cluster-wide. What stays out is the
+# actual privilege-escalation vector: write access to apiGroup
+# rbac.authorization.k8s.io.
 - apiGroups: [""]
   resources:
   - namespaces
   verbs: ["*"]
-# Cluster-scoped Cilium network policies (if using Cilium)
+# RBAC, READ ONLY. The RenderedRelease controller reads the live state of every
+# GVK it knows about to build `status.resources`, and that list includes
+# Role/RoleBinding/ClusterRole/ClusterRoleBinding. The whole read-back aborts on
+# the first 403, `status.resources` stays empty, and ReleaseBinding then reports
+# `Ready=False / ResourcesProgressing` forever, for a Deployment that is 1/1 and
+# serving traffic. See internal/controller/renderedrelease/controller_status.go
+# and internal/controller/releasebinding/controller_status.go:95.
+#
+# get/list/watch is not the escalation vector: escalating needs
+# create/update/patch/bind/escalate, which stay denied. Do not widen these verbs.
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources:
+  - roles
+  - rolebindings
+  - clusterroles
+  - clusterrolebindings
+  verbs: ["get", "list", "watch"]
+# Core Kubernetes workload resources
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  - statefulsets
+  - daemonsets
+  - replicasets
+  verbs: ["*"]
+# Deployment scale subresource (required for kubectl scale)
+- apiGroups: ["apps"]
+  resources:
+  - deployments/scale
+  - statefulsets/scale
+  - replicasets/scale
+  verbs: ["get", "update", "patch"]
+- apiGroups: [""]
+  resources:
+  - pods
+  - services
+  - configmaps
+  - secrets
+  - persistentvolumeclaims
+  - serviceaccounts
+  - endpoints
+  verbs: ["*"]
+# Cell governance objects. A ProjectType template is free to emit a ResourceQuota
+# or a LimitRange for the Cell namespace, and the agent is what applies them.
+- apiGroups: [""]
+  resources:
+  - resourcequotas
+  - limitranges
+  verbs: ["*"]
+- apiGroups: [""]
+  resources:
+  - pods/log
+  - pods/status
+  - events
+  verbs: ["get", "list"]
+# Pod exec (required for occ component exec / interactive shell into pods)
+- apiGroups: [""]
+  resources:
+  - pods/exec
+  verbs: ["create", "get"]
+# Batch jobs
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  - cronjobs
+  verbs: ["*"]
+# Networking
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - ingresses
+  - networkpolicies
+  verbs: ["*"]
+# Autoscaling
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["*"]
+# Policy
+- apiGroups: ["policy"]
+  resources:
+  - poddisruptionbudgets
+  verbs: ["*"]
+# Cilium network policies (if using Cilium)
 - apiGroups: ["cilium.io"]
   resources:
+  - ciliumnetworkpolicies
   - ciliumclusterwidenetworkpolicies
   verbs: ["*"]
-# Cluster-scoped External Secrets Operator resources
+# Gateway API resources (if using Gateway API)
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - gateways
+  - httproutes
+  - tcproutes
+  - grpcroutes
+  - tlsroutes
+  - referencegrants
+  verbs: ["*"]
+# External Secrets Operator
 - apiGroups: ["external-secrets.io"]
   resources:
+  - externalsecrets
+  - secretstores
   - clustersecretstores
+  - pushsecrets
+  verbs: ["*"]
+# External Secrets Operator generators
+- apiGroups: ["generators.external-secrets.io"]
+  resources:
+  - passwords
   verbs: ["*"]
 # KGateway resources (if using KGateway)
 - apiGroups: ["gateway.kgateway.dev"]
   resources:
+  - backends
   - gatewayparameters
+  - trafficpolicies
   verbs: ["*"]
 {{- end }}

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/clusterrole.yaml
@@ -7,107 +7,24 @@ metadata:
     {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
     app.kubernetes.io/component: cluster-agent
 rules:
-# Core Kubernetes workload resources
-- apiGroups: ["apps"]
-  resources:
-  - deployments
-  - statefulsets
-  - daemonsets
-  - replicasets
-  verbs: ["*"]
-# Deployment scale subresource (required for kubectl scale)
-- apiGroups: ["apps"]
-  resources:
-  - deployments/scale
-  - statefulsets/scale
-  - replicasets/scale
-  verbs: ["get", "update", "patch"]
+# Cluster-scoped resources only. Namespaced workload permissions live in role.yaml.
 - apiGroups: [""]
   resources:
-  - pods
-  - services
-  - configmaps
-  - secrets
-  - persistentvolumeclaims
-  - serviceaccounts
   - namespaces
-  - endpoints
   verbs: ["*"]
-- apiGroups: [""]
-  resources:
-  - pods/log
-  - pods/status
-  - events
-  verbs: ["get", "list"]
-# Pod exec (required for occ component exec / interactive shell into pods)
-- apiGroups: [""]
-  resources:
-  - pods/exec
-  verbs: ["create", "get"]
-# Batch jobs
-- apiGroups: ["batch"]
-  resources:
-  - jobs
-  - cronjobs
-  verbs: ["*"]
-# Networking
-- apiGroups: ["networking.k8s.io"]
-  resources:
-  - ingresses
-  - networkpolicies
-  verbs: ["*"]
-# RBAC (for service account management)
-- apiGroups: ["rbac.authorization.k8s.io"]
-  resources:
-  - roles
-  - rolebindings
-  - clusterroles
-  - clusterrolebindings
-  verbs: ["*"]
-# Autoscaling
-- apiGroups: ["autoscaling"]
-  resources:
-  - horizontalpodautoscalers
-  verbs: ["*"]
-# Policy
-- apiGroups: ["policy"]
-  resources:
-  - poddisruptionbudgets
-  verbs: ["*"]
-# Cilium network policies (if using Cilium)
+# Cluster-scoped Cilium network policies (if using Cilium)
 - apiGroups: ["cilium.io"]
   resources:
-  - ciliumnetworkpolicies
   - ciliumclusterwidenetworkpolicies
   verbs: ["*"]
-# Gateway API resources (if using Gateway API)
-- apiGroups: ["gateway.networking.k8s.io"]
-  resources:
-  - gateways
-  - httproutes
-  - tcproutes
-  - grpcroutes
-  - tlsroutes
-  - referencegrants
-  verbs: ["*"]
-# External Secrets Operator
+# Cluster-scoped External Secrets Operator resources
 - apiGroups: ["external-secrets.io"]
   resources:
-  - externalsecrets
-  - secretstores
   - clustersecretstores
-  - pushsecrets
-  verbs: ["*"]
-# External Secrets Operator generators
-- apiGroups: ["generators.external-secrets.io"]
-  resources:
-  - passwords
   verbs: ["*"]
 # KGateway resources (if using KGateway)
 - apiGroups: ["gateway.kgateway.dev"]
   resources:
-  - backends
   - gatewayparameters
-  - trafficpolicies
   verbs: ["*"]
 {{- end }}

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/role.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/role.yaml
@@ -1,0 +1,101 @@
+{{- if .Values.clusterAgent.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}
+  labels:
+    {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+rules:
+# Core Kubernetes workload resources
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  - statefulsets
+  - daemonsets
+  - replicasets
+  verbs: ["*"]
+# Deployment scale subresource (required for kubectl scale)
+- apiGroups: ["apps"]
+  resources:
+  - deployments/scale
+  - statefulsets/scale
+  - replicasets/scale
+  verbs: ["get", "update", "patch"]
+- apiGroups: [""]
+  resources:
+  - pods
+  - services
+  - configmaps
+  - secrets
+  - persistentvolumeclaims
+  - serviceaccounts
+  - endpoints
+  verbs: ["*"]
+- apiGroups: [""]
+  resources:
+  - pods/log
+  - pods/status
+  - events
+  verbs: ["get", "list"]
+# Pod exec (required for occ component exec / interactive shell into pods)
+- apiGroups: [""]
+  resources:
+  - pods/exec
+  verbs: ["create", "get"]
+# Batch jobs
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  - cronjobs
+  verbs: ["*"]
+# Networking
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - ingresses
+  - networkpolicies
+  verbs: ["*"]
+# Autoscaling
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["*"]
+# Policy
+- apiGroups: ["policy"]
+  resources:
+  - poddisruptionbudgets
+  verbs: ["*"]
+# Cilium network policies (if using Cilium)
+- apiGroups: ["cilium.io"]
+  resources:
+  - ciliumnetworkpolicies
+  verbs: ["*"]
+# Gateway API resources (if using Gateway API)
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - gateways
+  - httproutes
+  - tcproutes
+  - grpcroutes
+  - tlsroutes
+  - referencegrants
+  verbs: ["*"]
+# External Secrets Operator
+- apiGroups: ["external-secrets.io"]
+  resources:
+  - externalsecrets
+  - secretstores
+  - pushsecrets
+  verbs: ["*"]
+# External Secrets Operator generators
+- apiGroups: ["generators.external-secrets.io"]
+  resources:
+  - passwords
+  verbs: ["*"]
+# KGateway resources (if using KGateway)
+- apiGroups: ["gateway.kgateway.dev"]
+  resources:
+  - backends
+  - trafficpolicies
+  verbs: ["*"]
+{{- end }}

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/rolebinding.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.clusterAgent.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}
+  labels:
+    {{- include "openchoreo-data-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "openchoreo-data-plane.clusterAgent.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "openchoreo-data-plane.clusterAgent.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/cluster-agent/clusterrole.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/cluster-agent/clusterrole.yaml
@@ -7,31 +7,9 @@ metadata:
     {{- include "openchoreo-observability-plane.labels" . | nindent 4 }}
     app.kubernetes.io/component: cluster-agent
 rules:
-# Core Kubernetes workload resources
-- apiGroups: ["apps"]
-  resources:
-  - deployments
-  verbs: ["get", "list", "patch"]
-# Deployment scale subresource (required for kubectl scale)
-- apiGroups: ["apps"]
-  resources:
-  - deployments/scale
-  verbs: ["get", "update", "patch"]
-# Core Kubernetes resources
+# Cluster-scoped resources only. Namespaced observability permissions live in role.yaml.
 - apiGroups: [""]
   resources:
-  - secrets
-  - configmaps
   - namespaces
-  verbs: ["*"]
-- apiGroups: [""]
-  resources:
-  - pods
-  - events
-  verbs: ["get", "list"]
-# OpenChoreo Observability Plane resources
-- apiGroups: ["openchoreo.dev"]
-  resources:
-  - observabilityalertrules
   verbs: ["*"]
 {{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/cluster-agent/role.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/cluster-agent/role.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.clusterAgent.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "openchoreo-observability-plane.clusterAgent.name" . }}
+  labels:
+    {{- include "openchoreo-observability-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+rules:
+# Core Kubernetes workload resources
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  verbs: ["get", "list", "patch"]
+# Deployment scale subresource (required for kubectl scale)
+- apiGroups: ["apps"]
+  resources:
+  - deployments/scale
+  verbs: ["get", "update", "patch"]
+# Core Kubernetes resources
+- apiGroups: [""]
+  resources:
+  - secrets
+  - configmaps
+  verbs: ["*"]
+- apiGroups: [""]
+  resources:
+  - pods
+  - events
+  verbs: ["get", "list"]
+# OpenChoreo Observability Plane resources
+- apiGroups: ["openchoreo.dev"]
+  resources:
+  - observabilityalertrules
+  verbs: ["*"]
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/cluster-agent/rolebinding.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/cluster-agent/rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.clusterAgent.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "openchoreo-observability-plane.clusterAgent.name" . }}
+  labels:
+    {{- include "openchoreo-observability-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "openchoreo-observability-plane.clusterAgent.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "openchoreo-observability-plane.clusterAgent.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/install/helm/openchoreo-workflow-plane/templates/cluster-agent/clusterrole.yaml
+++ b/install/helm/openchoreo-workflow-plane/templates/cluster-agent/clusterrole.yaml
@@ -7,24 +7,96 @@ metadata:
     {{- include "openchoreo-workflow-plane.labels" . | nindent 4 }}
     app.kubernetes.io/component: cluster-agent
 rules:
-# Cluster-scoped resources only. Namespaced workload permissions live in role.yaml.
+# The workflow-plane agent applies WorkflowRuns into workflows-<controlPlaneNs>
+# namespaces, which are derived at runtime and validated by the workflow webhook.
+# A namespaced Role in the release namespace cannot cover them. What stays out is
+# the actual privilege-escalation vector: apiGroup rbac.authorization.k8s.io.
 - apiGroups: [""]
   resources:
   - namespaces
   verbs: ["*"]
-# Cluster-scoped Cilium network policies (if using Cilium)
+# Core Kubernetes workload resources
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  - statefulsets
+  - daemonsets
+  - replicasets
+  verbs: ["*"]
+# Deployment scale subresource (required for kubectl scale)
+- apiGroups: ["apps"]
+  resources:
+  - deployments/scale
+  - statefulsets/scale
+  - replicasets/scale
+  verbs: ["get", "update", "patch"]
+- apiGroups: [""]
+  resources:
+  - pods
+  - services
+  - configmaps
+  - secrets
+  - persistentvolumeclaims
+  - serviceaccounts
+  - endpoints
+  verbs: ["*"]
+- apiGroups: [""]
+  resources:
+  - pods/log
+  - pods/status
+  - events
+  verbs: ["get", "list"]
+# Batch jobs
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  - cronjobs
+  verbs: ["*"]
+# Networking
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - ingresses
+  - networkpolicies
+  verbs: ["*"]
+# Autoscaling
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["*"]
+# Policy
+- apiGroups: ["policy"]
+  resources:
+  - poddisruptionbudgets
+  verbs: ["*"]
+# Cilium network policies (if using Cilium)
 - apiGroups: ["cilium.io"]
   resources:
+  - ciliumnetworkpolicies
   - ciliumclusterwidenetworkpolicies
   verbs: ["*"]
-# Cluster-scoped External Secrets Operator resources
+# Gateway API resources (if using Gateway API)
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - gateways
+  - httproutes
+  - tcproutes
+  - grpcroutes
+  verbs: ["*"]
+# External Secrets Operator
 - apiGroups: ["external-secrets.io"]
   resources:
+  - externalsecrets
+  - secretstores
   - clustersecretstores
+  - pushsecrets
   verbs: ["*"]
-# Cluster-scoped Argo Workflows resources
+# Argo Workflows (for CI/CD pipelines)
 - apiGroups: ["argoproj.io"]
   resources:
+  - workflows
+  - workflowtemplates
+  - cronworkflows
+  - workflowtaskresults
   - clusterworkflowtemplates
   verbs: ["*"]
 {{- end }}

--- a/install/helm/openchoreo-workflow-plane/templates/cluster-agent/clusterrole.yaml
+++ b/install/helm/openchoreo-workflow-plane/templates/cluster-agent/clusterrole.yaml
@@ -7,94 +7,24 @@ metadata:
     {{- include "openchoreo-workflow-plane.labels" . | nindent 4 }}
     app.kubernetes.io/component: cluster-agent
 rules:
-# Core Kubernetes workload resources
-- apiGroups: ["apps"]
-  resources:
-  - deployments
-  - statefulsets
-  - daemonsets
-  - replicasets
-  verbs: ["*"]
-# Deployment scale subresource (required for kubectl scale)
-- apiGroups: ["apps"]
-  resources:
-  - deployments/scale
-  - statefulsets/scale
-  - replicasets/scale
-  verbs: ["get", "update", "patch"]
+# Cluster-scoped resources only. Namespaced workload permissions live in role.yaml.
 - apiGroups: [""]
   resources:
-  - pods
-  - services
-  - configmaps
-  - secrets
-  - persistentvolumeclaims
-  - serviceaccounts
   - namespaces
-  - endpoints
   verbs: ["*"]
-- apiGroups: [""]
-  resources:
-  - pods/log
-  - pods/status
-  - events
-  verbs: ["get", "list"]
-# Batch jobs
-- apiGroups: ["batch"]
-  resources:
-  - jobs
-  - cronjobs
-  verbs: ["*"]
-# Networking
-- apiGroups: ["networking.k8s.io"]
-  resources:
-  - ingresses
-  - networkpolicies
-  verbs: ["*"]
-# RBAC (for service account management)
-- apiGroups: ["rbac.authorization.k8s.io"]
-  resources:
-  - roles
-  - rolebindings
-  verbs: ["*"]
-# Autoscaling
-- apiGroups: ["autoscaling"]
-  resources:
-  - horizontalpodautoscalers
-  verbs: ["*"]
-# Policy
-- apiGroups: ["policy"]
-  resources:
-  - poddisruptionbudgets
-  verbs: ["*"]
-# Cilium network policies (if using Cilium)
+# Cluster-scoped Cilium network policies (if using Cilium)
 - apiGroups: ["cilium.io"]
   resources:
-  - ciliumnetworkpolicies
   - ciliumclusterwidenetworkpolicies
   verbs: ["*"]
-# Gateway API resources (if using Gateway API)
-- apiGroups: ["gateway.networking.k8s.io"]
-  resources:
-  - gateways
-  - httproutes
-  - tcproutes
-  - grpcroutes
-  verbs: ["*"]
-# External Secrets Operator
+# Cluster-scoped External Secrets Operator resources
 - apiGroups: ["external-secrets.io"]
   resources:
-  - externalsecrets
-  - secretstores
   - clustersecretstores
-  - pushsecrets
   verbs: ["*"]
-# Argo Workflows (for CI/CD pipelines)
+# Cluster-scoped Argo Workflows resources
 - apiGroups: ["argoproj.io"]
   resources:
-  - workflows
-  - workflowtemplates
-  - cronworkflows
   - clusterworkflowtemplates
   verbs: ["*"]
 {{- end }}

--- a/install/helm/openchoreo-workflow-plane/templates/cluster-agent/clusterrole.yaml
+++ b/install/helm/openchoreo-workflow-plane/templates/cluster-agent/clusterrole.yaml
@@ -15,6 +15,17 @@ rules:
   resources:
   - namespaces
   verbs: ["*"]
+# RBAC, read only. Same reason as the data plane: the release status read-back
+# enumerates every known GVK, RBAC kinds included, and aborts on the first 403 —
+# which leaves status.resources empty and the binding NotReady forever. Read verbs
+# are not the escalation vector; create/update/patch/bind/escalate stay denied.
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources:
+  - roles
+  - rolebindings
+  - clusterroles
+  - clusterrolebindings
+  verbs: ["get", "list", "watch"]
 # Core Kubernetes workload resources
 - apiGroups: ["apps"]
   resources:

--- a/install/helm/openchoreo-workflow-plane/templates/cluster-agent/role.yaml
+++ b/install/helm/openchoreo-workflow-plane/templates/cluster-agent/role.yaml
@@ -1,0 +1,90 @@
+{{- if .Values.clusterAgent.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "openchoreo-workflow-plane.clusterAgent.name" . }}
+  labels:
+    {{- include "openchoreo-workflow-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+rules:
+# Core Kubernetes workload resources
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  - statefulsets
+  - daemonsets
+  - replicasets
+  verbs: ["*"]
+# Deployment scale subresource (required for kubectl scale)
+- apiGroups: ["apps"]
+  resources:
+  - deployments/scale
+  - statefulsets/scale
+  - replicasets/scale
+  verbs: ["get", "update", "patch"]
+- apiGroups: [""]
+  resources:
+  - pods
+  - services
+  - configmaps
+  - secrets
+  - persistentvolumeclaims
+  - serviceaccounts
+  - endpoints
+  verbs: ["*"]
+- apiGroups: [""]
+  resources:
+  - pods/log
+  - pods/status
+  - events
+  verbs: ["get", "list"]
+# Batch jobs
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  - cronjobs
+  verbs: ["*"]
+# Networking
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - ingresses
+  - networkpolicies
+  verbs: ["*"]
+# Autoscaling
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["*"]
+# Policy
+- apiGroups: ["policy"]
+  resources:
+  - poddisruptionbudgets
+  verbs: ["*"]
+# Cilium network policies (if using Cilium)
+- apiGroups: ["cilium.io"]
+  resources:
+  - ciliumnetworkpolicies
+  verbs: ["*"]
+# Gateway API resources (if using Gateway API)
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - gateways
+  - httproutes
+  - tcproutes
+  - grpcroutes
+  verbs: ["*"]
+# External Secrets Operator
+- apiGroups: ["external-secrets.io"]
+  resources:
+  - externalsecrets
+  - secretstores
+  - pushsecrets
+  verbs: ["*"]
+# Argo Workflows (for CI/CD pipelines)
+- apiGroups: ["argoproj.io"]
+  resources:
+  - workflows
+  - workflowtemplates
+  - cronworkflows
+  verbs: ["*"]
+{{- end }}

--- a/install/helm/openchoreo-workflow-plane/templates/cluster-agent/rolebinding.yaml
+++ b/install/helm/openchoreo-workflow-plane/templates/cluster-agent/rolebinding.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.clusterAgent.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "openchoreo-workflow-plane.clusterAgent.name" . }}
+  labels:
+    {{- include "openchoreo-workflow-plane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cluster-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "openchoreo-workflow-plane.clusterAgent.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "openchoreo-workflow-plane.clusterAgent.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}


### PR DESCRIPTION
## What

Removes the privilege-escalation vector from the `cluster-agent` ClusterRole in the data, observability and workflow plane charts, without breaking the agent's actual job.

The `cluster-agent` proxies requests to the API server with its own ServiceAccount. Granting `clusterroles` / `clusterrolebindings` with verb `*` makes that identity `cluster-admin` in effect and sidesteps the escalation prevention that normally requires `escalate` / `bind`.

## Important: this PR was revised

The first revision moved **every** namespaced grant into a `Role` in the release namespace. The escalation fix was right; the scope was not. **As originally written, this change stops the data plane from deploying anything.** We caught it running the first real workload through a cluster installed from these charts.

### Reproduction

1. Install `openchoreo-data-plane` with `clusterAgent.rbac.create=true`.
2. Declare a `Project` whose `ProjectType` template emits a `ResourceQuota` (or any object) for the Cell namespace, plus a `ProjectReleaseBinding` for an `Environment`.
3. The Cell namespace `dp-<ns>-<project>-<environment>-<hash>` is created at runtime, and the first apply into it fails:

```
Failed to apply resources to target plane: failed to apply resource resource-quota:
resourcequotas "..." is forbidden: User "system:serviceaccount:<ns>:cluster-agent-dataplane"
cannot patch resource "resourcequotas" in API group "" in the namespace "dp-..."
```

A `Role` in the release namespace can never cover a namespace created *after* the chart was installed — and Cells are created one per `Project` × `Environment`, as Projects are declared. The workflow-plane agent has the same problem against `workflows-<controlPlaneNamespace>`.

### Two more gaps found along the way

- **`resourcequotas` and `limitranges` were never granted at all**, before or after this PR. A `ProjectType` that emits Cell governance objects cannot be applied by the agent.
- **The status read-back aborts on the first 403 and takes the health signal with it.** `renderedrelease` lists every known GVK to build `status.resources`, RBAC kinds included:

```
Failed to list live resources from target plane: failed to list resources for
rbac.authorization.k8s.io/v1, Kind=ClusterRoleBinding: ... is forbidden
```

`status.resources` stays empty, so `releasebinding/controller_status.go:95` marks `ResourcesProgressing` and never evaluates readiness. Every component reports `Ready=False` **forever**, including a `Deployment` that is `1/1` and answering HTTP 200.

## What the PR does now

- Workload grants stay on the **ClusterRole** — the only scope that can cover runtime-created namespaces — and gain `resourcequotas` / `limitranges`.
- `rbac.authorization.k8s.io` is granted **`get`/`list`/`watch` only**, which is what the status read-back needs. Escalation requires `create`/`update`/`patch`/`bind`/`escalate`; those stay denied, so the wildcard this PR set out to remove does not come back.
- The observability plane keeps its namespaced `Role`: that agent only touches its own release namespace.

## Suggestion for a follow-up

Independently of the RBAC shape, `renderedrelease`'s live read-back aborting the whole reconcile on a single per-GVK 403 is fragile — any deployment that legitimately restricts one kind loses `status.resources` entirely, and the failure surfaces as a permanently unready component rather than as a permissions error. Tolerating per-GVK failures (and surfacing them as a condition) would make the health signal robust regardless of how tightly an operator scopes the agent. Happy to open a separate issue for that.

Related to #4237.