### PR TITLE
fix: harden cluster gateway proxy denylist

### DIFF
--- a/internal/cluster-gateway/validator.go
+++ b/internal/cluster-gateway/validator.go
@@ -39,7 +39,8 @@ func NewRequestValidator() *RequestValidator {
 		},
 		blockedPaths: []string{
 			"/api/v1/namespaces/kube-system/secrets",
-			"/apis/v1/serviceaccounts", // Cluster-wide service accounts
+			"/api/v1/secrets",         // Cluster-wide secrets
+			"/api/v1/serviceaccounts", // Cluster-wide service accounts
 		},
 		allowedTargets: map[string]bool{
 			"k8s":        true,
@@ -64,12 +65,10 @@ func (v *RequestValidator) ValidateRequest(r *http.Request, target, path string)
 		}
 	}
 
-	for _, blockedPath := range v.blockedPaths {
-		if strings.Contains(path, blockedPath) {
-			return &ValidationError{
-				Code:    http.StatusForbidden,
-				Message: fmt.Sprintf("Access to path is blocked: %s", path),
-			}
+	if v.isBlockedPath(r.Method, path) {
+		return &ValidationError{
+			Code:    http.StatusForbidden,
+			Message: fmt.Sprintf("Access to path is blocked: %s", path),
 		}
 	}
 
@@ -95,6 +94,40 @@ func (v *RequestValidator) ValidateRequest(r *http.Request, target, path string)
 	}
 
 	return nil
+}
+
+func (v *RequestValidator) isBlockedPath(method, requestPath string) bool {
+	for _, blockedPath := range v.blockedPaths {
+		if pathMatchesPrefix(requestPath, blockedPath) {
+			return true
+		}
+	}
+	return isServiceAccountTokenRequest(method, requestPath)
+}
+
+func pathMatchesPrefix(requestPath, blockedPath string) bool {
+	requestPath = strings.TrimRight(requestPath, "/")
+	blockedPath = strings.TrimRight(blockedPath, "/")
+	return requestPath == blockedPath || strings.HasPrefix(requestPath, blockedPath+"/")
+}
+
+func isServiceAccountTokenRequest(method, requestPath string) bool {
+	if method != http.MethodPost {
+		return false
+	}
+
+	segments := strings.Split(strings.Trim(requestPath, "/"), "/")
+	if len(segments) != 7 {
+		return false
+	}
+
+	return segments[0] == "api" &&
+		segments[1] == "v1" &&
+		segments[2] == "namespaces" &&
+		segments[3] != "" &&
+		segments[4] == "serviceaccounts" &&
+		segments[5] != "" &&
+		segments[6] == "token"
 }
 
 func (v *RequestValidator) AllowTarget(target string) {

--- a/internal/cluster-gateway/validator_test.go
+++ b/internal/cluster-gateway/validator_test.go
@@ -30,7 +30,7 @@ func TestNewRequestValidator(t *testing.T) {
 		assert.True(t, v.allowedTargets[tgt], "target %s should be allowed", tgt)
 	}
 
-	assert.Len(t, v.blockedPaths, 2)
+	assert.Len(t, v.blockedPaths, 3)
 }
 
 func TestValidateRequest_AllowedMethods(t *testing.T) {
@@ -65,17 +65,22 @@ func TestValidateRequest_BlockedPaths(t *testing.T) {
 	v := NewRequestValidator()
 
 	tests := []struct {
-		name string
-		path string
+		name   string
+		method string
+		path   string
 	}{
-		{"kube-system secrets", "/api/v1/namespaces/kube-system/secrets"},
-		{"cluster-wide service accounts", "/apis/v1/serviceaccounts"},
-		{"kube-system secrets subpath", "/api/v1/namespaces/kube-system/secrets/my-secret"},
+		{"kube-system secrets", http.MethodGet, "/api/v1/namespaces/kube-system/secrets"},
+		{"kube-system secrets subpath", http.MethodGet, "/api/v1/namespaces/kube-system/secrets/my-secret"},
+		{"cluster-wide secrets", http.MethodGet, "/api/v1/secrets"},
+		{"cluster-wide secrets subpath", http.MethodGet, "/api/v1/secrets/my-secret"},
+		{"cluster-wide service accounts", http.MethodGet, "/api/v1/serviceaccounts"},
+		{"cluster-wide service accounts subpath", http.MethodGet, "/api/v1/serviceaccounts/default"},
+		{"service account token request", http.MethodPost, "/api/v1/namespaces/default/serviceaccounts/default/token"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req := httptest.NewRequest(tt.method, "/test", nil)
 			err := v.ValidateRequest(req, "k8s", tt.path)
 			require.Error(t, err)
 			var valErr *ValidationError
@@ -83,6 +88,44 @@ func TestValidateRequest_BlockedPaths(t *testing.T) {
 			assert.Equal(t, http.StatusForbidden, valErr.Code)
 		})
 	}
+}
+
+func TestValidateRequest_BlockedPathsDoNotUseDeadAPIGroupPath(t *testing.T) {
+	v := NewRequestValidator()
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	err := v.ValidateRequest(req, "k8s", "/apis/v1/serviceaccounts")
+	assert.NoError(t, err)
+}
+
+func TestValidateRequest_AllowsNamespacedServiceAccountReads(t *testing.T) {
+	v := NewRequestValidator()
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"list namespaced service accounts", http.MethodGet, "/api/v1/namespaces/default/serviceaccounts"},
+		{"get namespaced service account", http.MethodGet, "/api/v1/namespaces/default/serviceaccounts/default"},
+		{"non-token service account subresource", http.MethodGet, "/api/v1/namespaces/default/serviceaccounts/default/token"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "/test", nil)
+			err := v.ValidateRequest(req, "k8s", tt.path)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateRequest_BlockedPathBoundary(t *testing.T) {
+	v := NewRequestValidator()
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	err := v.ValidateRequest(req, "k8s", "/api/v1/secretsuffix")
+	assert.NoError(t, err)
 }
 
 func TestValidateRequest_AllowedTargets(t *testing.T) {


### PR DESCRIPTION
## Summary
- correct the core Kubernetes API denylist entry for cluster-wide ServiceAccounts to `/api/v1/serviceaccounts`
- restore denylist coverage for cluster-wide Secrets at `/api/v1/secrets`
- block TokenRequest creation via `POST /api/v1/namespaces/{namespace}/serviceaccounts/{name}/token`
- update validator tests so they cover the actual Kubernetes core API paths and no longer assert the dead `/apis/v1/serviceaccounts` path

## Verification
- `go test ./internal/cluster-gateway`

Fixes #4237