### PR TITLE
fix: harden e2e installation and update e2e tests

### DIFF
--- a/make/e2e.mk
+++ b/make/e2e.mk
@@ -36,6 +36,11 @@ E2E_SETTLE_PROBE_TIMEOUT ?= 5s
 E2E_SETTLE_STABLE_HITS   ?= 3
 # Retries for prerequisite helm installs, see e2e_helm_retry.
 E2E_HELM_RETRY_ATTEMPTS  ?= 3
+# Probes for the API-server gate after cluster create, see e2e_wait_nodes_ready.
+E2E_NODE_READY_ATTEMPTS  ?= 30
+# Lines of pod log kept per container by the diagnostics targets. A UI leg runs
+# for ~an hour, so a small tail captures only the last few seconds of it.
+E2E_DIAGNOSTICS_LOG_TAIL ?= 20000
 # Ginkgo label-filter expression to select which specs run. Empty = run everything.
 # Suites are labeled `tier1`, `tier2`, … on their top-level Describe; see proposal #3509.
 # Examples: `tier1`, `tier1 || tier2`, `tier1 && !tier2`.
@@ -301,16 +306,20 @@ define e2e_wait_metrics_prometheus
 	done
 endef
 
-# Retries kubectl wait for node-Ready, since a just-created k3s API server can
-# briefly return ServiceUnavailable and kubectl wait won't retry that itself.
-# Usage: $(call e2e_mc_wait_nodes_ready,<kubectl-context-flags>,<cluster-label>)
-define e2e_mc_wait_nodes_ready
-	@for i in $$(seq 1 $(E2E_SETTLE_STABLE_HITS)); do \
-		if kubectl $(1) wait --for=condition=Ready nodes --all --timeout=120s; then exit 0; fi; \
-		if [ $$i -eq $(E2E_SETTLE_STABLE_HITS) ]; then echo "$(2) API server did not become ready in time"; exit 1; fi; \
-		$(call log_info, $(2) API server not ready yet, retrying node-ready wait); \
+# Gates on the API server answering, then on node readiness. The probe loop is
+# needed because a just-created k3s API server returns ServiceUnavailable and
+# kubectl won't retry that itself. Probing /readyz rather than re-running the
+# node wait keeps the worst case bounded to ATTEMPTS x (PROBE_TIMEOUT +
+# INTERVAL) plus one node wait, instead of ATTEMPTS full node waits.
+# Usage: $(call e2e_wait_nodes_ready,<kubectl-context-flags>,<cluster-label>)
+define e2e_wait_nodes_ready
+	@for i in $$(seq 1 $(E2E_NODE_READY_ATTEMPTS)); do \
+		if kubectl $(1) get --raw='/readyz' --request-timeout=$(E2E_SETTLE_PROBE_TIMEOUT) >/dev/null 2>&1; then break; fi; \
+		if [ $$i -eq $(E2E_NODE_READY_ATTEMPTS) ]; then echo "$(2) API server did not become ready in time"; exit 1; fi; \
+		$(call log_info, $(2) API server not ready yet); \
 		sleep $(E2E_SETTLE_INTERVAL); \
 	done
+	kubectl $(1) wait --for=condition=Ready nodes --all --timeout=120s
 endef
 
 # Retries a full helm command up to E2E_HELM_RETRY_ATTEMPTS times, since a
@@ -412,7 +421,7 @@ e2e.setup-cluster: ## Create k3d cluster
 	@# OpenAPI/aggregation layer, which a client-side `apply` needs ("failed
 	@# to download openapi: the server is currently unable to handle the
 	@# request"). Mirrors the multi-cluster setup.
-	$(E2E_KUBECTL) wait --for=condition=Ready nodes --all --timeout=120s
+	$(call e2e_wait_nodes_ready,--context $(E2E_KUBECONTEXT),cluster)
 	@$(call log_info, Applying CoreDNS rewrite for e2e domains)
 	$(E2E_KUBECTL) apply -f $(E2E_K3D_DIR)/coredns-custom.yaml
 	@$(call log_success, k3d cluster '$(E2E_CLUSTER_NAME)' created)
@@ -734,7 +743,7 @@ e2e.diagnostics: ## Collect logs, events, and resource dumps from all namespaces
 		$(E2E_KUBECTL) get pods -n $$ns -o wide > $(E2E_DIAGNOSTICS_DIR)/pods-$$ns.txt 2>&1 || true; \
 		$(E2E_KUBECTL) get events -n $$ns --sort-by=.lastTimestamp > $(E2E_DIAGNOSTICS_DIR)/events-$$ns.txt 2>&1 || true; \
 		for pod in $$($(E2E_KUBECTL) get pods -n $$ns -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do \
-			$(E2E_KUBECTL) logs $$pod -n $$ns --all-containers --tail=200 > $(E2E_DIAGNOSTICS_DIR)/logs-$$ns-$$pod.txt 2>&1 || true; \
+			$(E2E_KUBECTL) logs $$pod -n $$ns --all-containers --tail=$(E2E_DIAGNOSTICS_LOG_TAIL) > $(E2E_DIAGNOSTICS_DIR)/logs-$$ns-$$pod.txt 2>&1 || true; \
 		done; \
 	done
 	@$(E2E_KUBECTL) get clusterdataplane,workflowplane,observabilityplane -n default -o yaml > $(E2E_DIAGNOSTICS_DIR)/plane-resources.yaml 2>&1 || true
@@ -784,16 +793,16 @@ e2e.multi.setup: ## All setup: clusters + prerequisites + install + configure
 e2e.multi.setup-clusters: ## Create all four k3d clusters (CP, DP, WP, OP)
 	@$(call log_info, Creating CP cluster '$(E2E_MC_CP_CLUSTER_NAME)')
 	k3d cluster create --config $(E2E_MC_K3D_DIR)/config-cp.yaml
-	$(call e2e_mc_wait_nodes_ready,--context $(E2E_MC_CP_KUBECONTEXT),CP)
+	$(call e2e_wait_nodes_ready,--context $(E2E_MC_CP_KUBECONTEXT),CP)
 	@$(call log_info, Creating DP cluster '$(E2E_MC_DP_CLUSTER_NAME)')
 	k3d cluster create --config $(E2E_MC_K3D_DIR)/config-dp.yaml
-	$(call e2e_mc_wait_nodes_ready,--context $(E2E_MC_DP_KUBECONTEXT),DP)
+	$(call e2e_wait_nodes_ready,--context $(E2E_MC_DP_KUBECONTEXT),DP)
 	@$(call log_info, Creating WP cluster '$(E2E_MC_WP_CLUSTER_NAME)')
 	k3d cluster create --config $(E2E_MC_K3D_DIR)/config-wp.yaml
-	$(call e2e_mc_wait_nodes_ready,--context $(E2E_MC_WP_KUBECONTEXT),WP)
+	$(call e2e_wait_nodes_ready,--context $(E2E_MC_WP_KUBECONTEXT),WP)
 	@$(call log_info, Creating OP cluster '$(E2E_MC_OP_CLUSTER_NAME)')
 	k3d cluster create --config $(E2E_MC_K3D_DIR)/config-op.yaml
-	$(call e2e_mc_wait_nodes_ready,--context $(E2E_MC_OP_KUBECONTEXT),OP)
+	$(call e2e_wait_nodes_ready,--context $(E2E_MC_OP_KUBECONTEXT),OP)
 	@$(call log_info, Applying CoreDNS rewrites)
 	$(E2E_MC_CP_KUBECTL) apply -f $(E2E_MC_K3D_DIR)/coredns-custom-cp.yaml
 	$(E2E_MC_DP_KUBECTL) apply -f $(E2E_MC_K3D_DIR)/coredns-custom-dp.yaml
@@ -1312,7 +1321,7 @@ e2e.multi.diagnostics: ## Collect logs, events, and resource dumps from all four
 		$(E2E_MC_CP_KUBECTL) get pods -n $$ns -o wide > $(E2E_MC_DIAGNOSTICS_DIR)/cp-pods-$$ns.txt 2>&1 || true; \
 		$(E2E_MC_CP_KUBECTL) get events -n $$ns --sort-by=.lastTimestamp > $(E2E_MC_DIAGNOSTICS_DIR)/cp-events-$$ns.txt 2>&1 || true; \
 		for pod in $$($(E2E_MC_CP_KUBECTL) get pods -n $$ns -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do \
-			$(E2E_MC_CP_KUBECTL) logs $$pod -n $$ns --all-containers --tail=200 > $(E2E_MC_DIAGNOSTICS_DIR)/cp-logs-$$ns-$$pod.txt 2>&1 || true; \
+			$(E2E_MC_CP_KUBECTL) logs $$pod -n $$ns --all-containers --tail=$(E2E_DIAGNOSTICS_LOG_TAIL) > $(E2E_MC_DIAGNOSTICS_DIR)/cp-logs-$$ns-$$pod.txt 2>&1 || true; \
 		done; \
 	done
 	@for plane_ctx in $(E2E_MC_DP_KUBECONTEXT):dp:$(E2E_DP_NS) \
@@ -1326,7 +1335,7 @@ e2e.multi.diagnostics: ## Collect logs, events, and resource dumps from all four
 		kubectl --context $$ctx describe nodes > $(E2E_MC_DIAGNOSTICS_DIR)/$$prefix-nodes.txt 2>&1 || true; \
 		kubectl --context $$ctx top nodes > $(E2E_MC_DIAGNOSTICS_DIR)/$$prefix-top-nodes.txt 2>&1 || true; \
 		for pod in $$(kubectl --context $$ctx get pods -n $$ns -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do \
-			kubectl --context $$ctx logs $$pod -n $$ns --all-containers --tail=200 > $(E2E_MC_DIAGNOSTICS_DIR)/$$prefix-logs-$$pod.txt 2>&1 || true; \
+			kubectl --context $$ctx logs $$pod -n $$ns --all-containers --tail=$(E2E_DIAGNOSTICS_LOG_TAIL) > $(E2E_MC_DIAGNOSTICS_DIR)/$$prefix-logs-$$pod.txt 2>&1 || true; \
 		done; \
 	done
 	@$(E2E_MC_CP_KUBECTL) get clusterdataplane,clusterworkflowplane,clusterobservabilityplane -o yaml > $(E2E_MC_DIAGNOSTICS_DIR)/plane-resources.yaml 2>&1 || true
@@ -1341,7 +1350,7 @@ e2e.multi.diagnostics: ## Collect logs, events, and resource dumps from all four
 		kubectl --context $(E2E_MC_WP_KUBECONTEXT) get events -n $$ns --sort-by=.lastTimestamp > $(E2E_MC_DIAGNOSTICS_DIR)/wp-$$ns-events.txt 2>&1 || true; \
 		kubectl --context $(E2E_MC_WP_KUBECONTEXT) describe pods -n $$ns > $(E2E_MC_DIAGNOSTICS_DIR)/wp-$$ns-describe.txt 2>&1 || true; \
 		for pod in $$(kubectl --context $(E2E_MC_WP_KUBECONTEXT) get pods -n $$ns -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do \
-			kubectl --context $(E2E_MC_WP_KUBECONTEXT) logs $$pod -n $$ns --all-containers --tail=200 > $(E2E_MC_DIAGNOSTICS_DIR)/wp-$$ns-logs-$$pod.txt 2>&1 || true; \
+			kubectl --context $(E2E_MC_WP_KUBECONTEXT) logs $$pod -n $$ns --all-containers --tail=$(E2E_DIAGNOSTICS_LOG_TAIL) > $(E2E_MC_DIAGNOSTICS_DIR)/wp-$$ns-logs-$$pod.txt 2>&1 || true; \
 		done; \
 	done
 	@# Host-level resource usage of the k3d node containers. Captured from the

--- a/test/e2e/suites/observability/observer_mcp_test.go
+++ b/test/e2e/suites/observability/observer_mcp_test.go
@@ -44,7 +44,7 @@ const (
 	obsMCPAuthzLabelKey = "e2e-obsmcp/run"
 )
 
-// allObserverTools is the exact set of 11 tools the observer MCP server
+// allObserverTools is the exact set of 13 tools the observer MCP server
 // registers (internal/observer/mcp/server.go). Pinned here so O3 catches an
 // accidental add/remove.
 var allObserverTools = []string{
@@ -59,6 +59,8 @@ var allObserverTools = []string{
 	"get_span_details",
 	"query_alerts",
 	"query_incidents",
+	"query_costs",
+	"query_recommendations",
 }
 
 var _ = Describe("Observer MCP", Ordered, Label("tier3"), func() {
@@ -165,15 +167,15 @@ var _ = Describe("Observer MCP", Ordered, Label("tier3"), func() {
 		Expect(names).NotTo(BeEmpty(), "observer tool list should not be empty")
 	})
 
-	It("O3: all 11 observer tools are registered/visible (no visibility filter)", func() {
-		// O3: all 11 observer tools must be registered/visible; observer has NO visibility filter,
-		// so an unbound subject still sees all 11 (unlike the control-plane MCP). Pins the live registered
+	It("O3: all 13 observer tools are registered/visible (no visibility filter)", func() {
+		// O3: all 13 observer tools must be registered/visible; observer has NO visibility filter,
+		// so an unbound subject still sees all 13 (unlike the control-plane MCP). Pins the live registered
 		// inventory and the no-filter behavior end to end.
 		//
 		// Toolset narrowing / filterByAuthz / deprecated-tool specs are N/A here:
 		// the observer's NewHTTPServer (internal/observer/mcp/server.go:15-26)
 		// registers no filter middleware, so there is no per-tool authz visibility
-		// filter and the unbound subject sees the same 11 tools (pinned in O6).
+		// filter and the unbound subject sees the same 13 tools (pinned in O6).
 		adminNames, err := framework.ListMCPToolNames(adminSession)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(adminNames).To(ConsistOf(allObserverTools),
@@ -188,10 +190,12 @@ var _ = Describe("Observer MCP", Ordered, Label("tier3"), func() {
 	// O4 — tool chain: exactly one tool per distinct signal/service path
 	// (logs / metrics / events / traces).
 	//
-	// Selection rationale (4 of the 11 tools, not 7):
+	// Selection rationale (4 of the 13 tools):
 	//
-	// The 11 observer MCP tools share one integration path — jwt → MCP handler → authz-wrapped
-	// service → CP PDP → JSON-marshalled `TextContent` (internal/observer/mcp/server.go:29-42).
+	// The 13 observer MCP tools share one integration path — jwt → MCP handler → authz-wrapped
+	// service → CP PDP (only for the tools that carry an authz check; get_span_details passes
+	// through, see traces_authz.go:67-70) → JSON-marshalled `TextContent`
+	// (internal/observer/mcp/server.go:29-42).
 	// What actually differs per tool, and therefore needs a *live cluster* to verify, is the
 	// distinct signal/service path each tool drives — its own service + adapter + authz wrapper,
 	// and (for most) a distinct external dependency:
@@ -204,15 +208,15 @@ var _ = Describe("Observer MCP", Ordered, Label("tier3"), func() {
 	// e2e earns its (expensive, ingestion-lag-prone, CPU-starved tier3) keep by exercising one
 	// representative tool per signal/service path — query_component_logs, query_resource_metrics,
 	// query_component_events, query_traces — which proves the wiring to each external system end
-	// to end. The remaining 7 tools add no new signal path: they are the same service behind a
+	// to end. The remaining 9 tools add no new signal path: they are the same service behind a
 	// different query (query_workflow_logs/query_http_metrics/query_workflow_events/
 	// query_incidents), a follow-up read off a trace_id (query_trace_spans, get_span_details),
 	// or owned by another suite's fixtures (query_alerts/query_incidents ← alerts suite). Their
 	// per-tool logic (arg validation, validateComponentScope, query construction, response
-	// decoding, defaults) is pure and is covered by unit/integration tests. Testing all 7 here
-	// would re-prove the same integration path 7× at full e2e cost for zero new signal-path coverage.
+	// decoding, defaults) is pure and is covered by unit/integration tests. Testing all 9 here
+	// would re-prove the same integration path 9× at full e2e cost for zero new signal-path coverage.
 	//
-	// (O3 already asserts all 11 tools are registered/visible; O4 deliberately exercises only the
+	// (O3 already asserts all 13 tools are registered/visible; O4 deliberately exercises only the
 	// 4 backend-representatives. Distinguishing "listed" from "exercised" is intentional.)
 	//
 	// Tools deliberately NOT exercised in e2e, and where their coverage lives instead:
@@ -231,6 +235,8 @@ var _ = Describe("Observer MCP", Ordered, Label("tier3"), func() {
 	//   |                     | (traces_authz.go:67-71), already unit-tested                   | NOT add e2e or claim an authz gap.     |
 	//   | query_alerts,       | alert/incident firing is owned by the alerts suite's fixtures;  | alerts suite (firing) +                |
 	//   | query_incidents     | same authz/PDP path as O5/O6 proves the wiring                 | unit/integration (query/decode)        |
+	//   | query_costs,        | finops service derives both from the SAME Prometheus backend as | unit/integration: finops service +     |
+	//   | query_recommendations| query_resource_metrics; needs hours of usage history no e2e has | scope/granularity validation           |
 
 	It("O4a: query_component_logs returns the greeter's logs (logs → OpenObserve)", func() {
 		// O4a: query_component_logs must return the greeter's logs. Verifies the logs -> OpenObserve
@@ -367,9 +373,9 @@ var _ = Describe("Observer MCP", Ordered, Label("tier3"), func() {
 		}, "insufficient permissions to perform this action")
 	})
 
-	It("O6: grant developer role → query succeeds → revoke → denied (and tool count stays 11)", func() {
+	It("O6: grant developer role → query succeeds → revoke → denied (and tool count stays 13)", func() {
 		// O6: grant developer role -> query succeeds -> revoke -> denied (allow-after-grant +
-		// revocation propagation) on the observer path. Also pins tool count stays 11 before/after grant
+		// revocation propagation) on the observer path. Also pins tool count stays 13 before/after grant
 		// (no visibility filtering). The PDP decision is unit-tested in pdp_test.go; e2e adds real binding
 		// propagation across the OP and CP clusters over the live authz-API call.
 		bindingName := "e2e-obsmcp-dev-" + obsRunID

--- a/test/ui/specs/auth/pkce-login.spec.ts
+++ b/test/ui/specs/auth/pkce-login.spec.ts
@@ -68,6 +68,20 @@ function resolveOccBinary(): string {
 }
 
 test.describe('pkce-login: occ login drives PKCE through the Backstage browser', () => {
+  // `occ login` holds the fixed callback port until it exits, so a spec that
+  // fails mid-flow has to be reaped or every retry hits "address already in use".
+  let loginProc: ReturnType<typeof spawn> | undefined;
+
+  test.afterEach(async () => {
+    const proc = loginProc;
+    loginProc = undefined;
+    if (!proc || proc.exitCode !== null || proc.signalCode !== null) return;
+    // Await the exit so the port is released before the next attempt spawns occ.
+    const exited = new Promise<void>(resolve => proc.once('exit', () => resolve()));
+    proc.kill('SIGKILL');
+    await exited;
+  });
+
   test('occ login → consent → token persisted → occ get components succeeds', async ({
     page,
   }) => {
@@ -126,6 +140,7 @@ test.describe('pkce-login: occ login drives PKCE through the Backstage browser',
     );
 
     const child = spawn(occ, ['login', '--credential', 'ui-pkce'], { env });
+    loginProc = child;
 
     // Capture occ's output so a non-zero exit surfaces the cause (the token
     // exchange is host-side and never appears in the browser trace).


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This PR,
1. Updates the observer MCP server's tool inspection test
2. Harden e2e cluster installation

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content