### PR TITLE
fix(helm): correct nindent for backstage extraVolumes/extraVolumeMounts

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -284,7 +284,7 @@ spec:
           readOnly: true
         {{- end }}
         {{- with .Values.backstage.extraVolumeMounts }}
-        {{- toYaml . | nindent 12 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       volumes:
       {{- if eq .Values.backstage.database.type "sqlite" }}
@@ -310,6 +310,6 @@ spec:
           name: {{ include "openchoreo-control-plane.backstage.name" . }}-extra-config
       {{- end }}
       {{- with .Values.backstage.extraVolumes }}
-      {{- toYaml . | nindent 10 }}
+      {{- toYaml . | nindent 6 }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
## Purpose
Setting `backstage.extraVolumes` or `backstage.extraVolumeMounts` in the `openchoreo-control-plane` chart breaks the render. In `templates/backstage/deployment.yaml`, `extraVolumeMounts` uses `nindent 12` but the surrounding `volumeMounts` items sit at indent 8, and `extraVolumes` uses `nindent 10` but the surrounding `volumes` items sit at indent 6. So the extra entries land nested inside the previous list item instead of next to it, and `helm template`/`helm upgrade` fails with a YAML parse error.

It matters beyond the YAML error: mounting a file into the Backstage container is the only way to point `NODE_EXTRA_CA_CERTS` at a CA cert. With these fields broken there's no way to do that, so on installs where the OpenChoreo API/observer sit behind a private CA over HTTPS, Backstage's server-side calls fail TLS verification quietly (the cell-diagram endpoint still returns 200, the diagram just renders with no traffic). The only workaround was `NODE_TLS_REJECT_UNAUTHORIZED=0`, which turns off cert verification for every outbound call the backend makes.

Fixes #4514

## Approach
Fixed the two `nindent` values to match their surrounding list's indentation:
- `extraVolumeMounts`: `nindent 12` → `nindent 8`
- `extraVolumes`: `nindent 10` → `nindent 6`

## Related Issues
Fixes #4514

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks
Ran `helm template` and `helm lint` with the exact values from the issue's repro steps (an `extraVolumes` secret mount plus the matching `extraVolumeMounts` entry). Without the fix it fails with the same `mapping values are not allowed in this context` error from the issue; with the fix it renders valid YAML and the extra volume/mount show up as proper siblings under `volumes`/`volumeMounts`. Also checked the default case (no extra volumes set) still renders the same as before.
