### PR TITLE
fix(helm): expose Backstage auth audience

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -99,6 +99,10 @@ spec:
           value: {{ .Values.security.oidc.authorizationUrl | quote }}
         - name: OPENCHOREO_AUTH_TOKEN_URL
           value: {{ .Values.security.oidc.tokenUrl | quote }}
+        {{- if .Values.backstage.auth.audience }}
+        - name: OPENCHOREO_AUTH_AUDIENCE
+          value: {{ .Values.backstage.auth.audience | quote }}
+        {{- end }}
         - name: OPENCHOREO_AUTH_CLIENT_ID
           value: {{ .Values.backstage.auth.clientId | quote }}
         - name: OPENCHOREO_AUTH_CLIENT_SECRET

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -32,6 +32,12 @@
               "title": "clientId",
               "type": "string"
             },
+            "audience": {
+              "default": "",
+              "description": "OAuth/OIDC audience requested by the Backstage sign-in client. Set this for providers that require an API audience to issue JWT access tokens.",
+              "title": "audience",
+              "type": "string"
+            },
             "oidcScope": {
               "default": "openid profile email",
               "description": "Space-separated OIDC scopes for the OIDC provider (e.g. 'openid profile email')",

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -2818,6 +2818,12 @@ backstage:
     oidcScope: "openid profile email"
     # @schema
     # type: string
+    # description: OAuth/OIDC audience requested by the Backstage sign-in client. Set this for providers that require an API audience to issue JWT access tokens.
+    # default: ""
+    # @schema
+    audience: ""
+    # @schema
+    # type: string
     # description: Space-separated scopes for the OpenChoreo service token authenticator (e.g. 'openid' or 'api://client-id/.default openid')
     # default: ""
     # @schema


### PR DESCRIPTION
## Summary
- add optional `backstage.auth.audience` to the control-plane chart values and schema
- render `OPENCHOREO_AUTH_AUDIENCE` for the Backstage container when configured

## Why
OIDC providers such as Auth0 require an audience/API identifier to issue JWT access tokens. The Backstage auth provider can consume this as `OPENCHOREO_AUTH_AUDIENCE`, but the chart did not expose a value for it.

## Validation
- `helm lint install/helm/openchoreo-control-plane -f <local-values.yaml>`
- `helm template idp install/helm/openchoreo-control-plane -f <local-values.yaml> --set backstage.auth.audience=<audience-url> | grep -n OPENCHOREO_AUTH_AUDIENCE -A1 -B1`
- `git diff --check`