### PR TITLE
fix(sre-agent): switch to ToolStrategy to fix Groq json mode conflict

### DIFF
--- a/agents/sre-agent/src/agent/agent.py
+++ b/agents/sre-agent/src/agent/agent.py
@@ -11,7 +11,7 @@ from typing import Any
 import httpx
 from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware, TodoListMiddleware
-from langchain.agents.structured_output import ProviderStrategy, StructuredOutputValidationError
+from langchain.agents.structured_output import ProviderStrategy, StructuredOutputValidationError, ToolStrategy
 from langchain_core.callbacks import BaseCallbackHandler, UsageMetadataCallbackHandler
 from langchain_core.runnables import Runnable, RunnableConfig
 from langchain_core.tools import BaseTool
@@ -103,7 +103,7 @@ class Agent:
             tools=tools,
             system_prompt=render(self.template, template_context),
             middleware=middleware,
-            response_format=ProviderStrategy(self.response_format),
+            response_format=ToolStrategy(self.response_format),
         )
 
         runnable_config: RunnableConfig = {"recursion_limit": self.recursion_limit}
@@ -128,7 +128,6 @@ RCA_AGENT = Agent(
         LoggingMiddleware,
         ToolErrorHandlerMiddleware,
         OutputTransformerMiddleware,
-        TodoListMiddleware,
     ],
     response_format=RCAReport,
     recursion_limit=200,
@@ -145,6 +144,7 @@ REMED_AGENT = Agent(
     ],
     response_format=RemediationResult,
     recursion_limit=50,
+    use_summarization=True,
 )
 
 CHAT_AGENT = Agent(

--- a/agents/sre-agent/src/agent/middleware/output_transformer.py
+++ b/agents/sre-agent/src/agent/middleware/output_transformer.py
@@ -337,7 +337,7 @@ def _extract_content(content: Any) -> dict[str, Any] | None:
                     parsed = json.loads(block["text"])
                     if isinstance(parsed, dict):
                         return parsed
-                except json.JSONDecodeError, KeyError, TypeError:
+                except (json.JSONDecodeError, KeyError, TypeError):
                     continue
 
     return None

--- a/agents/sre-agent/src/agent/tool_registry.py
+++ b/agents/sre-agent/src/agent/tool_registry.py
@@ -137,6 +137,17 @@ class _ListComponentsInput(BaseModel):
     project: str = Field(..., description="Project name")
 
 
+_K8S_NOISE_KEYS = {"managedFields", "resourceVersion", "uid", "generation", "creationTimestamp"}
+
+
+def _strip_k8s_noise(obj):
+    if isinstance(obj, dict):
+        return {k: _strip_k8s_noise(v) for k, v in obj.items() if k not in _K8S_NOISE_KEYS}
+    if isinstance(obj, list):
+        return [_strip_k8s_noise(item) for item in obj]
+    return obj
+
+
 def create_list_release_bindings_tool(auth: httpx.Auth) -> StructuredTool:
     async def _run(namespace: str, component: str) -> str:
         result = await get(
@@ -144,7 +155,7 @@ def create_list_release_bindings_tool(auth: httpx.Auth) -> StructuredTool:
             auth,
             params={"component": component},
         )
-        return json.dumps(result)
+        return json.dumps(_strip_k8s_noise(result))
 
     return StructuredTool.from_function(
         coroutine=_run,


### PR DESCRIPTION
## Purpose
Fixes a 400 error that broke every RCA analysis: `json mode cannot be
combined with tool/function calling`. This occurred on every model call
for RCA_AGENT and REMED_AGENT, blocking the entire RCA → remediation
pipeline regardless of the Groq model configured.

## Approach
- Switched `response_format` from `ProviderStrategy` to `ToolStrategy` in
  `agent.py`. `ProviderStrategy` forces provider-native JSON structured
  output, which Groq's API rejects when tools are also bound to the
  request — confirmed via direct request interception, and reproduced
  with two different models (`openai/gpt-oss-120b` and
  `qwen/qwen3.6-27b`), ruling out a model-specific issue.
- Also includes earlier fixes bundled in this branch: a Python 2 style
  `except` syntax error, missing summarization middleware on
  `REMED_AGENT` (previously causing 413 token-limit errors), and
  Kubernetes metadata stripping on `list_release_bindings` output to
  reduce payload size.
- `TodoListMiddleware` was removed from `RCA_AGENT` defensively during
  debugging; it turned out not to be the root cause, but no functional
  dependency on it was found elsewhere in the code, so it's left out.

## Related Issues
N/A

## Testing
Reproduced the 400 error consistently across two Groq models. Verified
the fix by intercepting the exact payload sent to the OpenAI-compatible
client before it hits the network — confirmed `response_format` is no
longer combined with `tools` after switching to `ToolStrategy`.

Note: after this fix, a separate and pre-existing issue was surfaced —
the RCA_AGENT's own system prompt + tool schemas approach Groq's free
tier limit of 8000 tokens/minute even before any incident data is
added. This is a distinct problem (rate limiting, not a code defect)
and is not addressed by this PR.

## Checklist
- [x] This PR includes AI-generated code or content