### PR TITLE
fix: treat empty-allocation 500 from FinOps adapter as empty result

### DIFF
--- a/internal/observer/service/finops_adapter.go
+++ b/internal/observer/service/finops_adapter.go
@@ -4,6 +4,7 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -240,10 +241,30 @@ func parseFinOpsWindow(startTime, endTime string) (time.Time, time.Time, error) 
 	return start, end, nil
 }
 
+// emptyAllocationErrorSignature is the message OpenCost returns when a cost
+// query's window contains no allocation data (e.g. an environment with no
+// workloads, or a window before OpenCost started collecting metrics).
+// OpenCost answers that case with a 500 instead of an empty result, and the
+// adapter propagates it verbatim. Since "no data" is an expected outcome
+// reachable through normal use, it is treated as an empty result here rather
+// than surfaced as a retrieval failure.
+const emptyAllocationErrorSignature = "AllocationSetRange has empty AssetSet"
+
+// emptyFinOpsItems is the empty-result body returned in place of an
+// emptyAllocationErrorSignature 500, matching the `items` envelope shared by
+// the costs and recommendations responses.
+var emptyFinOpsItems = json.RawMessage(`{"items":[]}`)
+
 // rawFinOpsResponse returns the adapter body verbatim on a 2xx, or an error
-// carrying the status and body otherwise.
+// carrying the status and body otherwise. A 500 caused by an empty cost
+// window is treated as a successful empty result instead of an error. This
+// applies to both the costs and recommendations responses, since both use
+// the same `items`-array envelope where an empty list is a valid response.
 func rawFinOpsResponse(statusCode int, body []byte) (any, error) {
 	if statusCode < 200 || statusCode >= 300 {
+		if statusCode == http.StatusInternalServerError && bytes.Contains(body, []byte(emptyAllocationErrorSignature)) {
+			return emptyFinOpsItems, nil
+		}
 		return nil, fmt.Errorf("%w: finops adapter returned HTTP %d: %s", ErrFinOpsRetrieval, statusCode, string(body))
 	}
 	return json.RawMessage(body), nil

--- a/internal/observer/service/finops_adapter_test.go
+++ b/internal/observer/service/finops_adapter_test.go
@@ -288,6 +288,38 @@ func TestFinOpsAdapter_AdapterErrorStatus(t *testing.T) {
 	assert.ErrorIs(t, err, ErrFinOpsRetrieval)
 }
 
+func TestFinOpsAdapter_EmptyAllocationWindow(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"code":500,"data":null,"message":"error accumulating by all: ` +
+			`error accumulating all:AllocationSetRange has empty AssetSet in accumulation"}`))
+	}))
+	defer server.Close()
+
+	resolver, closeResolver := newMockUIDResolver(testProjectUID, testComponentUID, testEnvironmentUID, nil)
+	defer closeResolver()
+
+	adapter, err := NewFinOpsAdapter(server.URL, 30*time.Second, resolver, newTestFinOpsLogger())
+	require.NoError(t, err)
+
+	req := &types.CostQueryRequest{
+		Namespace:   "default",
+		Environment: "production",
+		StartTime:   "2026-05-23T10:00:01Z",
+		EndTime:     "2026-05-24T10:00:01Z",
+	}
+	result, err := adapter.GetComponentCosts(context.Background(), req)
+	require.NoError(t, err, "an empty allocation window is a valid, empty result, not a retrieval failure")
+
+	raw, ok := result.(json.RawMessage)
+	require.True(t, ok, "result should be raw JSON passthrough")
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, []any{}, got["items"])
+}
+
 func TestFinOpsAdapter_NetworkError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Purpose
When a cost query's window contains no allocation data, OpenCost answers `500` instead of an empty result. The `finops-opencost` adapter propagates that `500` verbatim, and the Observer turns it into a generic `internalServerError`, so the console shows "Failed to retrieve data from the FinOps adapter".

This is reachable through normal use: a newly created project's `staging`/`production` environments have no workloads yet, and a fresh install has no cost history for the "Last 1 hour" / "Last 24 hours" presets until OpenCost has been running long enough to emit `node_total_hourly_cost`.

## Approach
`internal/observer/service/finops_adapter.go`'s `rawFinOpsResponse` now recognizes OpenCost's specific "no data" error signature (`AllocationSetRange has empty AssetSet`, as shown in the adapter log in the issue) on a `500` response and treats it as a successful, empty result (`{"items":[]}`) instead of surfacing `ErrFinOpsRetrieval`. This matches the `CostResponse`/`RecommendationResponse` OpenAPI schema, where `items` is a required array that is legally empty, and applies uniformly to both the costs and recommendations endpoints, which share the same envelope and the same code path. Any other `500` (or non-2xx status) is unaffected and still surfaces as an error.

## Related Issues
Report: https://github.com/openchoreo/openchoreo/issues/4522

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks
Validation performed locally (no live OpenCost/Kubernetes cluster available in this environment):
- Added `TestFinOpsAdapter_EmptyAllocationWindow`, which stubs the adapter's HTTP response with the exact 500 body shown in the issue's adapter log. Confirmed it fails against the old code (`finops adapter returned HTTP 500: ...`) and passes with the fix.
- `go build ./...` succeeds.
- `go test ./internal/observer/...` passes (all packages, including the new test).
- `golangci-lint run ./internal/observer/service/...` reports 0 issues.
- License-header and trailing-newline checks pass for the changed files.

This is a translation-layer bug (status/body → error vs. success mapping) fully exercised by a unit test against a fake HTTP server, so a live OpenCost/Kubernetes reproduction was not necessary to validate the fix.

Fixes #4522