### PR TITLE
chore: update CHANGELOG for v1.2.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to OpenChoreo are documented in this file.
 
+## v1.2.3
+
+Changes since [v1.2.2](https://github.com/openchoreo/openchoreo/releases/tag/v1.2.2).
+
+### Bug Fixes
+
+- **(API)** The exec and wirelogs endpoints now resolve the target component first and take its owning project from the component itself rather than from the request parameter, aligning them with the pattern used by other component operations. ([#4251](https://github.com/openchoreo/openchoreo/pull/4251))
+- **(API)** The exec authorization hierarchy now includes the component, so component-scoped exec grants resolve correctly. ([#4506](https://github.com/openchoreo/openchoreo/pull/4506))
+
 ## v1.2.2
 
 Changes since [v1.2.1](https://github.com/openchoreo/openchoreo/releases/tag/v1.2.1).


### PR DESCRIPTION
## Purpose

Adds the `v1.2.3` CHANGELOG section ahead of cutting the patch release from `release-v1.2`.

## Approach

Documents the two fixes backported to `release-v1.2` since v1.2.2:

- **#4251** (backported in #4516) — exec/wirelogs authorization pinned to the component's owning project.
- **#4506** (backported in #4517) — component included in the exec authorization hierarchy.

## Related Issues

Fixes shipped: #4251, #4506

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content
