### PR TITLE
fix(api): include component in exec authorization hierarchy (backport to release-v1.1)

### DIFF
--- a/internal/openchoreo-api/api/handlers/exec.go
+++ b/internal/openchoreo-api/api/handlers/exec.go
@@ -89,6 +89,7 @@ func (h *ExecHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Hierarchy: authz.ResourceHierarchy{
 				Namespace: namespace,
 				Project:   project,
+				Component: componentName,
 			},
 		}); err != nil {
 			if errors.Is(err, svcpkg.ErrForbidden) {

--- a/internal/openchoreo-api/api/handlers/exec_test.go
+++ b/internal/openchoreo-api/api/handlers/exec_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package handlers
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	authz "github.com/openchoreo/openchoreo/internal/authz/core"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services/testutil"
+)
+
+func newExecHandler(t *testing.T, pdp *testutil.CapturingPDP, objs ...client.Object) *ExecHandler {
+	t.Helper()
+	return &ExecHandler{
+		k8sClient:    fake.NewClientBuilder().WithScheme(newTestScheme(t)).WithObjects(objs...).Build(),
+		authzChecker: testutil.NewTestAuthzChecker(pdp),
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+// The exec authz check must carry the target component in its resource
+// hierarchy, otherwise a component-scoped role binding can never match the
+// request path and exec is denied. The fake client has no Component, so the
+// request fails right after the check — but by then the PDP has captured the
+// evaluate request.
+func TestExecHandler_AuthzHierarchyIncludesComponent(t *testing.T) {
+	pdp := testutil.AllowPDP()
+	h := newExecHandler(t, pdp)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/exec/namespaces/default/components/greeter-service?env=development&project=default",
+		nil).WithContext(testutil.AuthzContext())
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.Len(t, pdp.Captured, 1, "authz check should run before pod resolution")
+	testutil.RequireEvalRequest(t, pdp.Captured[0],
+		authz.ActionExecComponent, "component", "greeter-service",
+		authz.ResourceHierarchy{Namespace: "default", Project: "default", Component: "greeter-service"})
+}


### PR DESCRIPTION
## Purpose

Manual backport of #4506 to `release-v1.1`. The automated backport failed because the cherry-pick of `361007ba9` could not be applied cleanly.

The bug is present on `release-v1.1`: when a role binding's scope is restricted to a specific component, the bound role cannot exec into that component, even though the binding explicitly grants access to it. `ExecHandler.ServeHTTP` builds the authorization `ResourceHierarchy` with only `Namespace` and `Project` set, omitting `Component`, even though the component name is already known at that point in the handler.

The Casbin policy matcher (`resourceMatch` in `internal/authz/casbin/helpers.go`, identical on this branch) only allows a policy path to match a request path when the policy path is an exact match or a strict prefix of it. Because the exec request's hierarchy path omits the `component/<name>` segment, it is shorter than a component-scoped policy's path, so a component-scoped binding's policy path can never be a prefix of (or equal to) the request path — it can never match, and exec is denied. Namespace- and project-scoped bindings are unaffected because their shorter policy path is still a valid prefix of the request path.

## Approach

Set `Component: componentName` in the `authz.ResourceHierarchy` literal built by `ExecHandler.ServeHTTP`, matching the convention used by the other component-scoped authorization checks in the codebase.

The cherry-pick conflicted in two places, so the change was applied manually. Two differences from the original commit are worth reviewer attention:

- **`exec.go`** — the upstream hunk also carried an unrelated ABAC context block (`Context.Resource.Environment`) that does not exist on `release-v1.1`. I took only the one-line `Component` field and kept this branch's existing handler structure, so no unrelated feature is pulled back.
- **`exec_test.go`** — the file does not exist on `release-v1.1`, and the upstream test could not be applied as-is: its second case (`TestExecHandler_AuthzEnvironmentContext_DerivedEnv`) asserts the ABAC environment context, which this branch lacks. I added an equivalent test covering the hierarchy assertion, using the `services/testutil` helpers already present on this branch.

## Related Issues

Original PR: #4506
Report: https://github.com/openchoreo/openchoreo/issues/4504

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks

Verified the new test is a real regression guard rather than a test that merely passes: on `release-v1.1` without the fix it fails with a hierarchy mismatch (`Component` empty instead of `"greeter-service"`), and passes with the fix applied.

Also ran `go build ./...`, `go test ./internal/openchoreo-api/... ./internal/authz/...` (all pass), and `make lint` (0 issues, license headers and trailing newlines clean). No live cluster / e2e exec reproduction, same as the original PR — the matcher is exercised directly by the handler's authz check request, with no live-cluster dependency.

Note on `release-v1.0`: the automated backport also failed there, but no backport is needed. That branch has no exec handler and no `component:exec` action at all (`internal/openchoreo-api/api/handlers/exec.go` does not exist and `ActionExecComponent` is not defined), so the bug does not exist on `release-v1.0`.
