### PR TITLE
fix(api): pin exec authz to the component's owning project (backport to release-v1.1)

### DIFF
--- a/internal/openchoreo-api/api/handlers/exec.go
+++ b/internal/openchoreo-api/api/handlers/exec.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/websocket"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -65,7 +66,7 @@ func (h *ExecHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	componentName := parts[1]
 
 	query := r.URL.Query()
-	project := query.Get("project")
+	requestedProject := query.Get("project")
 	envName := query.Get("env")
 	container := query.Get("container")
 	commands := query["command"]
@@ -75,12 +76,31 @@ func (h *ExecHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := h.logger.With("namespace", namespace, "component", componentName)
 
-	// Authorize: check that the caller has component:exec permission.
+	// Authorization must be configured before any access decision is made.
 	if h.authzChecker == nil {
 		logger.Error("Authorization checker not configured")
 		http.Error(w, "authorization not configured", http.StatusInternalServerError)
 		return
 	}
+
+	// Pin authorization and pod resolution to the component's real owning project
+	// rather than the caller-supplied `project`.
+	project, err := h.resolveComponentProject(ctx, namespace, componentName)
+	if err != nil {
+		logger.Warn("Failed to resolve component for exec", "error", err)
+		http.Error(w, fmt.Sprintf("failed to resolve component: %v", err), http.StatusBadRequest)
+		return
+	}
+	// Fail closed if the caller named a project that does not own the component.
+	// The generic forbidden message avoids disclosing the component's real owner.
+	if requestedProject != "" && requestedProject != project {
+		logger.Warn("requested project does not own the target component; denying exec",
+			"requestedProject", requestedProject, "ownerProject", project)
+		http.Error(w, "you do not have permission to exec into this component", http.StatusForbidden)
+		return
+	}
+
+	// Authorize: check that the caller has component:exec permission.
 	{
 		if err := h.authzChecker.Check(ctx, svcpkg.CheckRequest{
 			Action:       authz.ActionExecComponent,
@@ -200,6 +220,21 @@ type execPodInfo struct {
 	podNamespace string
 	podName      string
 	plane        execPlaneInfo
+}
+
+// resolveComponentProject returns the owning project of the named component.
+func (h *ExecHandler) resolveComponentProject(ctx context.Context, namespace, componentName string) (string, error) {
+	comp := &openchoreov1alpha1.Component{}
+	if err := h.k8sClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: componentName}, comp); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", fmt.Errorf("component %q not found in namespace %q", componentName, namespace)
+		}
+		return "", fmt.Errorf("failed to look up component %q: %w", componentName, err)
+	}
+	if comp.Spec.Owner.ProjectName == "" {
+		return "", fmt.Errorf("component %q has no owning project", componentName)
+	}
+	return comp.Spec.Owner.ProjectName, nil
 }
 
 // resolvePod resolves the target pod for exec by traversing:

--- a/internal/openchoreo-api/api/handlers/exec_test.go
+++ b/internal/openchoreo-api/api/handlers/exec_test.go
@@ -11,9 +11,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	authz "github.com/openchoreo/openchoreo/internal/authz/core"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services/testutil"
 )
@@ -27,14 +29,26 @@ func newExecHandler(t *testing.T, pdp *testutil.CapturingPDP, objs ...client.Obj
 	}
 }
 
+// execComponent builds a minimal Component owned by the given project, enough for
+// the handler to resolve the component's owning project before authorizing.
+func execComponent(namespace, name, project string) *openchoreov1alpha1.Component {
+	return &openchoreov1alpha1.Component{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: openchoreov1alpha1.ComponentSpec{
+			Owner: openchoreov1alpha1.ComponentOwner{ProjectName: project},
+		},
+	}
+}
+
 // The exec authz check must carry the target component in its resource
 // hierarchy, otherwise a component-scoped role binding can never match the
-// request path and exec is denied. The fake client has no Component, so the
-// request fails right after the check — but by then the PDP has captured the
+// request path and exec is denied. The component is owned by project "default";
+// after the authz check the request fails during pod resolution (no
+// Environment/DataPlane seeded) — but by then the PDP has captured the
 // evaluate request.
 func TestExecHandler_AuthzHierarchyIncludesComponent(t *testing.T) {
 	pdp := testutil.AllowPDP()
-	h := newExecHandler(t, pdp)
+	h := newExecHandler(t, pdp, execComponent("default", "greeter-service", "default"))
 
 	req := httptest.NewRequest(http.MethodGet,
 		"/exec/namespaces/default/components/greeter-service?env=development&project=default",
@@ -45,4 +59,59 @@ func TestExecHandler_AuthzHierarchyIncludesComponent(t *testing.T) {
 	testutil.RequireEvalRequest(t, pdp.Captured[0],
 		authz.ActionExecComponent, "component", "greeter-service",
 		authz.ResourceHierarchy{Namespace: "default", Project: "default", Component: "greeter-service"})
+}
+
+// The authz hierarchy must carry the component's owning project, not the one the
+// caller supplied — including when `project` is omitted from the request.
+func TestExecHandler_AuthzUsesOwnerProject(t *testing.T) {
+	for _, tc := range []struct{ name, query string }{
+		{"project omitted", "?env=development"},
+		{"project matches owner", "?env=development&project=team-b"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pdp := testutil.AllowPDP()
+			h := newExecHandler(t, pdp, execComponent("default", "victim-svc", "team-b"))
+
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+				"/exec/namespaces/default/components/victim-svc"+tc.query,
+				nil).WithContext(testutil.AuthzContext()))
+
+			require.NotEqual(t, http.StatusForbidden, rec.Code)
+			require.Len(t, pdp.Captured, 1)
+			require.Equal(t, "team-b", pdp.Captured[0].Resource.Hierarchy.Project)
+		})
+	}
+}
+
+// A caller that names a component owned by another project must be refused before
+// authorization runs, so the outcome cannot depend on their grants elsewhere.
+// victim-svc is owned by team-b; the caller claims team-a.
+func TestExecHandler_DeniesComponentProjectMismatch(t *testing.T) {
+	pdp := testutil.AllowPDP()
+	h := newExecHandler(t, pdp, execComponent("default", "victim-svc", "team-b"))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/exec/namespaces/default/components/victim-svc?env=development&project=team-a",
+		nil).WithContext(testutil.AuthzContext()))
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Empty(t, pdp.Captured, "authz must not run when the requested project does not own the component")
+}
+
+// Exec must fail before authorization when the target component does not exist,
+// so component existence — not a caller-supplied project — drives the decision.
+func TestExecHandler_ComponentNotFound(t *testing.T) {
+	pdp := testutil.AllowPDP()
+	h := newExecHandler(t, pdp) // no component seeded
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/exec/namespaces/default/components/ghost?env=development&project=default",
+		nil).WithContext(testutil.AuthzContext()))
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), `component "ghost" not found`)
+	require.Empty(t, pdp.Captured, "authz must not run for a non-existent component")
 }


### PR DESCRIPTION
## Purpose

Backports the exec portion of #4251 to `release-v1.1`.

On `release-v1.1` the exec handler derives its authorization scope from the caller-supplied `project` query parameter while resolving the target component by name only. The scope used for the check is therefore independent of the component's actual owner, and the two can disagree. #4251 aligned this on `main` with the fetch-then-authorize pattern already used by the other component operations in `services/component`.

## Approach

- Adds `resolveComponentProject`, which reads `Component.Spec.Owner.ProjectName`.
- Resolves the owning project before the authorization check and uses it for both the authz hierarchy and pod resolution, in place of the caller-supplied value.
- Returns 403 when the caller names a project that does not own the component, before the PDP is consulted, so the outcome does not vary with the caller's grants elsewhere. The message is intentionally generic and does not echo the component's owner.

## Related Issues

Backport of #4251

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content