### PR TITLE
feat(helm): add bootstrap.extraRoles to append organisation-specific authz roles

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/authz/_authz-bootstrap.tpl
+++ b/install/helm/openchoreo-control-plane/templates/authz/_authz-bootstrap.tpl
@@ -153,6 +153,10 @@ Roles before bindings. Consumed by the bootstrap ConfigMap.
 ---
 {{ include "openchoreo-control-plane.authz.roleManifest" (dict "role" $r "root" $root) }}
 {{- end }}
+{{- range $r := $bootstrap.extraRoles }}
+---
+{{ include "openchoreo-control-plane.authz.roleManifest" (dict "role" $r "root" $root) }}
+{{- end }}
 {{- range $m := $bootstrap.mappings }}
 ---
 {{ include "openchoreo-control-plane.authz.bindingManifest" (dict "mapping" $m "root" $root) }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -17,7 +17,7 @@
         "appConfig": {
           "additionalProperties": true,
           "default": {},
-          "description": "Arbitrary Backstage app-config YAML injected as an additional config overlay. When non-empty the chart renders a ConfigMap named \u003crelease\u003e-backstage-extra-config, mounts it at /app/app-config.extra.yaml, and appends --config app-config.extra.yaml to the startup args automatically. This is the preferred mechanism for operator-specific Backstage configuration (auth, integrations, etc.) without requiring a custom container image. WARNING: Do not store secrets here — this value is rendered into a ConfigMap (plaintext). Use Kubernetes Secrets or existing Secret refs (e.g. via extraEnv secretKeyRef) instead.\n",
+          "description": "Arbitrary Backstage app-config YAML injected as an additional config overlay. When non-empty the chart renders a ConfigMap named <release>-backstage-extra-config, mounts it at /app/app-config.extra.yaml, and appends --config app-config.extra.yaml to the startup args automatically. This is the preferred mechanism for operator-specific Backstage configuration (auth, integrations, etc.) without requiring a custom container image. WARNING: Do not store secrets here — this value is rendered into a ConfigMap (plaintext). Use Kubernetes Secrets or existing Secret refs (e.g. via extraEnv secretKeyRef) instead.\n",
           "required": [],
           "title": "appConfig",
           "type": "object"
@@ -404,7 +404,7 @@
               "properties": {
                 "apiBaseUrl": {
                   "default": "",
-                  "description": "GitHub API base URL. Leave empty for public GitHub (Backstage will derive `https://api.github.com` from the host). For GitHub Enterprise Server, set to `https://\u003chost\u003e/api/v3`.",
+                  "description": "GitHub API base URL. Leave empty for public GitHub (Backstage will derive `https://api.github.com` from the host). For GitHub Enterprise Server, set to `https://<host>/api/v3`.",
                   "title": "apiBaseUrl",
                   "type": "string"
                 },
@@ -474,7 +474,7 @@
         },
         "extraArgs": {
           "default": [],
-          "description": "Extra arguments appended to the Backstage node startup command after the built-in --config flags. Typically used to add additional --config \u003cfile\u003e arguments for operator-provided app-config overlays.\n",
+          "description": "Extra arguments appended to the Backstage node startup command after the built-in --config flags. Typically used to add additional --config <file> arguments for operator-provided app-config overlays.\n",
           "items": {
             "type": "string"
           },
@@ -3388,6 +3388,38 @@
                             "type": "object"
                           },
                           "title": "mappings",
+                          "type": "array"
+                        },
+                        "extraRoles": {
+                          "default": [],
+                          "description": "Organisation-specific authorization roles, APPENDED to `roles` instead of replacing it. Helm replaces lists, it does not merge them, so adding one role through `roles` means copying every default role into your values and silently inheriting none of the upstream changes on the next upgrade.",
+                          "items": {
+                            "properties": {
+                              "actions": {
+                                "description": "List of actions this role can perform",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "name": {
+                                "description": "Role name",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace for role (empty string for cluster-scoped)",
+                                "type": "string"
+                              },
+                              "system": {
+                                "default": false,
+                                "description": "Whether this is a system-managed role (adds openchoreo.io/system label when true, omitted when false)",
+                                "type": "boolean"
+                              }
+                            },
+                            "required": [],
+                            "type": "object"
+                          },
+                          "title": "extraRoles",
                           "type": "array"
                         },
                         "roles": {

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -1627,6 +1627,30 @@ openchoreoApi:
 
           # @schema
           # type: array
+          # description: Organisation-specific authorization roles, APPENDED to `roles` instead of replacing it. Helm replaces lists, it does not merge them, so adding one role through `roles` means copying every default role into your values and silently inheriting none of the upstream changes on the next upgrade.
+          # items:
+          #   type: object
+          #   properties:
+          #     name:
+          #       type: string
+          #       description: Role name
+          #     namespace:
+          #       type: string
+          #       description: Namespace for role (empty string for cluster-scoped)
+          #     system:
+          #       type: boolean
+          #       description: Whether this is a system-managed role (adds openchoreo.io/system label when true, omitted when false)
+          #       default: false
+          #     actions:
+          #       type: array
+          #       items:
+          #         type: string
+          #       description: List of actions this role can perform
+          # default: []
+          # @schema
+          extraRoles: []
+          # @schema
+          # type: array
           # description: Default role-to-entitlement mappings to create at installation
           # items:
           #   type: object


### PR DESCRIPTION
## Problem

The authz bootstrap only accepts roles through `openchoreoApi.config.security.authorization.bootstrap.roles`, and Helm **replaces** lists rather than merging them.

So contributing a single deployment-specific role means copying **all eleven** upstream roles into your values file — 458 lines in `values.yaml` today — and from that moment on silently inheriting none of the upstream changes to them. A new action added to `developer` in a later release simply never reaches the cluster, and nothing reports it: the values file is valid, the render succeeds, and the bootstrap Job upserts the stale copy.

We hit this adding one role for our own deploy/promote policy.

## Change

`bootstrap.extraRoles` is **appended** to `bootstrap.roles` instead of replacing it:

```yaml
openchoreoApi:
  config:
    security:
      authorization:
        bootstrap:
          extraRoles:
            - name: component-deployer
              actions:
                - "project:view"
                - "componentrelease:create"
                - "releasebinding:create"
                - "releasebinding:update"
```

It goes through the same `roleManifest` helper, so the extra roles receive the same `openchoreo.dev/managed-by` label and are upserted and pruned by the bootstrap Job exactly like the defaults — no second lifecycle to reason about.

Defaults are untouched: `extraRoles` is `[]` unless set.

## Verification

Rendered with a real production values file plus one `extraRoles` entry:

```
roles rendered: 12                     # 11 upstream defaults + 1
component-deployer present: True
upstream defaults intact: True         # admin, developer, platform-engineer, sre, workload-publisher
managed-by: openchoreo-authz-bootstrap # same prune selector as the defaults
```

`helm lint` clean. `values.schema.json` updated alongside `values.yaml` (`bootstrap` is `additionalProperties: false`, so the schema entry is required for the key to be accepted at all).

## Scope note

Deliberately narrow: only `roles` has this problem for us right now. If maintainers prefer, the same treatment for `mappings` (`extraMappings`) is a two-line follow-up and I'm happy to add it here.