### PR TITLE
fix(resourcereleasebinding): log why the finalizer is held on retainPolicy=Retain

### DIFF
--- a/internal/controller/resourcereleasebinding/controller_finalize.go
+++ b/internal/controller/resourcereleasebinding/controller_finalize.go
@@ -73,6 +73,16 @@ func (r *Reconciler) finalize(ctx context.Context, old, binding *openchoreov1alp
 		return ctrl.Result{}, fmt.Errorf("resolve effective retainPolicy: %w", err)
 	}
 	if retain == openchoreov1alpha1.ResourceRetainPolicyRetain {
+		// Logged, not just surfaced as a condition. Holding the finalizer is correct
+		// here, but it makes `kubectl delete` block forever with no output, and the
+		// condition is unreachable while the command hangs: you cannot read the status
+		// of an object whose delete has not returned. Without this line the only
+		// symptom is a command that never comes back, which reads exactly like a
+		// broken controller - it cost a full working session to tell the two apart.
+		logger.Info("Holding finalizer: retainPolicy=Retain",
+			"resourceRelease", binding.Spec.ResourceRelease,
+			"hint", "clear the finalizer manually after reclaiming data-plane state, "+
+				"or set spec.retainPolicy=Delete on the binding to cascade")
 		if controller.MarkTrueCondition(binding, ConditionFinalizing, ReasonRetainHold,
 			"retainPolicy=Retain; finalizer held until cleared manually") {
 			return controller.UpdateStatusConditionsAndReturn(ctx, r.Client, old, binding)

--- a/internal/controller/resourcereleasebinding/controller_finalize_test.go
+++ b/internal/controller/resourcereleasebinding/controller_finalize_test.go
@@ -6,7 +6,10 @@ package resourcereleasebinding
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -18,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
@@ -364,4 +368,85 @@ var _ = Describe("ResourceReleaseBinding controller — finalize", func() {
 		Expect(cli.Get(finCtx, client.ObjectKeyFromObject(rr), &openchoreov1alpha1.RenderedRelease{})).To(Succeed(),
 			"RenderedRelease must remain when retainPolicy=Retain")
 	})
+
+	// Guard. The Retain branch is correct, but it is the single most expensive
+	// thing to misread in this controller: `kubectl delete` blocks forever and
+	// the status condition that explains why is unreachable, because you cannot
+	// read the status of an object whose delete has not returned. The only
+	// channel that reaches an operator mid-hang is the controller log.
+	//
+	// This asserts the log line exists. Without it the symptom is
+	// indistinguishable from a controller that never reconciles deletions at
+	// all — a misdiagnosis that cost a full working session here.
+	It("logs why it is holding the finalizer when retainPolicy=Retain", func() {
+		b := newBinding("retain-log-binding", true, openchoreov1alpha1.ResourceRetainPolicyRetain)
+		rr := newRenderedRelease()
+		Expect(controllerutil.SetControllerReference(b, rr, scheme.Scheme)).To(Succeed())
+		cli := buildClient(b, rr)
+		r := newReconciler(cli)
+
+		sink := &recordingSink{}
+		logCtx := log.IntoContext(finCtx, logr.New(sink))
+
+		Expect(cli.Delete(logCtx, b)).To(Succeed())
+		req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(b)}
+
+		// 1st reconcile sets Finalizing; 2nd takes the Retain branch.
+		_, err := r.Reconcile(logCtx, req)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = r.Reconcile(logCtx, req)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(sink.messages()).To(ContainElement(ContainSubstring("retainPolicy=Retain")),
+			"the Retain hold must be logged: it is the only signal an operator can "+
+				"read while `kubectl delete` is blocked. Logged lines: "+
+				strings.Join(sink.messages(), " | "))
+	})
+
+	// Guard. Every deletion test above drives r.Reconcile rather than calling
+	// r.finalize directly, so they collectively assert that Reconcile still
+	// dispatches to the finalize path on DeletionTimestamp. This one states
+	// that contract explicitly so a rebase that drops the dispatch fails with
+	// a message that names the cause instead of eight unrelated red specs.
+	It("dispatches to the finalize path on DeletionTimestamp (deletion is reconciled at all)", func() {
+		b := newBinding("dispatch-binding", true, openchoreov1alpha1.ResourceRetainPolicyDelete)
+		rr := newRenderedRelease()
+		Expect(controllerutil.SetControllerReference(b, rr, scheme.Scheme)).To(Succeed())
+		cli := buildClient(b, rr)
+		r := newReconciler(cli)
+
+		Expect(cli.Delete(finCtx, b)).To(Succeed())
+		req := reconcile.Request{NamespacedName: client.ObjectKeyFromObject(b)}
+
+		_, err := r.Reconcile(finCtx, req)
+		Expect(err).NotTo(HaveOccurred())
+
+		updated := &openchoreov1alpha1.ResourceReleaseBinding{}
+		Expect(cli.Get(finCtx, client.ObjectKeyFromObject(b), updated)).To(Succeed())
+		Expect(meta.FindStatusCondition(updated.Status.Conditions, string(ConditionFinalizing))).NotTo(BeNil(),
+			"Reconcile must route objects with a DeletionTimestamp to finalize(); "+
+				"if this is nil the controller is ignoring deletions and every "+
+				"ResourceReleaseBinding will hang on its finalizer forever")
+	})
 })
+
+// recordingSink is a logr.LogSink that keeps the messages it is handed, so a
+// test can assert on what the controller logged.
+type recordingSink struct {
+	lines []string
+}
+
+func (s *recordingSink) Init(logr.RuntimeInfo)          {}
+func (s *recordingSink) Enabled(int) bool               { return true }
+func (s *recordingSink) WithValues(...any) logr.LogSink { return s }
+func (s *recordingSink) WithName(string) logr.LogSink   { return s }
+
+func (s *recordingSink) Info(_ int, msg string, kv ...any) {
+	s.lines = append(s.lines, msg+" "+fmt.Sprint(kv...))
+}
+
+func (s *recordingSink) Error(err error, msg string, kv ...any) {
+	s.lines = append(s.lines, msg+" "+fmt.Sprint(err)+" "+fmt.Sprint(kv...))
+}
+
+func (s *recordingSink) messages() []string { return s.lines }


### PR DESCRIPTION
### Problem

Holding the finalizer under `retainPolicy: Retain` is correct behaviour, and this PR does not change it. The problem is that the controller does it **silently**.

The only symptom an operator gets is a `kubectl delete` that never returns. The `Finalizing` / `RetainHold` condition that explains the hold is unreachable while that command is blocked — you cannot read the status of an object whose delete has not returned. Nothing appears in the controller log either.

So the observable behaviour is **identical to a controller that ignores deletions entirely**. That matters because the two have opposite remedies: one is "this is working as designed, decide whether you want retention"; the other is "the controller is broken". We diagnosed it as the latter and lost a working session to it before reading `controller_finalize.go`.

The natural next step when a delete hangs is `--wait=false` followed by clearing the finalizer by hand — which silently discards exactly the retention the policy was asking for.

### Reproduction

```yaml
apiVersion: openchoreo.dev/v1alpha1
kind: ResourceReleaseBinding
metadata: {name: repro, namespace: default}
spec:
  owner: {projectName: p, resourceName: r}
  environment: dev
  resourceRelease: repro-release
  retainPolicy: Retain
```

```console
$ kubectl delete resourcereleasebinding repro
# blocks forever. No controller log output. `kubectl describe` on the object
# does return the condition, but only if you know to open a second terminal and
# look -- and only if you already suspect retention rather than a broken watch.
```

Same shape with the policy inherited from the snapshot (`ResourceRelease.spec.resourceType.spec.retainPolicy: Retain`), which is the common case: the binding itself carries no `retainPolicy` and the operator has no local evidence of why the delete hangs.

### Change

One `logger.Info` on the `Retain` branch of `finalize()`, naming the policy and both ways out: clear the finalizer after reclaiming data-plane state, or set `spec.retainPolicy: Delete` on the binding to cascade.

### Tests

Two specs in `controller_finalize_test.go`:

- **`dispatches to the finalize path on DeletionTimestamp`** — states explicitly that `Reconcile` routes objects with a `DeletionTimestamp` to `finalize()`. Every other deletion spec in the file drives `Reconcile` and so asserts this implicitly; making it explicit means a refactor that drops the dispatch fails with a message naming the cause instead of eight unrelated red specs. Verified by replacing the dispatch condition with `if false`: 8 specs fail, this one among them.
- **`logs why it is holding the finalizer when retainPolicy=Retain`** — records controller output through a `logr.LogSink` injected with `log.IntoContext`. Verified by deleting the `logger.Info`: this spec fails.

`go test ./internal/controller/resourcereleasebinding/...` → `ok`, 45 specs.
