### PR TITLE
chore: update CHANGELOG for v1.1.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to OpenChoreo are documented in this file.
 
+## v1.1.6
+
+Changes since [v1.1.5](https://github.com/openchoreo/openchoreo/releases/tag/v1.1.5).
+
+### Bug Fixes
+
+- **(API)** The exec endpoint now resolves the target component first and takes its owning project from the component itself rather than from the request parameter, aligning it with the pattern used by other component operations. ([#4251](https://github.com/openchoreo/openchoreo/pull/4251))
+- **(API)** The exec authorization hierarchy now includes the component, so component-scoped exec grants resolve correctly. ([#4506](https://github.com/openchoreo/openchoreo/pull/4506))
+- **(Cluster Gateway)** Fixed cluster gateway failing to authorize plane CRs created after an agent connects when the agent's client certificate is issued by an intermediate CA: incremental re-validation now includes the TLS handshake intermediates, matching connect-time verification. ([#4417](https://github.com/openchoreo/openchoreo/pull/4417))
+
 ## v1.1.5
 
 Changes since [v1.1.4](https://github.com/openchoreo/openchoreo/releases/tag/v1.1.4).


### PR DESCRIPTION
## Purpose

Adds the `v1.1.6` CHANGELOG section ahead of cutting the patch release from `release-v1.1`.

## Approach

Documents the three fixes backported to `release-v1.1` since v1.1.5:

- **#4251** (backported in #4538) — the exec endpoint resolves the component's owning project.
- **#4506** (backported in #4537) — component included in the exec authorization hierarchy.
- **#4417** (backported in #4424) — cluster gateway authorizes plane CRs created after an agent connects.

## Related Issues

Fixes shipped: #4251, #4506, #4417

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content