### PR TITLE
fix(api): make external store remote key prefix configurable

### DIFF
--- a/cmd/openchoreo-api/main.go
+++ b/cmd/openchoreo-api/main.go
@@ -182,7 +182,7 @@ func main() {
 
 	// Initialize all handler services
 	services := handlerservices.NewServices(
-		k8sClient, runtime.pap, runtime.pdp, planeClientProvider, logger, gwClient, webhookProcessor,
+		k8sClient, runtime.pap, runtime.pdp, planeClientProvider, cfg.SecretManagement, logger, gwClient, webhookProcessor,
 	)
 
 	// Initialize OpenAPI handlers

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/configmap.yaml
@@ -64,6 +64,7 @@ data:
 
     secret_management:
       enabled: {{ .Values.features.secretManagement.enabled }}
+      remote_key_prefix: {{ .Values.features.secretManagement.remoteKeyPrefix | quote }}
 
     cluster_gateway:
       enabled: {{ if hasKey .Values.openchoreoApi.clusterGateway "enabled" }}{{ .Values.openchoreoApi.clusterGateway.enabled }}{{ else }}true{{ end }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2762,6 +2762,12 @@
               "description": "Enable the Secret management API and Backstage UI for managing data-plane secrets.",
               "title": "enabled",
               "type": "boolean"
+            },
+            "remoteKeyPrefix": {
+              "default": "secret",
+              "description": "First segment of every key written to the external secret store, as in \u003cprefix\u003e/\u003cnamespace\u003e/\u003ctype\u003e/\u003cname\u003e. Set to an empty string to drop the segment. It must not equal the KV mount name that the ClusterSecretStore points at, otherwise external-secrets writes the value and its ownership metadata to two different paths and leaves a duplicate data-less entry per secret. This is an install-time setting, since changing it after secrets exist does not move existing entries.",
+              "title": "remoteKeyPrefix",
+              "type": "string"
             }
           },
           "required": [],

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -170,6 +170,13 @@ features:
     # @schema
     enabled: false
 
+    # @schema
+    # type: string
+    # description: First segment of every key written to the external secret store, as in <prefix>/<namespace>/<type>/<name>. Set to an empty string to drop the segment. It must not equal the KV mount name that the ClusterSecretStore points at, otherwise external-secrets writes the value and its ownership metadata to two different paths and leaves a duplicate data-less entry per secret. This is an install-time setting, since changing it after secrets exist does not move existing entries.
+    # default: secret
+    # @schema
+    remoteKeyPrefix: "secret"
+
 # @schema
 # type: object
 # description: Controller Manager configuration - the main controller for OpenChoreo CRDs

--- a/internal/openchoreo-api/config/secrets.go
+++ b/internal/openchoreo-api/config/secrets.go
@@ -3,17 +3,57 @@
 
 package config
 
+import "strings"
+
+// DefaultRemoteKeyPrefix is the first segment prepended to every remote key
+// written to the external secret store. It matches the value used before the
+// prefix became configurable, so existing installs keep their key layout.
+const DefaultRemoteKeyPrefix = "secret"
+
 // SecretManagementConfig defines settings for the Secret management API endpoints.
 type SecretManagementConfig struct {
 	// Enabled toggles the Secret management API (POST/PUT/GET/LIST/DELETE under
 	// /api/v1alpha1/namespaces/{ns}/secrets). When false, all five
 	// endpoints return 501 Not Implemented.
 	Enabled bool `koanf:"enabled"`
+
+	// RemoteKeyPrefix is the first segment of every key written to the external
+	// secret store, as in "<prefix>/<namespace>/<segment>/<name>". An empty
+	// value drops the segment entirely, giving "<namespace>/<segment>/<name>".
+	//
+	// The prefix must not equal the name of the KV mount the ClusterSecretStore
+	// points at. When the two collide, external-secrets strips the duplicated
+	// segment when writing the value but not when writing the ownership
+	// metadata, so each secret lands as two entries: the value at the stripped
+	// path and a data-less metadata entry at the un-stripped path.
+	//
+	// This setting decides where secrets are stored, so it is install-time
+	// configuration. Changing it after secrets exist does not move the existing
+	// entries; they must be migrated separately.
+	RemoteKeyPrefix string `koanf:"remote_key_prefix"`
 }
 
 // SecretManagementDefaults returns the default Secret management configuration.
 func SecretManagementDefaults() SecretManagementConfig {
 	return SecretManagementConfig{
-		Enabled: false,
+		Enabled:         false,
+		RemoteKeyPrefix: DefaultRemoteKeyPrefix,
 	}
+}
+
+// NormalizedRemoteKeyPrefix returns the configured prefix with every empty
+// slash-separated component dropped, so callers can join it into a key path
+// without producing empty or doubled segments. Leading, trailing and interior
+// slash runs are all collapsed, so "//team///prod//" normalizes to "team/prod".
+// A prefix that holds no components normalizes to the empty string, which omits
+// the prefix segment entirely.
+func (c SecretManagementConfig) NormalizedRemoteKeyPrefix() string {
+	parts := strings.Split(c.RemoteKeyPrefix, "/")
+	kept := parts[:0]
+	for _, p := range parts {
+		if p != "" {
+			kept = append(kept, p)
+		}
+	}
+	return strings.Join(kept, "/")
 }

--- a/internal/openchoreo-api/config/secrets_test.go
+++ b/internal/openchoreo-api/config/secrets_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSecretManagementDefaults(t *testing.T) {
+	cfg := SecretManagementDefaults()
+	if cfg.Enabled {
+		t.Error("secret management should default to disabled")
+	}
+	// The default prefix must stay "secret" so existing installs keep the key
+	// layout they already have in the external store.
+	if cfg.RemoteKeyPrefix != DefaultRemoteKeyPrefix {
+		t.Errorf("RemoteKeyPrefix = %q, want %q", cfg.RemoteKeyPrefix, DefaultRemoteKeyPrefix)
+	}
+}
+
+func TestNormalizedRemoteKeyPrefix(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"secret", "secret"},
+		{"/secret", "secret"},
+		{"secret/", "secret"},
+		{"/secret/", "secret"},
+		{"oc/secrets", "oc/secrets"},
+		// Interior slash runs must collapse too, not just the surrounding ones,
+		// otherwise the joined key carries an empty segment.
+		{"team//prod", "team/prod"},
+		{"//team///prod//", "team/prod"},
+		{"", ""},
+		{"/", ""},
+		{"///", ""},
+	}
+	for _, tt := range tests {
+		got := SecretManagementConfig{RemoteKeyPrefix: tt.in}.NormalizedRemoteKeyPrefix()
+		if got != tt.want {
+			t.Errorf("NormalizedRemoteKeyPrefix(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+// TestRemoteKeyPrefixLoadsFromYAML feeds the loader the same config shape the
+// Helm chart renders, checking that remote_key_prefix reaches the struct and
+// that an explicitly empty value is preserved rather than falling back to the
+// default.
+func TestRemoteKeyPrefixLoadsFromYAML(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{"explicit default", "secret_management:\n  enabled: true\n  remote_key_prefix: \"secret\"\n", "secret"},
+		{"explicit empty", "secret_management:\n  enabled: true\n  remote_key_prefix: \"\"\n", ""},
+		{"custom", "secret_management:\n  enabled: true\n  remote_key_prefix: \"openchoreo\"\n", "openchoreo"},
+		{"omitted falls back to default", "secret_management:\n  enabled: true\n", DefaultRemoteKeyPrefix},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(path, []byte(tt.yaml), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			loader, err := NewLoader(path, nil)
+			if err != nil {
+				t.Fatalf("NewLoader: %v", err)
+			}
+			var cfg Config
+			if err := loader.Unmarshal("", &cfg); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if cfg.SecretManagement.RemoteKeyPrefix != tt.want {
+				t.Errorf("RemoteKeyPrefix = %q, want %q", cfg.SecretManagement.RemoteKeyPrefix, tt.want)
+			}
+		})
+	}
+}

--- a/internal/openchoreo-api/services/handlerservices/services.go
+++ b/internal/openchoreo-api/services/handlerservices/services.go
@@ -11,6 +11,7 @@ import (
 	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
 	gatewayClient "github.com/openchoreo/openchoreo/internal/clients/gateway"
 	kubernetesClient "github.com/openchoreo/openchoreo/internal/clients/kubernetes"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/config"
 	authzsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/authz"
 	autobuildsvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/autobuild"
 	clustercomponenttypesvc "github.com/openchoreo/openchoreo/internal/openchoreo-api/services/clustercomponenttype"
@@ -92,7 +93,7 @@ type Services struct {
 }
 
 // NewServices creates all K8s-native API services with authorization wrappers.
-func NewServices(k8sClient client.Client, pap authzcore.PAP, pdp authzcore.PDP, planeClientProvider kubernetesClient.PlaneClientProvider, logger *slog.Logger, gwClient *gatewayClient.Client, webhookProcessor autobuildsvc.WebhookProcessor) *Services {
+func NewServices(k8sClient client.Client, pap authzcore.PAP, pdp authzcore.PDP, planeClientProvider kubernetesClient.PlaneClientProvider, secretCfg config.SecretManagementConfig, logger *slog.Logger, gwClient *gatewayClient.Client, webhookProcessor autobuildsvc.WebhookProcessor) *Services {
 	return &Services{
 		AutoBuildService:                              autobuildsvc.NewService(k8sClient, webhookProcessor, logger.With("component", "autobuild-service")),
 		AuthzService:                                  authzsvc.NewServiceWithAuthz(pap, pdp, logger.With("component", "authz-service")),
@@ -125,7 +126,7 @@ func NewServices(k8sClient client.Client, pap authzcore.PAP, pdp authzcore.PDP, 
 		ResourceReleaseService:                        resourcereleasesvc.NewServiceWithAuthz(k8sClient, pdp, logger.With("component", "resourcerelease-service")),
 		ResourceReleaseBindingService:                 resourcereleasebindingsvc.NewServiceWithAuthz(k8sClient, pdp, logger.With("component", "resourcereleasebinding-service")),
 		ResourceTypeService:                           resourcetypesvc.NewServiceWithAuthz(k8sClient, pdp, logger.With("component", "resourcetype-service")),
-		SecretService:                                 secretsvc.NewServiceWithAuthz(k8sClient, planeClientProvider, pdp, logger.With("component", "secret-service")),
+		SecretService:                                 secretsvc.NewServiceWithAuthz(k8sClient, planeClientProvider, secretCfg, pdp, logger.With("component", "secret-service")),
 		SecretReferenceService:                        secretreferencesvc.NewServiceWithAuthz(k8sClient, pdp, logger.With("component", "secretreference-service")),
 		TraitService:                                  traitsvc.NewServiceWithAuthz(k8sClient, pdp, logger.With("component", "trait-service")),
 		WorkflowService:                               workflowsvc.NewServiceWithAuthz(k8sClient, pdp, logger.With("component", "workflow-service")),

--- a/internal/openchoreo-api/services/secret/service.go
+++ b/internal/openchoreo-api/services/secret/service.go
@@ -19,6 +19,7 @@ import (
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	kubernetesClient "github.com/openchoreo/openchoreo/internal/clients/kubernetes"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/config"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 )
 
@@ -57,10 +58,15 @@ func kvNamespace(ownerNamespace string) string {
 }
 
 // remoteKeyFor maps a (namespace, secretType, name) tuple to the key path used
-// in the external secret store.
-func remoteKeyFor(namespace string, secretType corev1.SecretType, name string) string {
+// in the external secret store. prefix is the configured first segment; an
+// empty prefix omits the segment.
+func remoteKeyFor(prefix, namespace string, secretType corev1.SecretType, name string) string {
 	segment := remoteKeySegment(secretType)
-	return fmt.Sprintf("secret/%s/%s/%s", namespace, segment, name)
+	key := fmt.Sprintf("%s/%s/%s", namespace, segment, name)
+	if prefix == "" {
+		return key
+	}
+	return prefix + "/" + key
 }
 
 func remoteKeySegment(secretType corev1.SecretType) string {
@@ -83,16 +89,21 @@ type secretService struct {
 	k8sClient           client.Client
 	planeClientProvider kubernetesClient.PlaneClientProvider
 	logger              *slog.Logger
+	// remoteKeyPrefix is the first segment of every key written to the
+	// external secret store. Empty means no prefix segment.
+	remoteKeyPrefix string
 }
 
 var _ Service = (*secretService)(nil)
 
 // NewService creates a new secret service without authorization.
-func NewService(k8sClient client.Client, planeClientProvider kubernetesClient.PlaneClientProvider, logger *slog.Logger) Service {
+// secretCfg supplies the remote key prefix used for external store keys.
+func NewService(k8sClient client.Client, planeClientProvider kubernetesClient.PlaneClientProvider, secretCfg config.SecretManagementConfig, logger *slog.Logger) Service {
 	return &secretService{
 		k8sClient:           k8sClient,
 		planeClientProvider: planeClientProvider,
 		logger:              logger,
+		remoteKeyPrefix:     secretCfg.NormalizedRemoteKeyPrefix(),
 	}
 }
 
@@ -142,12 +153,12 @@ func (s *secretService) CreateSecret(ctx context.Context, namespaceName string, 
 		return nil, fmt.Errorf("failed to apply k8s secret in target plane: %w", err)
 	}
 
-	pushSecret := buildPushSecret(req.SecretName, namespaceName, targetNs, planeInfo.secretStoreName, req.SecretType, sortedKeys(req.Data))
+	pushSecret := buildPushSecret(s.remoteKeyPrefix, req.SecretName, namespaceName, targetNs, planeInfo.secretStoreName, req.SecretType, sortedKeys(req.Data))
 	if err := planeInfo.k8sClient.Patch(ctx, pushSecret, client.Apply, client.ForceOwnership, client.FieldOwner(fieldOwner)); err != nil {
 		return nil, fmt.Errorf("failed to apply push secret in target plane: %w", err)
 	}
 
-	secretRef := buildSecretReference(namespaceName, req.SecretName, req.SecretType, req.TargetPlane, sortedKeys(req.Data), req.Labels)
+	secretRef := buildSecretReference(s.remoteKeyPrefix, namespaceName, req.SecretName, req.SecretType, req.TargetPlane, sortedKeys(req.Data), req.Labels)
 	if err := s.k8sClient.Create(ctx, secretRef); err != nil {
 		return nil, fmt.Errorf("failed to create secret reference: %w", err)
 	}
@@ -195,7 +206,7 @@ func (s *secretService) UpdateSecret(ctx context.Context, namespaceName, secretN
 		return nil, fmt.Errorf("failed to apply k8s secret in target plane: %w", err)
 	}
 
-	pushSecret := buildPushSecret(secretName, namespaceName, targetNs, planeInfo.secretStoreName, secretType, newKeys)
+	pushSecret := buildPushSecret(s.remoteKeyPrefix, secretName, namespaceName, targetNs, planeInfo.secretStoreName, secretType, newKeys)
 	if err := planeInfo.k8sClient.Patch(ctx, pushSecret, client.Apply, client.ForceOwnership, client.FieldOwner(fieldOwner)); err != nil {
 		return nil, fmt.Errorf("failed to apply push secret in target plane: %w", err)
 	}
@@ -206,7 +217,7 @@ func (s *secretService) UpdateSecret(ctx context.Context, namespaceName, secretN
 	keysChanged := !sameStringSlice(existingKeys, newKeys)
 	labelsChanged := !maps.Equal(secretRef.Labels, newLabels)
 	if keysChanged || labelsChanged {
-		secretRef.Spec.Data = buildSecretDataSources(namespaceName, secretName, secretType, newKeys)
+		secretRef.Spec.Data = buildSecretDataSources(s.remoteKeyPrefix, namespaceName, secretName, secretType, newKeys)
 		secretRef.Labels = newLabels
 		if err := s.k8sClient.Update(ctx, secretRef); err != nil {
 			if apierrors.IsInvalid(err) {
@@ -569,8 +580,8 @@ func buildK8sSecret(name, targetNamespace string, secretType corev1.SecretType, 
 	}
 }
 
-func buildPushSecret(name, ownerNamespace, targetNamespace, secretStoreName string, secretType corev1.SecretType, keys []string) *unstructured.Unstructured {
-	remoteKey := remoteKeyFor(ownerNamespace, secretType, name)
+func buildPushSecret(remoteKeyPrefix, name, ownerNamespace, targetNamespace, secretStoreName string, secretType corev1.SecretType, keys []string) *unstructured.Unstructured {
+	remoteKey := remoteKeyFor(remoteKeyPrefix, ownerNamespace, secretType, name)
 
 	dataMatches := make([]map[string]any, 0, len(keys))
 	for _, k := range keys {
@@ -607,7 +618,7 @@ func buildPushSecret(name, ownerNamespace, targetNamespace, secretStoreName stri
 	return ps
 }
 
-func buildSecretReference(ownerNamespace, name string, secretType corev1.SecretType, target openchoreov1alpha1.TargetPlaneRef, keys []string, userLabels map[string]string) *openchoreov1alpha1.SecretReference {
+func buildSecretReference(remoteKeyPrefix, ownerNamespace, name string, secretType corev1.SecretType, target openchoreov1alpha1.TargetPlaneRef, keys []string, userLabels map[string]string) *openchoreov1alpha1.SecretReference {
 	return &openchoreov1alpha1.SecretReference{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: openchoreov1alpha1.GroupVersion.String(),
@@ -621,7 +632,7 @@ func buildSecretReference(ownerNamespace, name string, secretType corev1.SecretT
 		Spec: openchoreov1alpha1.SecretReferenceSpec{
 			TargetPlane: &openchoreov1alpha1.TargetPlaneRef{Kind: target.Kind, Name: target.Name},
 			Template:    openchoreov1alpha1.SecretTemplate{Type: secretType},
-			Data:        buildSecretDataSources(ownerNamespace, name, secretType, keys),
+			Data:        buildSecretDataSources(remoteKeyPrefix, ownerNamespace, name, secretType, keys),
 		},
 	}
 }
@@ -638,8 +649,8 @@ func mergeManagedLabels(userLabels map[string]string) map[string]string {
 	return labels
 }
 
-func buildSecretDataSources(ownerNamespace, name string, secretType corev1.SecretType, keys []string) []openchoreov1alpha1.SecretDataSource {
-	remoteKey := remoteKeyFor(ownerNamespace, secretType, name)
+func buildSecretDataSources(remoteKeyPrefix, ownerNamespace, name string, secretType corev1.SecretType, keys []string) []openchoreov1alpha1.SecretDataSource {
+	remoteKey := remoteKeyFor(remoteKeyPrefix, ownerNamespace, secretType, name)
 	out := make([]openchoreov1alpha1.SecretDataSource, 0, len(keys))
 	for _, k := range keys {
 		out = append(out, openchoreov1alpha1.SecretDataSource{

--- a/internal/openchoreo-api/services/secret/service_authz.go
+++ b/internal/openchoreo-api/services/secret/service_authz.go
@@ -12,6 +12,7 @@ import (
 
 	authz "github.com/openchoreo/openchoreo/internal/authz/core"
 	kubernetesClient "github.com/openchoreo/openchoreo/internal/clients/kubernetes"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/config"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 )
 
@@ -23,9 +24,9 @@ type secretServiceWithAuthz struct {
 }
 
 // NewServiceWithAuthz creates a new secret service with authorization checks.
-func NewServiceWithAuthz(k8sClient client.Client, planeClientProvider kubernetesClient.PlaneClientProvider, authzPDP authz.PDP, logger *slog.Logger) Service {
+func NewServiceWithAuthz(k8sClient client.Client, planeClientProvider kubernetesClient.PlaneClientProvider, secretCfg config.SecretManagementConfig, authzPDP authz.PDP, logger *slog.Logger) Service {
 	return &secretServiceWithAuthz{
-		internal: NewService(k8sClient, planeClientProvider, logger),
+		internal: NewService(k8sClient, planeClientProvider, secretCfg, logger),
 		authz:    services.NewAuthzChecker(authzPDP, logger),
 	}
 }

--- a/internal/openchoreo-api/services/secret/service_test.go
+++ b/internal/openchoreo-api/services/secret/service_test.go
@@ -21,6 +21,7 @@ import (
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	k8sMocks "github.com/openchoreo/openchoreo/internal/clients/kubernetes/mocks"
+	"github.com/openchoreo/openchoreo/internal/openchoreo-api/config"
 	"github.com/openchoreo/openchoreo/internal/openchoreo-api/services"
 )
 
@@ -205,7 +206,7 @@ func TestRemoteKeyFor(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := remoteKeyFor(testNamespace, tt.secretType, testSecretName); got != tt.want {
+			if got := remoteKeyFor(config.DefaultRemoteKeyPrefix, testNamespace, tt.secretType, testSecretName); got != tt.want {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}
 		})
@@ -248,7 +249,7 @@ func TestBuildK8sSecret(t *testing.T) {
 }
 
 func TestBuildPushSecret(t *testing.T) {
-	ps := buildPushSecret(testSecretName, testNamespace, kvNamespace(testNamespace), "vault-store",
+	ps := buildPushSecret(config.DefaultRemoteKeyPrefix, testSecretName, testNamespace, kvNamespace(testNamespace), "vault-store",
 		corev1.SecretTypeOpaque, []string{"a", "b"})
 
 	if ps.GetAPIVersion() != pushSecretAPIVersion {
@@ -301,7 +302,7 @@ func TestBuildPushSecret(t *testing.T) {
 }
 
 func TestBuildSecretReference(t *testing.T) {
-	ref := buildSecretReference(testNamespace, testSecretName, corev1.SecretTypeBasicAuth,
+	ref := buildSecretReference(config.DefaultRemoteKeyPrefix, testNamespace, testSecretName, corev1.SecretTypeBasicAuth,
 		openchoreov1alpha1.TargetPlaneRef{Kind: planeKindWorkflowPlane, Name: "wp1"},
 		[]string{"password", "username"},
 		map[string]string{"team": testLabelValue})
@@ -351,7 +352,7 @@ func TestResolvePlane_WorkflowPlane(t *testing.T) {
 	targetClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	mockProvider.EXPECT().WorkflowPlaneClient(wp).Return(targetClient, nil).Once()
 
-	svc := &secretService{k8sClient: k8sClient, planeClientProvider: mockProvider, logger: newTestLogger()}
+	svc := &secretService{k8sClient: k8sClient, planeClientProvider: mockProvider, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	info, err := svc.resolvePlane(context.Background(), testNamespace, planeKindWorkflowPlane, "wp1")
 	if err != nil {
@@ -381,7 +382,7 @@ func TestResolvePlane_ClusterDataPlane(t *testing.T) {
 	targetClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 	mockProvider.EXPECT().ClusterDataPlaneClient(cdp).Return(targetClient, nil).Once()
 
-	svc := &secretService{k8sClient: k8sClient, planeClientProvider: mockProvider, logger: newTestLogger()}
+	svc := &secretService{k8sClient: k8sClient, planeClientProvider: mockProvider, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	info, err := svc.resolvePlane(context.Background(), testNamespace, planeKindClusterDataPlane, "cdp1")
 	if err != nil {
@@ -395,7 +396,7 @@ func TestResolvePlane_ClusterDataPlane(t *testing.T) {
 func TestResolvePlane_NotFound(t *testing.T) {
 	scheme := newTestScheme(t)
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	svc := &secretService{k8sClient: k8sClient, logger: newTestLogger()}
+	svc := &secretService{k8sClient: k8sClient, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	for _, kind := range []string{
 		planeKindWorkflowPlane, planeKindClusterWorkflowPlane,
@@ -414,7 +415,7 @@ func TestResolvePlane_NoSecretStore(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "wp1", Namespace: testNamespace},
 	}
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(wp).Build()
-	svc := &secretService{k8sClient: k8sClient, logger: newTestLogger()}
+	svc := &secretService{k8sClient: k8sClient, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	_, err := svc.resolvePlane(context.Background(), testNamespace, planeKindWorkflowPlane, "wp1")
 	if !errors.Is(err, ErrSecretStoreNotConfigured) {
@@ -423,7 +424,7 @@ func TestResolvePlane_NoSecretStore(t *testing.T) {
 }
 
 func TestResolvePlane_InvalidKind(t *testing.T) {
-	svc := &secretService{logger: newTestLogger()}
+	svc := &secretService{logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 	_, err := svc.resolvePlane(context.Background(), testNamespace, "Bogus", "x")
 	if !isValidationError(err) {
 		t.Errorf("expected validation error, got %v", err)
@@ -436,7 +437,7 @@ func TestEnsureNamespaceExists_AlreadyExists(t *testing.T) {
 	scheme := newTestScheme(t)
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openchoreo-kv-ns1"}}
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
-	svc := &secretService{logger: newTestLogger()}
+	svc := &secretService{logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	if err := svc.ensureNamespaceExists(context.Background(), k8sClient, "openchoreo-kv-ns1"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -446,7 +447,7 @@ func TestEnsureNamespaceExists_AlreadyExists(t *testing.T) {
 func TestEnsureNamespaceExists_CreatesNew(t *testing.T) {
 	scheme := newTestScheme(t)
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	svc := &secretService{logger: newTestLogger()}
+	svc := &secretService{logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	if err := svc.ensureNamespaceExists(context.Background(), k8sClient, "openchoreo-kv-ns1"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -465,7 +466,7 @@ func TestCreateSecret_AlreadyExists(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: testSecretName, Namespace: testNamespace},
 	}
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
-	svc := &secretService{k8sClient: k8sClient, logger: newTestLogger()}
+	svc := &secretService{k8sClient: k8sClient, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	_, err := svc.CreateSecret(context.Background(), testNamespace, &CreateSecretParams{
 		SecretName:  testSecretName,
@@ -481,7 +482,7 @@ func TestCreateSecret_AlreadyExists(t *testing.T) {
 func TestCreateSecret_ValidationErrors(t *testing.T) {
 	scheme := newTestScheme(t)
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	svc := &secretService{k8sClient: k8sClient, logger: newTestLogger()}
+	svc := &secretService{k8sClient: k8sClient, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	cases := []struct {
 		name string
@@ -537,7 +538,7 @@ func TestCreateSecret_ValidationErrors(t *testing.T) {
 func TestCreateSecret_PlaneNotFound(t *testing.T) {
 	scheme := newTestScheme(t)
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	svc := &secretService{k8sClient: k8sClient, logger: newTestLogger()}
+	svc := &secretService{k8sClient: k8sClient, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	_, err := svc.CreateSecret(context.Background(), testNamespace, &CreateSecretParams{
 		SecretName:  testSecretName,
@@ -555,7 +556,7 @@ func TestCreateSecret_PlaneNotFound(t *testing.T) {
 func TestDeleteSecret_NotFound(t *testing.T) {
 	scheme := newTestScheme(t)
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	svc := &secretService{k8sClient: k8sClient, logger: newTestLogger()}
+	svc := &secretService{k8sClient: k8sClient, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	err := svc.DeleteSecret(context.Background(), testNamespace, "missing")
 	if !errors.Is(err, ErrSecretNotFound) {
@@ -572,7 +573,7 @@ func TestDeleteSecret_NoTargetPlane(t *testing.T) {
 		},
 	}
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(legacy).Build()
-	svc := &secretService{k8sClient: k8sClient, logger: newTestLogger()}
+	svc := &secretService{k8sClient: k8sClient, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	err := svc.DeleteSecret(context.Background(), testNamespace, "legacy")
 	if !errors.Is(err, ErrSecretNotFound) {
@@ -594,7 +595,7 @@ func TestDeleteSecret_PlaneNotFound(t *testing.T) {
 		},
 	}
 	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ref).Build()
-	svc := &secretService{k8sClient: k8sClient, logger: newTestLogger()}
+	svc := &secretService{k8sClient: k8sClient, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	err := svc.DeleteSecret(context.Background(), testNamespace, testSecretName)
 	if !errors.Is(err, ErrPlaneNotFound) {
@@ -654,7 +655,7 @@ func TestCreateSecret_Success(t *testing.T) {
 	mockProvider := k8sMocks.NewMockPlaneClientProvider(t)
 	mockProvider.EXPECT().WorkflowPlaneClient(wp).Return(targetClient, nil).Once()
 
-	svc := &secretService{k8sClient: cpClient, planeClientProvider: mockProvider, logger: newTestLogger()}
+	svc := &secretService{k8sClient: cpClient, planeClientProvider: mockProvider, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	info, err := svc.CreateSecret(context.Background(), testNamespace, &CreateSecretParams{
 		SecretName:  testSecretName,
@@ -727,7 +728,7 @@ func TestDeleteSecret_Success(t *testing.T) {
 	mockProvider := k8sMocks.NewMockPlaneClientProvider(t)
 	mockProvider.EXPECT().WorkflowPlaneClient(wp).Return(targetClient, nil).Once()
 
-	svc := &secretService{k8sClient: cpClient, planeClientProvider: mockProvider, logger: newTestLogger()}
+	svc := &secretService{k8sClient: cpClient, planeClientProvider: mockProvider, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	if err := svc.DeleteSecret(context.Background(), testNamespace, testSecretName); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -753,7 +754,7 @@ func managedRef(name string, secretType corev1.SecretType, keys []string) *openc
 		dataSources = append(dataSources, openchoreov1alpha1.SecretDataSource{
 			SecretKey: k,
 			RemoteRef: openchoreov1alpha1.RemoteReference{
-				Key: remoteKeyFor(testNamespace, secretType, name), Property: k,
+				Key: remoteKeyFor(config.DefaultRemoteKeyPrefix, testNamespace, secretType, name), Property: k,
 			},
 		})
 	}
@@ -799,7 +800,7 @@ func TestGetSecret_Success(t *testing.T) {
 	mockProvider := k8sMocks.NewMockPlaneClientProvider(t)
 	mockProvider.EXPECT().WorkflowPlaneClient(wp).Return(targetClient, nil).Once()
 
-	svc := &secretService{k8sClient: cpClient, planeClientProvider: mockProvider, logger: newTestLogger()}
+	svc := &secretService{k8sClient: cpClient, planeClientProvider: mockProvider, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	got, err := svc.GetSecret(context.Background(), testNamespace, testSecretName)
 	if err != nil {
@@ -819,7 +820,7 @@ func TestGetSecret_Success(t *testing.T) {
 func TestGetSecret_NotFound_Missing(t *testing.T) {
 	scheme := newTestScheme(t)
 	cpClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	svc := &secretService{k8sClient: cpClient, logger: newTestLogger()}
+	svc := &secretService{k8sClient: cpClient, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	_, err := svc.GetSecret(context.Background(), testNamespace, testSecretName)
 	if !errors.Is(err, ErrSecretNotFound) {
@@ -838,7 +839,7 @@ func TestGetSecret_NotFound_UnmanagedRef(t *testing.T) {
 		},
 	}
 	cpClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(unmanaged).Build()
-	svc := &secretService{k8sClient: cpClient, logger: newTestLogger()}
+	svc := &secretService{k8sClient: cpClient, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	_, err := svc.GetSecret(context.Background(), testNamespace, testSecretName)
 	if !errors.Is(err, ErrSecretNotFound) {
@@ -858,7 +859,7 @@ func TestGetSecret_NotFound_TargetPlaneSecretMissing(t *testing.T) {
 	mockProvider := k8sMocks.NewMockPlaneClientProvider(t)
 	mockProvider.EXPECT().WorkflowPlaneClient(wp).Return(targetClient, nil).Once()
 
-	svc := &secretService{k8sClient: cpClient, planeClientProvider: mockProvider, logger: newTestLogger()}
+	svc := &secretService{k8sClient: cpClient, planeClientProvider: mockProvider, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	_, err := svc.GetSecret(context.Background(), testNamespace, testSecretName)
 	if !errors.Is(err, ErrSecretNotFound) {
@@ -890,7 +891,7 @@ func TestListSecrets_FiltersManagedByLabel(t *testing.T) {
 	mockProvider := k8sMocks.NewMockPlaneClientProvider(t)
 	mockProvider.EXPECT().WorkflowPlaneClient(wp).Return(targetClient, nil).Once()
 
-	svc := &secretService{k8sClient: cpClient, planeClientProvider: mockProvider, logger: newTestLogger()}
+	svc := &secretService{k8sClient: cpClient, planeClientProvider: mockProvider, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	result, err := svc.ListSecrets(context.Background(), testNamespace, services.ListOptions{})
 	if err != nil {
@@ -916,7 +917,7 @@ func TestListSecrets_SkipsMissingTargetSecret(t *testing.T) {
 	mockProvider := k8sMocks.NewMockPlaneClientProvider(t)
 	mockProvider.EXPECT().WorkflowPlaneClient(wp).Return(targetClient, nil).Once()
 
-	svc := &secretService{k8sClient: cpClient, planeClientProvider: mockProvider, logger: newTestLogger()}
+	svc := &secretService{k8sClient: cpClient, planeClientProvider: mockProvider, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	result, err := svc.ListSecrets(context.Background(), testNamespace, services.ListOptions{})
 	if err != nil {
@@ -941,7 +942,7 @@ func TestUpdateSecret_Success_SameKeys(t *testing.T) {
 	mockProvider := k8sMocks.NewMockPlaneClientProvider(t)
 	mockProvider.EXPECT().WorkflowPlaneClient(wp).Return(targetClient, nil).Once()
 
-	svc := &secretService{k8sClient: cpClient, planeClientProvider: mockProvider, logger: newTestLogger()}
+	svc := &secretService{k8sClient: cpClient, planeClientProvider: mockProvider, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	got, err := svc.UpdateSecret(context.Background(), testNamespace, testSecretName, &UpdateSecretParams{
 		Data: map[string]string{"a": "1", "b": "2"},
@@ -980,7 +981,7 @@ func TestUpdateSecret_Success_KeysChanged(t *testing.T) {
 	mockProvider := k8sMocks.NewMockPlaneClientProvider(t)
 	mockProvider.EXPECT().WorkflowPlaneClient(wp).Return(targetClient, nil).Once()
 
-	svc := &secretService{k8sClient: cpClient, planeClientProvider: mockProvider, logger: newTestLogger()}
+	svc := &secretService{k8sClient: cpClient, planeClientProvider: mockProvider, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	_, err := svc.UpdateSecret(context.Background(), testNamespace, testSecretName, &UpdateSecretParams{
 		Data: map[string]string{"a": "1", "c": "3"},
@@ -1011,7 +1012,7 @@ func TestUpdateSecret_LabelsApplied(t *testing.T) {
 	mockProvider := k8sMocks.NewMockPlaneClientProvider(t)
 	mockProvider.EXPECT().WorkflowPlaneClient(wp).Return(targetClient, nil).Once()
 
-	svc := &secretService{k8sClient: cpClient, planeClientProvider: mockProvider, logger: newTestLogger()}
+	svc := &secretService{k8sClient: cpClient, planeClientProvider: mockProvider, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	_, err := svc.UpdateSecret(context.Background(), testNamespace, testSecretName, &UpdateSecretParams{
 		Data:   map[string]string{"a": "1", "b": "2"},
@@ -1045,7 +1046,7 @@ func TestUpdateSecret_LabelsReplacedAndManagedByPreserved(t *testing.T) {
 	mockProvider := k8sMocks.NewMockPlaneClientProvider(t)
 	mockProvider.EXPECT().WorkflowPlaneClient(wp).Return(targetClient, nil).Once()
 
-	svc := &secretService{k8sClient: cpClient, planeClientProvider: mockProvider, logger: newTestLogger()}
+	svc := &secretService{k8sClient: cpClient, planeClientProvider: mockProvider, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	_, err := svc.UpdateSecret(context.Background(), testNamespace, testSecretName, &UpdateSecretParams{
 		Data:   map[string]string{"a": "1", "b": "2"},
@@ -1073,7 +1074,7 @@ func TestUpdateSecret_InvalidLabel(t *testing.T) {
 	wp := newWorkflowPlane()
 	ref := managedRef(testSecretName, corev1.SecretTypeOpaque, []string{"a", "b"})
 	cpClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(wp, ref).Build()
-	svc := &secretService{k8sClient: cpClient, logger: newTestLogger()}
+	svc := &secretService{k8sClient: cpClient, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	_, err := svc.UpdateSecret(context.Background(), testNamespace, testSecretName, &UpdateSecretParams{
 		Data:   map[string]string{"a": "1", "b": "2"},
@@ -1130,7 +1131,7 @@ func TestMergeManagedLabels(t *testing.T) {
 func TestUpdateSecret_NotFound(t *testing.T) {
 	scheme := newTestScheme(t)
 	cpClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-	svc := &secretService{k8sClient: cpClient, logger: newTestLogger()}
+	svc := &secretService{k8sClient: cpClient, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	_, err := svc.UpdateSecret(context.Background(), testNamespace, testSecretName, &UpdateSecretParams{
 		Data: map[string]string{"k": "v"},
@@ -1145,7 +1146,7 @@ func TestUpdateSecret_ValidationFailure(t *testing.T) {
 	wp := newWorkflowPlane()
 	ref := managedRef(testSecretName, corev1.SecretTypeBasicAuth, []string{"password", "username"})
 	cpClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(wp, ref).Build()
-	svc := &secretService{k8sClient: cpClient, logger: newTestLogger()}
+	svc := &secretService{k8sClient: cpClient, logger: newTestLogger(), remoteKeyPrefix: config.DefaultRemoteKeyPrefix}
 
 	_, err := svc.UpdateSecret(context.Background(), testNamespace, testSecretName, &UpdateSecretParams{
 		// Missing required password key for basic-auth.
@@ -1153,5 +1154,84 @@ func TestUpdateSecret_ValidationFailure(t *testing.T) {
 	})
 	if !isValidationError(err) {
 		t.Errorf("expected ValidationError, got %v", err)
+	}
+}
+
+func TestRemoteKeyForPrefixes(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix string
+		want   string
+	}{
+		{"default prefix", config.DefaultRemoteKeyPrefix, "secret/ns1/generic/my-secret"},
+		{"empty prefix drops segment", "", "ns1/generic/my-secret"},
+		{"custom prefix", "openchoreo", "openchoreo/ns1/generic/my-secret"},
+		{"nested prefix", "oc/secrets", "oc/secrets/ns1/generic/my-secret"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := remoteKeyFor(tt.prefix, testNamespace, corev1.SecretTypeOpaque, testSecretName); got != tt.want {
+				t.Errorf("remoteKeyFor(%q) = %q, want %q", tt.prefix, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildersHonorEmptyPrefix pins the fix for the duplicate-entry bug: with an
+// empty prefix the PushSecret and the SecretReference must agree on a key that
+// carries no leading segment, so the key cannot collide with the KV mount name.
+func TestBuildersHonorEmptyPrefix(t *testing.T) {
+	const wantKey = "ns1/generic/my-secret"
+
+	ps := buildPushSecret("", testSecretName, testNamespace, kvNamespace(testNamespace), "vault-store",
+		corev1.SecretTypeOpaque, []string{"a"})
+	spec, ok := ps.Object["spec"].(map[string]any)
+	if !ok {
+		t.Fatal("spec is not a map")
+	}
+	matches, ok := spec["data"].([]map[string]any)
+	if !ok || len(matches) != 1 {
+		t.Fatalf("data = %#v", spec["data"])
+	}
+	match := matches[0]["match"].(map[string]any)
+	remoteRef := match["remoteRef"].(map[string]any)
+	if remoteRef["remoteKey"] != wantKey {
+		t.Errorf("PushSecret remoteKey = %v, want %q", remoteRef["remoteKey"], wantKey)
+	}
+
+	ref := buildSecretReference("", testNamespace, testSecretName, corev1.SecretTypeOpaque,
+		openchoreov1alpha1.TargetPlaneRef{Kind: planeKindDataPlane, Name: "dp1"}, []string{"a"}, nil)
+	if len(ref.Spec.Data) != 1 {
+		t.Fatalf("data sources = %d", len(ref.Spec.Data))
+	}
+	if ref.Spec.Data[0].RemoteRef.Key != wantKey {
+		t.Errorf("SecretReference key = %q, want %q", ref.Spec.Data[0].RemoteRef.Key, wantKey)
+	}
+}
+
+// TestNewServiceNormalizesPrefix checks that stray slashes in the configured
+// prefix cannot produce empty or doubled segments in the key.
+func TestNewServiceNormalizesPrefix(t *testing.T) {
+	tests := []struct {
+		configured string
+		want       string
+	}{
+		{"secret", "secret/ns1/generic/my-secret"},
+		{"/secret/", "secret/ns1/generic/my-secret"},
+		{"team//prod", "team/prod/ns1/generic/my-secret"},
+		{"//team///prod//", "team/prod/ns1/generic/my-secret"},
+		{"", "ns1/generic/my-secret"},
+		{"/", "ns1/generic/my-secret"},
+	}
+	for _, tt := range tests {
+		cfg := config.SecretManagementConfig{Enabled: true, RemoteKeyPrefix: tt.configured}
+		svc, ok := NewService(nil, nil, cfg, newTestLogger()).(*secretService)
+		if !ok {
+			t.Fatal("NewService did not return *secretService")
+		}
+		got := remoteKeyFor(svc.remoteKeyPrefix, testNamespace, corev1.SecretTypeOpaque, testSecretName)
+		if got != tt.want {
+			t.Errorf("prefix %q: key = %q, want %q", tt.configured, got, tt.want)
+		}
 	}
 }


### PR DESCRIPTION
## Purpose

Every remote key written to the external secret store started with a hardcoded `secret/` segment, and the installer also names the OpenBao KV mount `secret`. On a default install the first segment of every key repeats the mount name, and external-secrets handles that overlap inconsistently: `buildPath` strips the duplicated segment when writing the value, `buildMetadataPath` does not. ESO carries a comment acknowledging this in `providers/v1/vault/client_get.go`.

The result is two KV entries for every secret created through the Secret API:

| Path in the `secret` mount | Contents |
|---|---|
| `<ns>/generic/<name>` | the value, `custom_metadata: null` |
| `secret/<ns>/generic/<name>` | `managed-by: external-secrets`, `current_version: 0`, no data |

Consequences on a stock install:

1. Two entries per secret, so listings, inventories and audits double count.
2. The value carries no `managed-by` marker. ESO's "do not clobber unmanaged secrets" check reads the other path, so it validates a marker that does not sit on the secret.
3. `PushSecret.status.syncedPushSecrets` records the un-stripped key, a path with no data.
4. A direct read using `remoteRef.key` from the SecretReference returns an entry with no data, which is more confusing than a clean "not found" for operators, purge tooling and restores.

## Approach

- Add `remoteKeyPrefix` under the existing secret management feature config (`features.secretManagement.remoteKeyPrefix`, `secret_management.remote_key_prefix`), defaulting to `secret` so existing installs keep their key layout and no data moves.
- Thread the prefix into `remoteKeyFor` and the PushSecret / SecretReference builders in the secret service. An empty prefix drops the segment entirely, giving `<namespace>/<type>/<name>`.
- Normalize the configured value (`NormalizedRemoteKeyPrefix`) by dropping every empty slash-separated component, so leading, trailing and interior slash runs all collapse. `//team///prod//` becomes `team/prod` rather than leaving an empty segment in the key, which in KV v2 would resolve to a different path than intended.
- Document in the chart that the prefix must not equal the KV mount name, and that this is install-time configuration since changing it after secrets exist does not move existing entries.

Verified on a local k3d cluster (OpenBao 2.5.1, external-secrets 2.0.1, KV v2, mount `secret`):

- Reproduced the duplicate pair first, with the metadata entry written ~23 ms before the value, matching ESO's write order.
- With an empty prefix, creating a secret through the API produces one entry that holds the data and carries `managed-by: external-secrets` on the value itself, with nothing at the un-stripped path.
- With the default prefix the key is still `secret/<ns>/generic/<name>`, unchanged from before.
- Checked the read path as well: the pipeline copies `remoteRef.key` verbatim into the generated ExternalSecret, and a K8s Secret materializes with the correct value for both the empty and the default prefix.


## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks

Scoped to the Secret API path. The git secret flow derives the same key shape from its own hardcoded literal, but it is a deprecated flow and is deliberately left unchanged here.

Two follow-ups from the issue are also not in this PR:

- **No migration path.** Changing the prefix on an install that already has secrets leaves the old entries where they are; nothing detects or moves them.
- **No validation that the prefix differs from the mount name.** The API server does not read the ClusterSecretStore, so it cannot check this at startup. The constraint is documented, but an operator can still set `remoteKeyPrefix: secret` against a `secret` mount and reintroduce the duplicate. A controller-side warning would close that gap.