### PR TITLE
fix: test update for the websocket certificate pool

### DIFF
--- a/internal/cluster-gateway/agent_auth_test.go
+++ b/internal/cluster-gateway/agent_auth_test.go
@@ -32,6 +32,14 @@ func pemChain(t *testing.T, certs ...*x509.Certificate) string {
 	return b.String()
 }
 
+func getCertificatePoolFromCreds(creds *agentCredentials) *x509.CertPool {
+	certPool := x509.NewCertPool()
+	for _, cert := range creds.intermediates {
+		certPool.AddCert(cert)
+	}
+	return certPool
+}
+
 // albHeaderValue mimics the AWS ALB X-Amzn-Mtls-Clientcert value: a URL-encoded,
 // concatenated PEM chain.
 func albHeaderValue(t *testing.T, certs ...*x509.Certificate) string {
@@ -259,9 +267,14 @@ func TestBuildAgentAuthenticator(t *testing.T) {
 // per-CR verifier, so a given client certificate is accepted for exactly the same
 // CRs regardless of how it reached the gateway. If this parity ever breaks, the
 // forwarded-header path would silently diverge from the trusted mtls path.
+//
+// The certificate chains through an intermediate CA so both paths carry a
+// non-empty intermediates list: verification only succeeds if those intermediates
+// survive the conversion into the pool handed to the verifier.
 func TestForwardedHeaderMatchesHandshakeVerification(t *testing.T) {
 	caCert, caKey := generateTestCA(t)
-	leaf := generateTestClientCert(t, caCert, caKey)
+	interCert, interKey := generateTestIntermediateCA(t, caCert, caKey)
+	leaf := generateTestClientCert(t, interCert, interKey)
 	caPEM := encodeCertToPEM(t, caCert)
 
 	dp := &openchoreov1alpha1.DataPlane{
@@ -276,21 +289,23 @@ func TestForwardedHeaderMatchesHandshakeVerification(t *testing.T) {
 	fakeClient := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(dp).Build()
 	s := &Server{k8sClient: fakeClient, logger: testLogger()}
 
-	// mtls path: certificate from the TLS handshake.
+	// mtls path: certificate chain from the TLS handshake.
 	mtlsReq := httptest.NewRequest(http.MethodGet, "/ws", nil)
-	mtlsReq.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{leaf}}
+	mtlsReq.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{leaf, interCert}}
 	mtlsCreds, err := mtlsAuthenticator{}.Authenticate(mtlsReq)
 	require.NoError(t, err)
+	require.Len(t, mtlsCreds.intermediates, 1)
 
-	// forwarded-header path: same certificate, forwarded by an ALB-style proxy.
+	// forwarded-header path: same chain, forwarded by an ALB-style proxy.
 	fwdReq := httptest.NewRequest(http.MethodGet, "/ws", nil)
-	fwdReq.Header.Set(DefaultForwardedHeaderName, albHeaderValue(t, leaf))
+	fwdReq.Header.Set(DefaultForwardedHeaderName, albHeaderValue(t, leaf, interCert))
 	fwdCreds, err := forwardedHeaderAuthenticator{header: DefaultForwardedHeaderName}.Authenticate(fwdReq)
 	require.NoError(t, err)
+	require.Len(t, fwdCreds.intermediates, 1)
 
-	mtlsValid, err := s.verifyClientCertificatePerCR(mtlsCreds.clientCert, mtlsCreds.intermediates, "dataplane", "prod")
+	mtlsValid, err := s.verifyClientCertificatePerCR(mtlsCreds.clientCert, getCertificatePoolFromCreds(mtlsCreds), "dataplane", "prod")
 	require.NoError(t, err)
-	fwdValid, err := s.verifyClientCertificatePerCR(fwdCreds.clientCert, fwdCreds.intermediates, "dataplane", "prod")
+	fwdValid, err := s.verifyClientCertificatePerCR(fwdCreds.clientCert, getCertificatePoolFromCreds(fwdCreds), "dataplane", "prod")
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{"ns/dp1"}, mtlsValid)

--- a/internal/cluster-gateway/connection_manager_test.go
+++ b/internal/cluster-gateway/connection_manager_test.go
@@ -72,6 +72,34 @@ func generateTestCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
 	return caCert, caKey
 }
 
+// generateTestIntermediateCA creates an intermediate CA certificate signed by the
+// given parent CA, for building multi-level chains in testing.
+func generateTestIntermediateCA(t *testing.T, parentCert *x509.Certificate, parentKey *ecdsa.PrivateKey) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	interKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	interTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(3),
+		Subject:               pkix.Name{CommonName: "Test Intermediate CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		MaxPathLen:            0,
+		MaxPathLenZero:        true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+
+	interDER, err := x509.CreateCertificate(rand.Reader, interTemplate, parentCert, &interKey.PublicKey, parentKey)
+	require.NoError(t, err)
+
+	interCert, err := x509.ParseCertificate(interDER)
+	require.NoError(t, err)
+
+	return interCert, interKey
+}
+
 // generateTestClientCert creates a client certificate signed by the given CA.
 func generateTestClientCert(t *testing.T, caCert *x509.Certificate, caKey *ecdsa.PrivateKey) *x509.Certificate {
 	t.Helper()


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This PR is to update the test related to the https://github.com/openchoreo/openchoreo/issues/4229

## Approach
> Summarize the solution and implementation details.

## Related Issues
Issue - https://github.com/openchoreo/openchoreo/issues/4229

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [ ] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
