### PR TITLE
fix(controller): honor clientCA.secretKeyRef for (Cluster)ObservabilityPlane agent mode

### DIFF
--- a/internal/clients/kubernetes/client.go
+++ b/internal/clients/kubernetes/client.go
@@ -234,8 +234,9 @@ func GetK8sClientFromObservabilityPlane(
 	// Include "v2" to force cache invalidation after proxy client signature change
 	key := fmt.Sprintf("v2/observabilityplane/%s/%s", observabilityPlane.Namespace, observabilityPlane.Name)
 
-	// Agent mode - use HTTP proxy through cluster gateway
-	if observabilityPlane.Spec.ClusterAgent.ClientCA.Value != "" {
+	// Agent mode - use HTTP proxy through cluster gateway.
+	if observabilityPlane.Spec.ClusterAgent.ClientCA.Value != "" ||
+		observabilityPlane.Spec.ClusterAgent.ClientCA.SecretKeyRef != nil {
 		if gatewayURL == "" {
 			return nil, fmt.Errorf("gatewayURL is required for agent mode")
 		}
@@ -251,7 +252,13 @@ func GetK8sClientFromObservabilityPlane(
 
 		// Use GetOrAddClient to cache the proxy client
 		return clientMgr.GetOrAddClient(key, func() (client.Client, error) {
-			return NewProxyClient(gatewayURL, planeIdentifier, observabilityPlane.Namespace, observabilityPlane.Name, clientMgr.ProxyTLSConfig)
+			return NewProxyClient(
+				gatewayURL,
+				planeIdentifier,
+				observabilityPlane.Namespace,
+				observabilityPlane.Name,
+				clientMgr.ProxyTLSConfig,
+			)
 		})
 	}
 
@@ -270,8 +277,9 @@ func GetK8sClientFromClusterObservabilityPlane(
 	// Cluster-scoped: no namespace in key
 	key := fmt.Sprintf("v2/clusterobservabilityplane/%s", clusterObsPlane.Name)
 
-	// Agent mode - use HTTP proxy through cluster gateway
-	if clusterObsPlane.Spec.ClusterAgent.ClientCA.Value != "" {
+	// Agent mode - use HTTP proxy through cluster gateway.
+	if clusterObsPlane.Spec.ClusterAgent.ClientCA.Value != "" ||
+		clusterObsPlane.Spec.ClusterAgent.ClientCA.SecretKeyRef != nil {
 		if gatewayURL == "" {
 			return nil, fmt.Errorf("gatewayURL is required for agent mode")
 		}

--- a/internal/clients/kubernetes/client_test.go
+++ b/internal/clients/kubernetes/client_test.go
@@ -330,6 +330,25 @@ func TestGetK8sClientFromObservabilityPlane(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("with ClientCA.SecretKeyRef and valid gatewayURL returns client", func(t *testing.T) {
+		mgr := NewManager()
+		op := &openchoreov1alpha1.ObservabilityPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "obs", Namespace: "default"},
+			Spec: openchoreov1alpha1.ObservabilityPlaneSpec{
+				ClusterAgent: openchoreov1alpha1.ClusterAgentConfig{
+					ClientCA: openchoreov1alpha1.ValueFrom{
+						SecretKeyRef: &openchoreov1alpha1.SecretKeyReference{
+							Name: "cluster-agent-tls", Key: "ca.crt",
+						},
+					},
+				},
+			},
+		}
+		cl, err := GetK8sClientFromObservabilityPlane(mgr, op, testGatewayURL)
+		require.NoError(t, err)
+		assert.NotNil(t, cl)
+	})
+
 	t.Run("with ClientCA.Value and valid gatewayURL returns client", func(t *testing.T) {
 		mgr := NewManager()
 		op := &openchoreov1alpha1.ObservabilityPlane{
@@ -389,6 +408,25 @@ func TestGetK8sClientFromClusterObservabilityPlane(t *testing.T) {
 		}
 		_, err := GetK8sClientFromClusterObservabilityPlane(mgr, cop, "")
 		require.Error(t, err)
+	})
+
+	t.Run("with ClientCA.SecretKeyRef and valid gatewayURL returns client", func(t *testing.T) {
+		mgr := NewManager()
+		cop := &openchoreov1alpha1.ClusterObservabilityPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster-obs"},
+			Spec: openchoreov1alpha1.ClusterObservabilityPlaneSpec{
+				ClusterAgent: openchoreov1alpha1.ClusterAgentConfig{
+					ClientCA: openchoreov1alpha1.ValueFrom{
+						SecretKeyRef: &openchoreov1alpha1.SecretKeyReference{
+							Name: "cluster-agent-tls", Key: "ca.crt",
+						},
+					},
+				},
+			},
+		}
+		cl, err := GetK8sClientFromClusterObservabilityPlane(mgr, cop, testGatewayURL)
+		require.NoError(t, err)
+		require.NotNil(t, cl)
 	})
 
 	t.Run("with ClientCA.Value and valid gatewayURL returns client", func(t *testing.T) {


### PR DESCRIPTION
## Problem
`GetK8sClientFromObservabilityPlane` / `GetK8sClientFromClusterObservabilityPlane`
gate agent mode on `ClusterAgent.ClientCA.Value != ""` and never consider
`SecretKeyRef`. The CRD `ValueFrom` type accepts **either** an inline `value`
**or** a `secretKeyRef`, and the cluster-gateway already resolves `secretKeyRef`
when validating the agent cert — but this client path does not.

As a result, an ObservabilityPlane/ClusterObservabilityPlane configured with
`clusterAgent.clientCA.secretKeyRef` is rejected with:

    agent mode must be enabled for ClusterObservabilityPlane

This blocks **obs-plane RenderedRelease finalization**: deleting/undeploying a
component that carries an `observability-alert-rule` trait gets stuck in
`CleanupFailed`, because the `-observability` RenderedRelease finalizer can't get
an obs-plane client to delete the `ObservabilityAlertRule`.

The `clientCA` content isn't even used by this path — the connection uses
`clientMgr.ProxyTLSConfig`; `.Value != ""` was only a presence flag. Note that
the Data/Workflow plane resolvers don't gate on `clientCA` at all.

## Fix
Treat clientCA supplied via **either** `Value` **or** `SecretKeyRef` as "agent
mode configured". Minimal, backwards-compatible.

## Notes / alternative
An even cleaner option would be to drop the `clientCA` gate entirely and just
require `gatewayURL` (exactly like the Data/Workflow plane resolvers), since the
CA content is unused here. Happy to switch to that if maintainers prefer.

Fixes #4578 