### PR TITLE
feat: resolve internal workload dependencies from provider status

### DIFF
--- a/api/v1alpha1/releasebinding_types.go
+++ b/api/v1alpha1/releasebinding_types.go
@@ -63,6 +63,11 @@ type ResolvedConnection struct {
 
 	// URL is the resolved endpoint URL.
 	URL EndpointURL `json:"url"`
+
+	// Audience is the service identity audience accepted by the target endpoint.
+	// It is empty when the target does not publish one.
+	// +optional
+	Audience string `json:"audience,omitempty"`
 }
 
 // PendingConnection represents a connection that could not be resolved.
@@ -266,6 +271,18 @@ type EndpointURLStatus struct {
 	// ServiceURL is the in-cluster service URL for this endpoint.
 	// +optional
 	ServiceURL *EndpointURL `json:"serviceURL,omitempty"`
+
+	// InternalDirectURL is the private cross-cell address for callers which
+	// explicitly request internal visibility. Platform traits populate this with
+	// the wake-capable alias when one is required, or with the ServiceURL when it
+	// is not. The core resolver never guesses or synthesizes this address.
+	// +optional
+	InternalDirectURL *EndpointURL `json:"internalDirectURL,omitempty"`
+
+	// Audience is the service identity audience accepted by this endpoint. It is
+	// published by the provider so callers do not duplicate identity strings.
+	// +optional
+	Audience string `json:"audience,omitempty"`
 
 	// InvokeURL is the resolved public URL for this endpoint, derived from the
 	// rendered HTTPRoute whose backendRef port matches the endpoint port.

--- a/api/v1alpha1/workload_types.go
+++ b/api/v1alpha1/workload_types.go
@@ -178,7 +178,7 @@ type WorkloadConnection struct {
 
 	// Visibility is the visibility level at which this connection consumes the endpoint.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=project;namespace
+	// +kubebuilder:validation:Enum=project;namespace;internal
 	Visibility string `json:"visibility"`
 
 	// EnvBindings maps semantic URL components to environment variable names.
@@ -205,6 +205,12 @@ type ConnectionEnvBindings struct {
 	// BasePath is the optional env var name for just the base path.
 	// +optional
 	BasePath string `json:"basePath,omitempty"`
+
+	// Audience is the optional env var name for the service identity audience
+	// accepted by the target endpoint. It is resolved from the target
+	// ReleaseBinding, rather than copied into every caller configuration.
+	// +optional
+	Audience string `json:"audience,omitempty"`
 }
 
 // WorkloadDependencies defines the dependencies of a workload on other components' endpoints

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -2567,6 +2567,11 @@ func (in *EndpointURLStatus) DeepCopyInto(out *EndpointURLStatus) {
 		*out = new(EndpointURL)
 		**out = **in
 	}
+	if in.InternalDirectURL != nil {
+		in, out := &in.InternalDirectURL, &out.InternalDirectURL
+		*out = new(EndpointURL)
+		**out = **in
+	}
 	if in.InternalURLs != nil {
 		in, out := &in.InternalURLs, &out.InternalURLs
 		*out = new(EndpointGatewayURLs)

--- a/config/crd/bases/openchoreo.dev_componentreleases.yaml
+++ b/config/crd/bases/openchoreo.dev_componentreleases.yaml
@@ -1072,6 +1072,12 @@ spec:
                                     For HTTP/HTTPS/WS/WSS: scheme://host:port/basePath
                                     For gRPC/TCP/UDP: host:port
                                   type: string
+                                audience:
+                                  description: |-
+                                    Audience is the optional env var name for the service identity audience
+                                    accepted by the target endpoint. It is resolved from the target
+                                    ReleaseBinding, rather than copied into every caller configuration.
+                                  type: string
                                 basePath:
                                   description: BasePath is the optional env var name
                                     for just the base path.
@@ -1102,6 +1108,7 @@ spec:
                               enum:
                               - project
                               - namespace
+                              - internal
                               type: string
                           required:
                           - component

--- a/config/crd/bases/openchoreo.dev_releasebindings.yaml
+++ b/config/crd/bases/openchoreo.dev_releasebindings.yaml
@@ -327,6 +327,11 @@ spec:
                   description: EndpointURLStatus holds the resolved URLs for a single
                     named workload endpoint.
                   properties:
+                    audience:
+                      description: |-
+                        Audience is the service identity audience accepted by this endpoint. It is
+                        published by the provider so callers do not duplicate identity strings.
+                      type: string
                     externalURLs:
                       description: ExternalURLs holds the resolved external gateway
                         URLs.
@@ -403,6 +408,31 @@ spec:
                           required:
                           - host
                           type: object
+                      type: object
+                    internalDirectURL:
+                      description: |-
+                        InternalDirectURL is the private cross-cell address for callers which
+                        explicitly request internal visibility. Platform traits populate this with
+                        the wake-capable alias when one is required, or with the ServiceURL when it
+                        is not. The core resolver never guesses or synthesizes this address.
+                      properties:
+                        host:
+                          description: Host is the hostname or IP address.
+                          minLength: 1
+                          type: string
+                        path:
+                          description: Path is the URL path.
+                          type: string
+                        port:
+                          description: Port is the port number.
+                          format: int32
+                          type: integer
+                        scheme:
+                          description: Scheme is the URL scheme (e.g., http, https,
+                            tcp, udp, ws, wss, grpc, grpcs, tls).
+                          type: string
+                      required:
+                      - host
                       type: object
                     internalURLs:
                       description: InternalURLs holds the resolved internal gateway
@@ -611,6 +641,11 @@ spec:
                   description: ResolvedConnection holds the resolved URL for a single
                     connection.
                   properties:
+                    audience:
+                      description: |-
+                        Audience is the service identity audience accepted by the target endpoint.
+                        It is empty when the target does not publish one.
+                      type: string
                     component:
                       description: Component is the name of the target component.
                       minLength: 1

--- a/config/crd/bases/openchoreo.dev_workloads.yaml
+++ b/config/crd/bases/openchoreo.dev_workloads.yaml
@@ -176,6 +176,12 @@ spec:
                                 For HTTP/HTTPS/WS/WSS: scheme://host:port/basePath
                                 For gRPC/TCP/UDP: host:port
                               type: string
+                            audience:
+                              description: |-
+                                Audience is the optional env var name for the service identity audience
+                                accepted by the target endpoint. It is resolved from the target
+                                ReleaseBinding, rather than copied into every caller configuration.
+                              type: string
                             basePath:
                               description: BasePath is the optional env var name for
                                 just the base path.
@@ -206,6 +212,7 @@ spec:
                           enum:
                           - project
                           - namespace
+                          - internal
                           type: string
                       required:
                       - component

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_componentreleases.yaml
@@ -1071,6 +1071,12 @@ spec:
                                     For HTTP/HTTPS/WS/WSS: scheme://host:port/basePath
                                     For gRPC/TCP/UDP: host:port
                                   type: string
+                                audience:
+                                  description: |-
+                                    Audience is the optional env var name for the service identity audience
+                                    accepted by the target endpoint. It is resolved from the target
+                                    ReleaseBinding, rather than copied into every caller configuration.
+                                  type: string
                                 basePath:
                                   description: BasePath is the optional env var name
                                     for just the base path.
@@ -1101,6 +1107,7 @@ spec:
                               enum:
                               - project
                               - namespace
+                              - internal
                               type: string
                           required:
                           - component

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_releasebindings.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_releasebindings.yaml
@@ -326,6 +326,11 @@ spec:
                   description: EndpointURLStatus holds the resolved URLs for a single
                     named workload endpoint.
                   properties:
+                    audience:
+                      description: |-
+                        Audience is the service identity audience accepted by this endpoint. It is
+                        published by the provider so callers do not duplicate identity strings.
+                      type: string
                     externalURLs:
                       description: ExternalURLs holds the resolved external gateway
                         URLs.
@@ -402,6 +407,31 @@ spec:
                           required:
                           - host
                           type: object
+                      type: object
+                    internalDirectURL:
+                      description: |-
+                        InternalDirectURL is the private cross-cell address for callers which
+                        explicitly request internal visibility. Platform traits populate this with
+                        the wake-capable alias when one is required, or with the ServiceURL when it
+                        is not. The core resolver never guesses or synthesizes this address.
+                      properties:
+                        host:
+                          description: Host is the hostname or IP address.
+                          minLength: 1
+                          type: string
+                        path:
+                          description: Path is the URL path.
+                          type: string
+                        port:
+                          description: Port is the port number.
+                          format: int32
+                          type: integer
+                        scheme:
+                          description: Scheme is the URL scheme (e.g., http, https,
+                            tcp, udp, ws, wss, grpc, grpcs, tls).
+                          type: string
+                      required:
+                      - host
                       type: object
                     internalURLs:
                       description: InternalURLs holds the resolved internal gateway
@@ -610,6 +640,11 @@ spec:
                   description: ResolvedConnection holds the resolved URL for a single
                     connection.
                   properties:
+                    audience:
+                      description: |-
+                        Audience is the service identity audience accepted by the target endpoint.
+                        It is empty when the target does not publish one.
+                      type: string
                     component:
                       description: Component is the name of the target component.
                       minLength: 1

--- a/install/helm/openchoreo-control-plane/crds/openchoreo.dev_workloads.yaml
+++ b/install/helm/openchoreo-control-plane/crds/openchoreo.dev_workloads.yaml
@@ -175,6 +175,12 @@ spec:
                                 For HTTP/HTTPS/WS/WSS: scheme://host:port/basePath
                                 For gRPC/TCP/UDP: host:port
                               type: string
+                            audience:
+                              description: |-
+                                Audience is the optional env var name for the service identity audience
+                                accepted by the target endpoint. It is resolved from the target
+                                ReleaseBinding, rather than copied into every caller configuration.
+                              type: string
                             basePath:
                               description: BasePath is the optional env var name for
                                 just the base path.
@@ -205,6 +211,7 @@ spec:
                           enum:
                           - project
                           - namespace
+                          - internal
                           type: string
                       required:
                       - component

--- a/internal/controller/releasebinding/controller_connections.go
+++ b/internal/controller/releasebinding/controller_connections.go
@@ -140,6 +140,7 @@ func (r *Reconciler) resolveConnection(
 			Endpoint:   conn.Endpoint,
 			Visibility: conn.Visibility,
 			URL:        *url,
+			Audience:   ep.Audience,
 		}, nil, nil
 	}
 
@@ -174,6 +175,8 @@ func resolveURLForVisibility(
 			}
 		}
 		return nil
+	case openchoreov1alpha1.EndpointVisibilityInternal:
+		return ep.InternalDirectURL
 	default:
 		return nil
 	}
@@ -225,7 +228,7 @@ func buildEnvVarsForConnection(
 	conn openchoreov1alpha1.WorkloadConnection,
 	rc openchoreov1alpha1.ResolvedConnection,
 ) []pipelinecontext.EnvVarEntry {
-	envVars := make([]pipelinecontext.EnvVarEntry, 0, 4)
+	envVars := make([]pipelinecontext.EnvVarEntry, 0, 5)
 
 	if conn.EnvBindings.Address != "" {
 		envVars = append(envVars, pipelinecontext.EnvVarEntry{
@@ -256,6 +259,13 @@ func buildEnvVarsForConnection(
 		envVars = append(envVars, pipelinecontext.EnvVarEntry{
 			Name:  conn.EnvBindings.BasePath,
 			Value: rc.URL.Path,
+		})
+	}
+
+	if conn.EnvBindings.Audience != "" {
+		envVars = append(envVars, pipelinecontext.EnvVarEntry{
+			Name:  conn.EnvBindings.Audience,
+			Value: rc.Audience,
 		})
 	}
 

--- a/internal/controller/releasebinding/controller_connections_integration_test.go
+++ b/internal/controller/releasebinding/controller_connections_integration_test.go
@@ -739,16 +739,17 @@ var _ = Describe("ReleaseBinding connection resolution", func() {
 	// container env var via the dependencies.envVars template binding.
 	Context("S7: when a resolved connection wires env vars into the rendered Deployment", func() {
 		const (
-			rbName   = "rb-conn-s7"
-			crName   = "cr-conn-s7"
-			envName  = "env-conn-s7"
-			dpName   = "dp-conn-s7"
-			compName = "comp-conn-s7"
-			projName = "proj-conn-s7"
-			provComp = "provider-s7"
-			provRB   = "prov-s7"
-			epName   = "api"
-			svcHost  = "provider-s7-svc.default.svc.cluster.local"
+			rbName     = "rb-conn-s7"
+			crName     = "cr-conn-s7"
+			envName    = "env-conn-s7"
+			dpName     = "dp-conn-s7"
+			compName   = "comp-conn-s7"
+			projName   = "proj-conn-s7"
+			provComp   = "provider-s7"
+			provRB     = "prov-s7"
+			epName     = "api"
+			directHost = "provider-s7-keda.default.svc.cluster.local"
+			audience   = "https://provider.example.test"
 		)
 
 		AfterEach(func() {
@@ -779,11 +780,11 @@ var _ = Describe("ReleaseBinding connection resolution", func() {
 			Expect(k8sClient.Create(ctx, envFixture(envName, dpName))).To(Succeed())
 			Expect(k8sClient.Create(ctx, componentFixture(compName, projName))).To(Succeed())
 
-			By("Creating a deployed provider RB exposing the endpoint via ServiceURL")
+			By("Creating a deployed provider RB exposing a published internal direct URL and audience")
 			Expect(k8sClient.Create(ctx, providerRBFixture(provRB, projName, provComp, envName))).To(Succeed())
 			setProviderEndpoints(&openchoreov1alpha1.ReleaseBinding{ObjectMeta: metav1.ObjectMeta{Name: provRB}},
 				[]openchoreov1alpha1.EndpointURLStatus{
-					{Name: epName, ServiceURL: &openchoreov1alpha1.EndpointURL{Scheme: "http", Host: svcHost, Port: 8080}},
+					{Name: epName, InternalDirectURL: &openchoreov1alpha1.EndpointURL{Scheme: "http", Host: directHost, Port: 3001}, Audience: audience},
 				})
 
 			By("Creating ComponentRelease with a connection and a template projecting dependencies.envVars")
@@ -795,8 +796,8 @@ var _ = Describe("ReleaseBinding connection resolution", func() {
 						Project:     projName,
 						Component:   provComp,
 						Name:        epName,
-						Visibility:  string(openchoreov1alpha1.EndpointVisibilityProject),
-						EnvBindings: openchoreov1alpha1.ConnectionEnvBindings{Host: "DEP_HOST"},
+						Visibility:  string(openchoreov1alpha1.EndpointVisibilityInternal),
+						EnvBindings: openchoreov1alpha1.ConnectionEnvBindings{Host: "DEP_HOST", Audience: "DEP_AUDIENCE"},
 					},
 				},
 			}
@@ -816,7 +817,8 @@ var _ = Describe("ReleaseBinding connection resolution", func() {
 
 			By("ResolvedConnections has the expected host, PendingConnections empty")
 			Expect(rb.Status.ResolvedConnections).To(HaveLen(1))
-			Expect(rb.Status.ResolvedConnections[0].URL.Host).To(Equal(svcHost))
+			Expect(rb.Status.ResolvedConnections[0].URL.Host).To(Equal(directHost))
+			Expect(rb.Status.ResolvedConnections[0].Audience).To(Equal(audience))
 			Expect(rb.Status.PendingConnections).To(BeEmpty())
 			cond := conditionFor(rb, string(ConditionConnectionsResolved))
 			Expect(cond).NotTo(BeNil())
@@ -831,11 +833,15 @@ var _ = Describe("ReleaseBinding connection resolution", func() {
 			)).To(Succeed())
 			deploy := findDeploymentManifest(rendered)
 
-			By("Container.env contains DEP_HOST=" + svcHost)
+			By("Container.env contains the direct host and target-published audience")
 			Expect(deploy.Spec.Template.Spec.Containers).To(HaveLen(1))
 			Expect(deploy.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{
 				Name:  "DEP_HOST",
-				Value: svcHost,
+				Value: directHost,
+			}))
+			Expect(deploy.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{
+				Name:  "DEP_AUDIENCE",
+				Value: audience,
 			}))
 		})
 	})

--- a/internal/controller/releasebinding/controller_unit_test.go
+++ b/internal/controller/releasebinding/controller_unit_test.go
@@ -1900,6 +1900,7 @@ func TestBuildConnectionItems(t *testing.T) {
 					Namespace: testNamespace, Project: testProjectName, Component: "svc-a", Endpoint: "api",
 					Visibility: openchoreov1alpha1.EndpointVisibilityProject,
 					URL:        openchoreov1alpha1.EndpointURL{Scheme: "http", Host: "svc-a.ns.svc.cluster.local", Port: 8080, Path: "/v1"},
+					Audience:   "https://api.example.test",
 				},
 			},
 		},
@@ -1916,6 +1917,7 @@ func TestBuildConnectionItems(t *testing.T) {
 					Host:     "SVC_A_HOST",
 					Port:     "SVC_A_PORT",
 					BasePath: "SVC_A_PATH",
+					Audience: "SVC_A_AUDIENCE",
 				},
 			},
 		}
@@ -1926,10 +1928,11 @@ func TestBuildConnectionItems(t *testing.T) {
 		}
 
 		expected := map[string]string{
-			"SVC_A_ADDRESS": "http://svc-a.ns.svc.cluster.local:8080/v1",
-			"SVC_A_HOST":    "svc-a.ns.svc.cluster.local",
-			"SVC_A_PORT":    "8080",
-			"SVC_A_PATH":    "/v1",
+			"SVC_A_ADDRESS":  "http://svc-a.ns.svc.cluster.local:8080/v1",
+			"SVC_A_HOST":     "svc-a.ns.svc.cluster.local",
+			"SVC_A_PORT":     "8080",
+			"SVC_A_PATH":     "/v1",
+			"SVC_A_AUDIENCE": "https://api.example.test",
 		}
 		if len(items[0].EnvVars) != len(expected) {
 			t.Fatalf("expected %d env vars, got %d", len(expected), len(items[0].EnvVars))
@@ -2010,6 +2013,7 @@ func TestResolveURLForVisibility(t *testing.T) {
 		InternalURLs: &openchoreov1alpha1.EndpointGatewayURLs{
 			HTTP: &openchoreov1alpha1.EndpointURL{Scheme: "http", Host: "api.internal", Port: 80},
 		},
+		InternalDirectURL: &openchoreov1alpha1.EndpointURL{Scheme: "http", Host: "api.keda.ns.svc.cluster.local", Port: 3001},
 	}
 
 	t.Run("project visibility returns service URL", func(t *testing.T) {
@@ -2030,6 +2034,13 @@ func TestResolveURLForVisibility(t *testing.T) {
 		url := resolveURLForVisibility(ep, openchoreov1alpha1.EndpointVisibilityExternal)
 		if url == nil || url.Host != "api.example.com" {
 			t.Errorf("expected external URL, got %v", url)
+		}
+	})
+
+	t.Run("internal visibility returns only the published direct URL", func(t *testing.T) {
+		url := resolveURLForVisibility(ep, openchoreov1alpha1.EndpointVisibilityInternal)
+		if url == nil || url.Host != "api.keda.ns.svc.cluster.local" || url.Port != 3001 {
+			t.Errorf("expected internal direct URL, got %v", url)
 		}
 	})
 

--- a/internal/occ/resources/workload/converter.go
+++ b/internal/occ/resources/workload/converter.go
@@ -320,10 +320,11 @@ var validEndpointVisibilities = map[openchoreov1alpha1.EndpointVisibility]bool{
 }
 
 // validDependencyVisibilities is the set of allowed visibility values for dependency endpoint connections.
-// WorkloadConnection.Visibility is restricted to project and namespace by the CRD validation.
+// WorkloadConnection.Visibility is restricted to project, namespace and internal by the CRD validation.
 var validDependencyVisibilities = map[openchoreov1alpha1.EndpointVisibility]bool{
 	openchoreov1alpha1.EndpointVisibilityProject:   true,
 	openchoreov1alpha1.EndpointVisibilityNamespace: true,
+	openchoreov1alpha1.EndpointVisibilityInternal:  true,
 }
 
 // addDependenciesFromDescriptor adds dependencies from the descriptor to the workload


### PR DESCRIPTION
Extends the existing `Workload.spec.dependencies.endpoints` model with `visibility: internal`, a provider-published `internalDirectURL`, and a provider-published service identity audience.

The resolver consumes only the published URL (it does not synthesize hostnames); an absent direct URL leaves the dependency pending. Optional env bindings project the direct address and audience into the rendered workload.

Validation:
- `make generate manifests`
- `make helm-generate.openchoreo-control-plane`
- `go test ./internal/controller/releasebinding ./internal/occ/resources/workload -count=1`
- integration render asserts direct host and audience in Deployment env.