### PR TITLE
fix: exclude agent connections from selection after GOAWAY is sent

### DIFF
--- a/internal/cluster-gateway/connection_manager.go
+++ b/internal/cluster-gateway/connection_manager.go
@@ -32,7 +32,22 @@ type AgentConnection struct {
 	ValidCRs        []string          // List of CRs (namespace/name) this connection is authorized for
 	clientCert      *x509.Certificate // Client certificate for re-validation on CR updates
 	intermediates   *x509.CertPool    // Handshake intermediate CAs, used to chain the client cert on re-validation
+	draining        bool              // True after GOAWAY is sent, excluded from selection when live connections exist
 	mu              sync.Mutex
+}
+
+// SetDraining marks the connection as draining (e.g. after sending GOAWAY).
+func (ac *AgentConnection) SetDraining() {
+	ac.mu.Lock()
+	defer ac.mu.Unlock()
+	ac.draining = true
+}
+
+// IsDraining reports whether the connection is marked draining.
+func (ac *AgentConnection) IsDraining() bool {
+	ac.mu.Lock()
+	defer ac.mu.Unlock()
+	return ac.draining
 }
 
 // IsValidForCR checks if this connection is authorized for the specified CR
@@ -290,8 +305,54 @@ func (cm *ConnectionManager) Unregister(planeIdentifier, connID string) {
 	)
 }
 
+// SetDraining marks an agent connection as draining under the manager lock.
+// This serializes draining transitions with connection selection (Get, GetForCR).
+func (cm *ConnectionManager) SetDraining(conn *AgentConnection) {
+	if conn == nil {
+		return
+	}
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	conn.SetDraining()
+}
+
+// DrainConnection sends a GOAWAY frame and marks the connection as draining
+// under the manager lock. This ensures successful GOAWAY delivery and the
+// draining state transition are atomic with respect to connection selection (Get, GetForCR).
+func (cm *ConnectionManager) DrainConnection(conn *AgentConnection, goAway []byte) error {
+	if conn == nil {
+		return nil
+	}
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	if len(goAway) > 0 {
+		if err := conn.SendRawMessage(goAway); err != nil {
+			return err
+		}
+	}
+	conn.SetDraining()
+	return nil
+}
+
+// preferLive filters candidates to non-draining connections. If all candidates
+// are draining, it falls back to returning the full slice so callers still have a
+// chance to route rather than failing outright.
+func preferLive(conns []*AgentConnection) []*AgentConnection {
+	var live []*AgentConnection
+	for _, conn := range conns {
+		if !conn.IsDraining() {
+			live = append(live, conn)
+		}
+	}
+	if len(live) > 0 {
+		return live
+	}
+	return conns
+}
+
 // Get retrieves an agent connection by plane identifier using round-robin selection
-// If multiple connections exist for the plane, it rotates between them
+// If multiple connections exist for the plane, it rotates between them, preferring live connections
 func (cm *ConnectionManager) Get(planeIdentifier string) (*AgentConnection, error) {
 	cm.mu.Lock() // Need write lock for roundRobin update
 	defer cm.mu.Unlock()
@@ -301,14 +362,16 @@ func (cm *ConnectionManager) Get(planeIdentifier string) (*AgentConnection, erro
 		return nil, fmt.Errorf("no agents found for plane %s", planeIdentifier)
 	}
 
-	idx := cm.roundRobin[planeIdentifier] % len(conns)
-	cm.roundRobin[planeIdentifier] = (idx + 1) % len(conns)
+	candidates := preferLive(conns)
+	idx := cm.roundRobin[planeIdentifier] % len(candidates)
+	cm.roundRobin[planeIdentifier] = (idx + 1) % len(candidates)
 
-	return conns[idx], nil
+	return candidates[idx], nil
 }
 
 // GetForCR retrieves an agent connection authorized for the specified CR using round-robin selection
-// Only connections where the agent's certificate is valid for the requested CR are considered
+// Only connections where the agent's certificate is valid for the requested CR are considered,
+// preferring live (non-draining) connections.
 // This enforces per-CR security boundaries in multi-tenant scenarios
 // Returns error if no authorized connections are found
 func (cm *ConnectionManager) GetForCR(planeIdentifier, crKey string) (*AgentConnection, error) {
@@ -336,19 +399,22 @@ func (cm *ConnectionManager) GetForCR(planeIdentifier, crKey string) (*AgentConn
 		return nil, fmt.Errorf("no agents authorized for CR %s", crKey)
 	}
 
-	// Round-robin among valid connections only
+	candidates := preferLive(validConns)
+
+	// Round-robin among preferred valid connections only
 	// Use CR-specific round-robin key to ensure fair distribution per CR
 	rrKey := fmt.Sprintf("%s/%s", planeIdentifier, crKey)
-	idx := cm.roundRobin[rrKey] % len(validConns)
-	cm.roundRobin[rrKey] = (idx + 1) % len(validConns)
+	idx := cm.roundRobin[rrKey] % len(candidates)
+	cm.roundRobin[rrKey] = (idx + 1) % len(candidates)
 
-	selectedConn := validConns[idx]
+	selectedConn := candidates[idx]
 
 	cm.logger.Debug("selected agent for CR",
 		"planeIdentifier", planeIdentifier,
 		"cr", crKey,
 		"connectionID", selectedConn.ID,
 		"validAgents", len(validConns),
+		"candidateAgents", len(candidates),
 		"totalAgents", len(conns),
 	)
 

--- a/internal/cluster-gateway/connection_manager_test.go
+++ b/internal/cluster-gateway/connection_manager_test.go
@@ -9,11 +9,14 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"encoding/pem"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -942,4 +945,209 @@ func TestAgentConnection_SendHTTPTunnelRequest_Success(t *testing.T) {
 
 	err := ac.SendHTTPTunnelRequest(req)
 	assert.NoError(t, err)
+}
+
+func TestAgentConnection_Draining(t *testing.T) {
+	ac := &AgentConnection{}
+	assert.False(t, ac.IsDraining(), "new connection must not be draining")
+
+	ac.SetDraining()
+	assert.True(t, ac.IsDraining(), "connection must be marked draining after SetDraining")
+}
+
+func TestPreferLive(t *testing.T) {
+	c1 := &AgentConnection{ID: "c1"}
+	c2 := &AgentConnection{ID: "c2"}
+	c3 := &AgentConnection{ID: "c3"}
+	c2.SetDraining()
+
+	// Mixed: returns only non-draining
+	res := preferLive([]*AgentConnection{c1, c2, c3})
+	assert.Equal(t, []*AgentConnection{c1, c3}, res)
+
+	// All live: returns all
+	res = preferLive([]*AgentConnection{c1, c3})
+	assert.Equal(t, []*AgentConnection{c1, c3}, res)
+
+	// All draining: falls back to all
+	c1.SetDraining()
+	c3.SetDraining()
+	res = preferLive([]*AgentConnection{c1, c2, c3})
+	assert.Equal(t, []*AgentConnection{c1, c2, c3}, res)
+
+	// Empty
+	res = preferLive([]*AgentConnection{})
+	assert.Empty(t, res)
+}
+
+func TestConnectionManager_SetDraining(t *testing.T) {
+	cm := NewConnectionManager(testLogger())
+
+	// SetDraining handles nil safely
+	cm.SetDraining(nil)
+
+	ac := &AgentConnection{ID: "c1"}
+	assert.False(t, ac.IsDraining())
+	cm.SetDraining(ac)
+	assert.True(t, ac.IsDraining())
+}
+
+func TestConnectionManager_Get_PreferLive(t *testing.T) {
+	cm := NewConnectionManager(testLogger())
+
+	conn1, cleanup1 := newTestWSConn(t)
+	defer cleanup1()
+	conn2, cleanup2 := newTestWSConn(t)
+	defer cleanup2()
+
+	id1, _ := cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil, nil)
+	id2, _ := cm.Register("dataplane", "prod", conn2, []string{"ns/dp1"}, nil, nil)
+
+	// Both live: round robin returns id1 then id2
+	got1, err := cm.Get("dataplane/prod")
+	require.NoError(t, err)
+	assert.Equal(t, id1, got1.ID)
+
+	// Mark conn1 as draining: Get should always pick conn2
+	cm.SetDraining(got1)
+
+	for range 3 {
+		got, err := cm.Get("dataplane/prod")
+		require.NoError(t, err)
+		assert.Equal(t, id2, got.ID, "should exclusively select the live connection")
+	}
+
+	// Mark conn2 as draining as well: Get falls back to rotating between draining connections
+	got2, err := cm.Get("dataplane/prod")
+	require.NoError(t, err)
+	cm.SetDraining(got2)
+
+	seen := make(map[string]bool)
+	for range 2 {
+		got, err := cm.Get("dataplane/prod")
+		require.NoError(t, err)
+		seen[got.ID] = true
+	}
+	assert.True(t, seen[id1] && seen[id2], "should fall back to both connections when all are draining")
+}
+
+func TestConnectionManager_GetForCR_PreferLive(t *testing.T) {
+	cm := NewConnectionManager(testLogger())
+
+	conn1, cleanup1 := newTestWSConn(t)
+	defer cleanup1()
+	conn2, cleanup2 := newTestWSConn(t)
+	defer cleanup2()
+	conn3, cleanup3 := newTestWSConn(t)
+	defer cleanup3()
+
+	id1, _ := cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil, nil)
+	id2, _ := cm.Register("dataplane", "prod", conn2, []string{"ns/dp1"}, nil, nil)
+	id3, _ := cm.Register("dataplane", "prod", conn3, []string{"ns/dp2"}, nil, nil)
+
+	// Both conn1 and conn2 are valid for ns/dp1
+	got1, err := cm.GetForCR("dataplane/prod", "ns/dp1")
+	require.NoError(t, err)
+	assert.Equal(t, id1, got1.ID)
+
+	// Mark conn1 as draining: GetForCR for ns/dp1 should always select conn2
+	cm.SetDraining(got1)
+
+	for range 3 {
+		got, err := cm.GetForCR("dataplane/prod", "ns/dp1")
+		require.NoError(t, err)
+		assert.Equal(t, id2, got.ID, "should exclusively select the live connection for CR")
+	}
+
+	// For ns/dp2, only conn3 is authorized and live
+	got3, err := cm.GetForCR("dataplane/prod", "ns/dp2")
+	require.NoError(t, err)
+	assert.Equal(t, id3, got3.ID)
+
+	// Mark conn2 as draining: now all authorized connections for ns/dp1 are draining
+	// GetForCR should fall back to returning draining connections rather than failing
+	got2, err := cm.GetForCR("dataplane/prod", "ns/dp1")
+	require.NoError(t, err)
+	assert.Equal(t, id2, got2.ID)
+	cm.SetDraining(got2)
+
+	fallbackGot, err := cm.GetForCR("dataplane/prod", "ns/dp1")
+	require.NoError(t, err)
+	assert.True(t, fallbackGot.ID == id1 || fallbackGot.ID == id2, "should fall back to draining authorized connections")
+}
+
+func TestConnectionManager_DrainConnection_AtomicWithSelection(t *testing.T) {
+	cm := NewConnectionManager(testLogger())
+
+	// c1 will be drained, c2 will remain live
+	conn1, cleanup1 := newTestWSConn(t)
+	defer cleanup1()
+	conn2, cleanup2 := newTestWSConn(t)
+	defer cleanup2()
+
+	id1, err := cm.Register("dataplane", "prod", conn1, []string{"ns/dp1"}, nil, nil)
+	require.NoError(t, err)
+	id2, err := cm.Register("dataplane", "prod", conn2, []string{"ns/dp1"}, nil, nil)
+	require.NoError(t, err)
+
+	goAway, err := json.Marshal(messaging.GoAway{Type: messaging.MessageTypeGoAway})
+	require.NoError(t, err)
+
+	conns := cm.GetAll()
+	var c1 *AgentConnection
+	for _, c := range conns {
+		if c.ID == id1 {
+			c1 = c
+			break
+		}
+	}
+	require.NotNil(t, c1)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	var sawDrainingAfterDrain atomic.Bool
+
+	// Concurrently call Get and GetForCR
+	for range 5 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					got, err := cm.Get("dataplane/prod")
+					if err == nil && c1.IsDraining() && got.ID == id1 {
+						sawDrainingAfterDrain.Store(true)
+					}
+					gotCR, err := cm.GetForCR("dataplane/prod", "ns/dp1")
+					if err == nil && c1.IsDraining() && gotCR.ID == id1 {
+						sawDrainingAfterDrain.Store(true)
+					}
+				}
+			}
+		}()
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	err = cm.DrainConnection(c1, goAway)
+	require.NoError(t, err)
+	assert.True(t, c1.IsDraining())
+
+	// Run selections while c1 is drained to verify only c2 is picked
+	for range 50 {
+		got, err := cm.Get("dataplane/prod")
+		require.NoError(t, err)
+		assert.Equal(t, id2, got.ID)
+
+		gotCR, err := cm.GetForCR("dataplane/prod", "ns/dp1")
+		require.NoError(t, err)
+		assert.Equal(t, id2, gotCR.ID)
+	}
+
+	close(stop)
+	wg.Wait()
+
+	assert.False(t, sawDrainingAfterDrain.Load(), "selection must never return a connection after it has begun draining")
 }

--- a/internal/cluster-gateway/server.go
+++ b/internal/cluster-gateway/server.go
@@ -497,7 +497,7 @@ func (s *Server) drainAgentConnections(ctx context.Context, window time.Duration
 	spreadFully := true
 	for i, conn := range conns {
 		if goAway != nil {
-			if err := conn.SendRawMessage(goAway); err != nil {
+			if err := s.connMgr.DrainConnection(conn, goAway); err != nil {
 				s.logger.Debug("failed to send GOAWAY", "connectionID", conn.ID, "error", err)
 			}
 		}
@@ -1546,7 +1546,13 @@ func (s *Server) rebalanceOnce() {
 		return
 	}
 
-	local := s.connMgr.GetAll()
+	allLocal := s.connMgr.GetAll()
+	var local []*AgentConnection
+	for _, c := range allLocal {
+		if !c.IsDraining() {
+			local = append(local, c)
+		}
+	}
 	// Peers' connections, from the replicated registry. Excludes draining
 	// owners, so a fleet mid-rollout is measured against pods that will
 	// actually still be there.
@@ -1600,7 +1606,7 @@ func (s *Server) rebalanceOnce() {
 
 	for i := 0; i < shed && i < len(local); i++ {
 		conn := local[i]
-		if err := conn.SendRawMessage(goAway); err != nil {
+		if err := s.connMgr.DrainConnection(conn, goAway); err != nil {
 			s.logger.Debug("failed to send rebalance GOAWAY", "connectionID", conn.ID, "error", err)
 			continue
 		}

--- a/internal/cluster-gateway/server_test.go
+++ b/internal/cluster-gateway/server_test.go
@@ -862,6 +862,7 @@ type mockGatewayConn struct {
 	readIndex    int
 	writtenMsgs  [][]byte
 	closed       bool
+	writeErr     error
 }
 
 func (m *mockGatewayConn) ReadMessage() (int, []byte, error) {
@@ -878,6 +879,9 @@ func (m *mockGatewayConn) ReadMessage() (int, []byte, error) {
 func (m *mockGatewayConn) WriteMessage(_ int, data []byte) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.writeErr != nil {
+		return m.writeErr
+	}
 	m.writtenMsgs = append(m.writtenMsgs, data)
 	return nil
 }
@@ -2407,6 +2411,73 @@ func TestServer_RebalanceSkippedWithoutMesh(t *testing.T) {
 	s.rebalanceOnce()
 
 	assert.Zero(t, countGoAways(conns), "a meshless gateway has no fleet to balance against")
+}
+
+func TestServer_Rebalance_MarksConnectionsDraining(t *testing.T) {
+	peers := map[string]int{"gw-b": 1, "gw-c": 1}
+	s, conns := rebalanceSetup(t, 10, peers)
+
+	// Simulate send failure on one candidate to test that failed-write candidates remain non-draining and selectable
+	conns[0].writeErr = fmt.Errorf("simulated send error")
+
+	s.rebalanceOnce()
+
+	allConns := s.connMgr.GetAll()
+	require.Len(t, allConns, 10)
+
+	var drainingCount, liveCount int
+	for _, ac := range allConns {
+		if ac.IsDraining() {
+			drainingCount++
+		} else {
+			liveCount++
+		}
+	}
+
+	// Out of rebalanceMaxShedPerCycle shedding attempts, 1 failed write remains live
+	assert.Equal(t, rebalanceMaxShedPerCycle-1, drainingCount, "successfully shed connections must be marked draining")
+	assert.Equal(t, 10-(rebalanceMaxShedPerCycle-1), liveCount, "unshed and failed-shed connections must remain live")
+
+	// Get and GetForCR must exclusively select from live connections (including the failed-write candidate)
+	selectedIDs := make(map[string]bool)
+	for range 20 {
+		got, err := s.connMgr.Get("dataplane/prod")
+		require.NoError(t, err)
+		assert.False(t, got.IsDraining(), "selected connection must not be draining")
+		selectedIDs[got.ID] = true
+
+		gotCR, err := s.connMgr.GetForCR("dataplane/prod", "ns/dp1")
+		require.NoError(t, err)
+		assert.False(t, gotCR.IsDraining(), "selected connection for CR must not be draining")
+	}
+
+	// Verify that the candidate whose write failed remained selectable
+	assert.True(t, selectedIDs[allConns[0].ID], "failed-write candidate must remain selectable")
+}
+
+func TestServer_DrainAgentConnections_MarksDraining(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().WithScheme(testScheme()).Build()
+	s := New(&Config{}, fakeClient, testLogger())
+
+	m1 := &mockGatewayConn{}
+	m2 := &mockGatewayConn{writeErr: fmt.Errorf("simulated send failure")}
+	id1, err := s.connMgr.Register("dataplane", "prod", m1, []string{"ns/dp1"}, nil, nil)
+	require.NoError(t, err)
+	id2, err := s.connMgr.Register("dataplane", "prod", m2, []string{"ns/dp1"}, nil, nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	s.drainAgentConnections(ctx, 10*time.Millisecond)
+
+	for _, ac := range s.connMgr.GetAll() {
+		if ac.ID == id1 {
+			assert.True(t, ac.IsDraining(), "successfully notified connection must be marked draining after GOAWAY")
+		} else if ac.ID == id2 {
+			assert.False(t, ac.IsDraining(), "connection with failed GOAWAY write must remain non-draining")
+		}
+	}
 }
 
 // A stale registry entry must not fail the request. The owner answers NoAgent


### PR DESCRIPTION
## Purpose
When the cluster gateway sends a `GOAWAY` frame to an agent (during pod shutdown in `drainAgentConnections` or load shedding in `rebalanceOnce`), the connection previously remained fully selectable by `ConnectionManager.Get` / `GetForCR` until the socket closed. Requests routed to an agent in this window failed with `"agent connection closed before responding"`.

This PR introduces a draining state on `AgentConnection` so connections that have received `GOAWAY` are excluded from selection when live candidates are available, while keeping them registered to process any in-flight responses.

Fixes #4582

## Approach
1. **AgentConnection Draining State**: Added `draining bool` with thread-safe `SetDraining()` and `IsDraining()` methods.
2. **Selection with preferLive**: Added a `preferLive()` helper used in `Get` and `GetForCR` that filters candidates down to live (non-draining) connections. If all candidates are draining, it falls back to returning all candidates rather than failing immediately mid-rollout.
3. **Marking Draining in Send Paths**:
   - In `drainAgentConnections`: Calls `conn.SetDraining()` immediately upon successfully sending `GOAWAY`.
   - In `rebalanceOnce`: Filters `local` to active connections when computing load/fair-share, and calls `conn.SetDraining()` upon shedding a connection.
4. **Preserved In-Flight Handling**: The connection remains registered in `ConnectionManager` until socket close so `pendingHTTPRequests` continue to correlate and deliver responses for requests already in flight.

## Related Issues
- Resolves #4582

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks
Comprehensive unit and integration tests added in `connection_manager_test.go` and `server_test.go`.