### PR TITLE
fix(api): authorize WorkflowRun updates using stored ownership

### DIFF
--- a/internal/openchoreo-api/services/workflowrun/service.go
+++ b/internal/openchoreo-api/services/workflowrun/service.go
@@ -139,6 +139,29 @@ func (s *workflowRunService) UpdateWorkflowRun(ctx context.Context, namespaceNam
 			return fmt.Errorf("failed to get workflow run: %w", err)
 		}
 
+		// The project/component labels are the ownership record for a WorkflowRun, so they
+		// are immutable after creation, same as spec.workflow.kind/name. A request that
+		// doesn't specify one of these labels at all carries over the stored value instead
+		// of being treated as clearing it, so callers that aren't aware of ownership labels
+		// (or that predate WorkflowRuns always carrying them) can still update other fields.
+		// A request that explicitly supplies a different value is rejected.
+		for _, key := range []string{ocLabels.LabelKeyProjectName, ocLabels.LabelKeyComponentName} {
+			existingValue := existing.Labels[key]
+			incomingValue, present := wfRun.Labels[key]
+			if !present {
+				if existingValue != "" {
+					if wfRun.Labels == nil {
+						wfRun.Labels = make(map[string]string, len(existing.Labels))
+					}
+					wfRun.Labels[key] = existingValue
+				}
+				continue
+			}
+			if incomingValue != existingValue {
+				return &services.ValidationError{Msg: fmt.Sprintf("label %s is immutable", key)}
+			}
+		}
+
 		// Only apply user-mutable fields to the existing object, preserving server-managed fields
 		existing.Labels = wfRun.Labels
 		existing.Annotations = wfRun.Annotations
@@ -150,6 +173,10 @@ func (s *workflowRunService) UpdateWorkflowRun(ctx context.Context, namespaceNam
 		if errors.Is(err, ErrWorkflowRunNotFound) {
 			s.logger.Warn("Workflow run not found", "namespace", namespaceName, "name", wfRun.Name)
 			return nil, ErrWorkflowRunNotFound
+		}
+		if vErr, ok := errors.AsType[*services.ValidationError](err); ok {
+			s.logger.Error("Workflow run update rejected by validation", "error", err)
+			return nil, vErr
 		}
 		if vErr := services.ExtractValidationError(err); vErr != nil {
 			s.logger.Error("Workflow run update rejected by validation", "error", err)

--- a/internal/openchoreo-api/services/workflowrun/service.go
+++ b/internal/openchoreo-api/services/workflowrun/service.go
@@ -117,6 +117,15 @@ func (s *workflowRunService) CreateWorkflowRun(ctx context.Context, namespaceNam
 	return wfRun, nil
 }
 
+// normalizeWorkflowRefKind returns kind with the CRD's default applied, so an omitted
+// kind compares equal to an explicit ClusterWorkflow.
+func normalizeWorkflowRefKind(kind openchoreov1alpha1.WorkflowRefKind) openchoreov1alpha1.WorkflowRefKind {
+	if kind == "" {
+		return openchoreov1alpha1.WorkflowRefKindClusterWorkflow
+	}
+	return kind
+}
+
 func (s *workflowRunService) UpdateWorkflowRun(ctx context.Context, namespaceName string, wfRun *openchoreov1alpha1.WorkflowRun) (*openchoreov1alpha1.WorkflowRun, error) {
 	if wfRun == nil {
 		return nil, fmt.Errorf("workflow run cannot be nil")
@@ -160,6 +169,14 @@ func (s *workflowRunService) UpdateWorkflowRun(ctx context.Context, namespaceNam
 			if incomingValue != existingValue {
 				return &services.ValidationError{Msg: fmt.Sprintf("label %s is immutable", key)}
 			}
+		}
+
+		// The referenced workflow is immutable after creation (spec.workflow.kind/name
+		// carry a CEL "self == oldSelf" rule at the CRD level); reject it here too so the
+		// request fails cleanly instead of relying solely on that CRD-level validation.
+		if wfRun.Spec.Workflow.Name != existing.Spec.Workflow.Name ||
+			normalizeWorkflowRefKind(wfRun.Spec.Workflow.Kind) != normalizeWorkflowRefKind(existing.Spec.Workflow.Kind) {
+			return &services.ValidationError{Msg: "spec.workflow.kind/name is immutable"}
 		}
 
 		// Only apply user-mutable fields to the existing object, preserving server-managed fields

--- a/internal/openchoreo-api/services/workflowrun/service.go
+++ b/internal/openchoreo-api/services/workflowrun/service.go
@@ -178,6 +178,9 @@ func (s *workflowRunService) UpdateWorkflowRun(ctx context.Context, namespaceNam
 			normalizeWorkflowRefKind(wfRun.Spec.Workflow.Kind) != normalizeWorkflowRefKind(existing.Spec.Workflow.Kind) {
 			return &services.ValidationError{Msg: "spec.workflow.kind/name is immutable"}
 		}
+		// The check above confirmed the kind is unchanged once normalized; persist the
+		// stored value so an omitted kind in the request doesn't clear it to "".
+		wfRun.Spec.Workflow.Kind = existing.Spec.Workflow.Kind
 
 		// Only apply user-mutable fields to the existing object, preserving server-managed fields
 		existing.Labels = wfRun.Labels

--- a/internal/openchoreo-api/services/workflowrun/service_authz.go
+++ b/internal/openchoreo-api/services/workflowrun/service_authz.go
@@ -88,14 +88,20 @@ func (s *workflowRunServiceWithAuthz) CreateWorkflowRun(ctx context.Context, nam
 }
 
 func (s *workflowRunServiceWithAuthz) UpdateWorkflowRun(ctx context.Context, namespaceName string, wfRun *openchoreov1alpha1.WorkflowRun) (*openchoreov1alpha1.WorkflowRun, error) {
+	// Fetch the existing workflow run to get owner info for authz, mirroring the pattern
+	// used by workload/service_authz.go and friends.
+	existing, err := s.internal.GetWorkflowRun(ctx, namespaceName, wfRun.Name)
+	if err != nil {
+		return nil, err
+	}
 	if err := s.authz.Check(ctx, services.CheckRequest{
 		Action:       authz.ActionUpdateWorkflowRun,
 		ResourceType: resourceTypeWorkflowRun,
-		ResourceID:   wfRun.Name,
-		Hierarchy:    constructHierarchyForAuthzCheck(namespaceName, wfRun.Labels),
+		ResourceID:   existing.Name,
+		Hierarchy:    constructHierarchyForAuthzCheck(namespaceName, existing.Labels),
 		Context: authz.Context{
 			Resource: authz.ResourceAttribute{
-				Workflow: formatWorkflowAttr(namespaceName, wfRun.Spec.Workflow.Kind, wfRun.Spec.Workflow.Name),
+				Workflow: formatWorkflowAttr(namespaceName, existing.Spec.Workflow.Kind, existing.Spec.Workflow.Name),
 			},
 		},
 	}); err != nil {

--- a/internal/openchoreo-api/services/workflowrun/service_authz.go
+++ b/internal/openchoreo-api/services/workflowrun/service_authz.go
@@ -88,6 +88,9 @@ func (s *workflowRunServiceWithAuthz) CreateWorkflowRun(ctx context.Context, nam
 }
 
 func (s *workflowRunServiceWithAuthz) UpdateWorkflowRun(ctx context.Context, namespaceName string, wfRun *openchoreov1alpha1.WorkflowRun) (*openchoreov1alpha1.WorkflowRun, error) {
+	if wfRun == nil {
+		return nil, fmt.Errorf("workflow run cannot be nil")
+	}
 	// Fetch the existing workflow run to get owner info for authz, mirroring the pattern
 	// used by workload/service_authz.go and friends.
 	existing, err := s.internal.GetWorkflowRun(ctx, namespaceName, wfRun.Name)

--- a/internal/openchoreo-api/services/workflowrun/service_authz_test.go
+++ b/internal/openchoreo-api/services/workflowrun/service_authz_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	authz "github.com/openchoreo/openchoreo/internal/authz/core"
@@ -186,8 +187,10 @@ func TestUpdateWorkflowRun_Authz(t *testing.T) {
 		mockSvc := wfrmocks.NewMockService(t)
 		mockPDP := authzmocks.NewMockPDP(t)
 
+		stored := newWorkflowRun(testRunName, testProjectName, testComponentName)
 		update := newWorkflowRun(testRunName, "", "")
 		update.Labels = map[string]string{"env": "prod"}
+		mockSvc.EXPECT().GetWorkflowRun(mock.Anything, testNamespace, testRunName).Return(stored, nil)
 		mockPDP.EXPECT().Evaluate(mock.Anything, mock.Anything).Return(allowDecision(), nil)
 		mockSvc.EXPECT().UpdateWorkflowRun(mock.Anything, testNamespace, update).Return(update, nil)
 
@@ -201,22 +204,46 @@ func TestUpdateWorkflowRun_Authz(t *testing.T) {
 		mockSvc := wfrmocks.NewMockService(t)
 		mockPDP := authzmocks.NewMockPDP(t)
 
+		stored := newWorkflowRun(testRunName, testProjectName, testComponentName)
 		update := newWorkflowRun(testRunName, "", "")
+		mockSvc.EXPECT().GetWorkflowRun(mock.Anything, testNamespace, testRunName).Return(stored, nil)
 		mockPDP.EXPECT().Evaluate(mock.Anything, mock.Anything).Return(denyDecision(), nil)
+		// mockSvc.UpdateWorkflowRun should NOT be called
 
 		svc := newAuthzService(t, mockSvc, mockPDP)
 		_, err := svc.UpdateWorkflowRun(ctxWithSubject(), testNamespace, update)
 		require.ErrorIs(t, err, services.ErrForbidden)
 	})
 
-	t.Run("checks correct action", func(t *testing.T) {
+	t.Run("not found does not check authz", func(t *testing.T) {
 		mockSvc := wfrmocks.NewMockService(t)
 		mockPDP := authzmocks.NewMockPDP(t)
 
-		update := newWorkflowRun(testRunName, "", "")
+		update := newWorkflowRun("nonexistent", "", "")
+		mockSvc.EXPECT().GetWorkflowRun(mock.Anything, testNamespace, "nonexistent").
+			Return(nil, workflowrun.ErrWorkflowRunNotFound)
+		// PDP.Evaluate should NOT be called
+
+		svc := newAuthzService(t, mockSvc, mockPDP)
+		_, err := svc.UpdateWorkflowRun(ctxWithSubject(), testNamespace, update)
+		require.ErrorIs(t, err, workflowrun.ErrWorkflowRunNotFound)
+	})
+
+	t.Run("checks correct action and hierarchy from stored labels, not request body", func(t *testing.T) {
+		mockSvc := wfrmocks.NewMockService(t)
+		mockPDP := authzmocks.NewMockPDP(t)
+
+		// Stored run belongs to proj-b/comp-b; the request body carries no labels at all
+		// (or different ones). Authz must be decided on the stored labels/workflow ref,
+		// never on what the caller submitted.
+		stored := newWorkflowRun(testRunName, "proj-b", "comp-b")
+		update := newWorkflowRun(testRunName, testProjectName, testComponentName)
+		mockSvc.EXPECT().GetWorkflowRun(mock.Anything, testNamespace, testRunName).Return(stored, nil)
 		mockPDP.EXPECT().Evaluate(mock.Anything, mock.MatchedBy(func(req *authz.EvaluateRequest) bool {
 			return req.Action == authz.ActionUpdateWorkflowRun &&
 				req.Resource.Type == workflowrun.ExportResourceType &&
+				req.Resource.Hierarchy.Project == "proj-b" &&
+				req.Resource.Hierarchy.Component == "comp-b" &&
 				req.Context.Resource.Workflow == testNamespace+"/"+testWorkflowName
 		})).Return(allowDecision(), nil)
 		mockSvc.EXPECT().UpdateWorkflowRun(mock.Anything, testNamespace, update).Return(update, nil)
@@ -702,4 +729,41 @@ func TestFormatWorkflowAttr(t *testing.T) {
 			require.Equal(t, tt.want, workflowrun.ExportFormatWorkflowAttr(tt.namespace, tt.kind, tt.wfName))
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// UpdateWorkflowRun end-to-end authz test (real internal service + fake k8s
+// client, so authz denial and object mutation can both be observed together).
+// ---------------------------------------------------------------------------
+
+func TestUpdateWorkflowRun_AuthzUsesStoredOwnership(t *testing.T) {
+	t.Run("caller without access to the stored owner cannot update by echoing different labels in the body", func(t *testing.T) {
+		stored := newWorkflowRun(testRunName, "proj-b", "comp-b")
+		fakeClient := testutil.NewFakeClient(stored)
+		internal := workflowrun.NewService(fakeClient, nil, nil, testutil.TestLogger())
+
+		mockPDP := authzmocks.NewMockPDP(t)
+		// PDP grants access to proj-a/comp-a only, not to the stored owner proj-b/comp-b.
+		mockPDP.EXPECT().Evaluate(mock.Anything, mock.MatchedBy(func(req *authz.EvaluateRequest) bool {
+			return req.Resource.Hierarchy.Project == testProjectName && req.Resource.Hierarchy.Component == testComponentName
+		})).Return(allowDecision(), nil).Maybe()
+		mockPDP.EXPECT().Evaluate(mock.Anything, mock.Anything).Return(denyDecision(), nil).Once()
+
+		svc := workflowrun.NewTestServiceWithAuthz(internal, fakeClient, mockPDP, testutil.TestLogger())
+
+		// The request body names the stored run but carries proj-a/comp-a labels, which
+		// the caller does have access to. Authz must be decided on the stored owner
+		// (proj-b/comp-b), not on what the body claims.
+		body := newWorkflowRun(testRunName, testProjectName, testComponentName)
+		body.Annotations = map[string]string{"caller": "proj-a"}
+
+		_, err := svc.UpdateWorkflowRun(ctxWithSubject(), testNamespace, body)
+		require.ErrorIs(t, err, services.ErrForbidden)
+
+		reread := &openchoreov1alpha1.WorkflowRun{}
+		require.NoError(t, fakeClient.Get(context.Background(), client.ObjectKey{Name: testRunName, Namespace: testNamespace}, reread))
+		assert.Equal(t, "proj-b", reread.Labels[ocLabels.LabelKeyProjectName])
+		assert.Equal(t, "comp-b", reread.Labels[ocLabels.LabelKeyComponentName])
+		assert.NotContains(t, reread.Annotations, "caller")
+	})
 }

--- a/internal/openchoreo-api/services/workflowrun/service_authz_test.go
+++ b/internal/openchoreo-api/services/workflowrun/service_authz_test.go
@@ -183,6 +183,17 @@ func TestCreateWorkflowRun_Authz(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestUpdateWorkflowRun_Authz(t *testing.T) {
+	t.Run("nil input returns error without calling the internal service", func(t *testing.T) {
+		mockSvc := wfrmocks.NewMockService(t)
+		mockPDP := authzmocks.NewMockPDP(t)
+		// Neither GetWorkflowRun nor Evaluate should be called.
+
+		svc := newAuthzService(t, mockSvc, mockPDP)
+		_, err := svc.UpdateWorkflowRun(ctxWithSubject(), testNamespace, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot be nil")
+	})
+
 	t.Run("allowed delegates to internal service", func(t *testing.T) {
 		mockSvc := wfrmocks.NewMockService(t)
 		mockPDP := authzmocks.NewMockPDP(t)

--- a/internal/openchoreo-api/services/workflowrun/service_test.go
+++ b/internal/openchoreo-api/services/workflowrun/service_test.go
@@ -142,6 +142,112 @@ func TestUpdateWorkflowRun(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "other-workflow", result.Spec.Workflow.Name)
 	})
+
+	t.Run("rejects changing the project/component ownership labels", func(t *testing.T) {
+		existing := testutil.NewWorkflowRun(testNamespace, testWorkflowName, testRunName)
+		existing.Labels = map[string]string{
+			ocLabels.LabelKeyProjectName:   "proj-a",
+			ocLabels.LabelKeyComponentName: "comp-a",
+		}
+		svc := newService(t, existing)
+
+		update := testutil.NewWorkflowRun(testNamespace, testWorkflowName, testRunName)
+		update.Labels = map[string]string{
+			ocLabels.LabelKeyProjectName:   "proj-b",
+			ocLabels.LabelKeyComponentName: "comp-b",
+		}
+
+		_, err := svc.UpdateWorkflowRun(ctx, testNamespace, update)
+		var vErr *services.ValidationError
+		require.ErrorAs(t, err, &vErr)
+
+		stored := &openchoreov1alpha1.WorkflowRun{}
+		require.NoError(t, svc.(*workflowRunService).k8sClient.Get(ctx, client.ObjectKey{Name: testRunName, Namespace: testNamespace}, stored))
+		assert.Equal(t, "proj-a", stored.Labels[ocLabels.LabelKeyProjectName])
+		assert.Equal(t, "comp-a", stored.Labels[ocLabels.LabelKeyComponentName])
+	})
+
+	t.Run("reuses stored ownership labels when the request omits them entirely", func(t *testing.T) {
+		existing := testutil.NewWorkflowRun(testNamespace, testWorkflowName, testRunName)
+		existing.Labels = map[string]string{
+			ocLabels.LabelKeyProjectName:   "proj-a",
+			ocLabels.LabelKeyComponentName: "comp-a",
+		}
+		svc := newService(t, existing)
+
+		update := testutil.NewWorkflowRun(testNamespace, testWorkflowName, testRunName)
+		// Labels intentionally left nil, as a caller unaware of ownership labels would.
+		update.Annotations = map[string]string{"note": "updated"}
+
+		result, err := svc.UpdateWorkflowRun(ctx, testNamespace, update)
+		require.NoError(t, err)
+		assert.Equal(t, "proj-a", result.Labels[ocLabels.LabelKeyProjectName])
+		assert.Equal(t, "comp-a", result.Labels[ocLabels.LabelKeyComponentName])
+		assert.Equal(t, "updated", result.Annotations["note"])
+	})
+
+	t.Run("reuses stored ownership label when the request omits only one of them", func(t *testing.T) {
+		existing := testutil.NewWorkflowRun(testNamespace, testWorkflowName, testRunName)
+		existing.Labels = map[string]string{
+			ocLabels.LabelKeyProjectName:   "proj-a",
+			ocLabels.LabelKeyComponentName: "comp-a",
+		}
+		svc := newService(t, existing)
+
+		update := testutil.NewWorkflowRun(testNamespace, testWorkflowName, testRunName)
+		update.Labels = map[string]string{
+			ocLabels.LabelKeyProjectName: "proj-a",
+			// component label omitted
+		}
+
+		result, err := svc.UpdateWorkflowRun(ctx, testNamespace, update)
+		require.NoError(t, err)
+		assert.Equal(t, "proj-a", result.Labels[ocLabels.LabelKeyProjectName])
+		assert.Equal(t, "comp-a", result.Labels[ocLabels.LabelKeyComponentName])
+	})
+
+	t.Run("rejects adding ownership labels to a previously-standalone run", func(t *testing.T) {
+		// No project/component labels stored at all (a standalone run).
+		existing := testutil.NewWorkflowRun(testNamespace, testWorkflowName, testRunName)
+		svc := newService(t, existing)
+
+		update := testutil.NewWorkflowRun(testNamespace, testWorkflowName, testRunName)
+		update.Labels = map[string]string{
+			ocLabels.LabelKeyProjectName:   "proj-a",
+			ocLabels.LabelKeyComponentName: "comp-a",
+		}
+
+		_, err := svc.UpdateWorkflowRun(ctx, testNamespace, update)
+		var vErr *services.ValidationError
+		require.ErrorAs(t, err, &vErr)
+
+		stored := &openchoreov1alpha1.WorkflowRun{}
+		require.NoError(t, svc.(*workflowRunService).k8sClient.Get(ctx, client.ObjectKey{Name: testRunName, Namespace: testNamespace}, stored))
+		assert.Empty(t, stored.Labels[ocLabels.LabelKeyProjectName])
+		assert.Empty(t, stored.Labels[ocLabels.LabelKeyComponentName])
+	})
+
+	t.Run("positive control: matching labels with other field changes succeeds", func(t *testing.T) {
+		existing := testutil.NewWorkflowRun(testNamespace, testWorkflowName, testRunName)
+		existing.Labels = map[string]string{
+			ocLabels.LabelKeyProjectName:   "proj-a",
+			ocLabels.LabelKeyComponentName: "comp-a",
+		}
+		svc := newService(t, existing)
+
+		update := testutil.NewWorkflowRun(testNamespace, testWorkflowName, testRunName)
+		update.Labels = map[string]string{
+			ocLabels.LabelKeyProjectName:   "proj-a",
+			ocLabels.LabelKeyComponentName: "comp-a",
+		}
+		update.Annotations = map[string]string{"note": "updated"}
+
+		result, err := svc.UpdateWorkflowRun(ctx, testNamespace, update)
+		require.NoError(t, err)
+		assert.Equal(t, "updated", result.Annotations["note"])
+		assert.Equal(t, "proj-a", result.Labels[ocLabels.LabelKeyProjectName])
+		assert.Equal(t, "comp-a", result.Labels[ocLabels.LabelKeyComponentName])
+	})
 }
 
 func TestListWorkflowRuns(t *testing.T) {

--- a/internal/openchoreo-api/services/workflowrun/service_test.go
+++ b/internal/openchoreo-api/services/workflowrun/service_test.go
@@ -136,11 +136,52 @@ func TestUpdateWorkflowRun(t *testing.T) {
 		svc := newService(t, existing)
 
 		update := testutil.NewWorkflowRun(testNamespace, testWorkflowName, testRunName)
-		update.Spec.Workflow.Name = "other-workflow"
+		update.Spec.Workflow.Parameters = &runtime.RawExtension{Raw: []byte(`{"foo":"bar"}`)}
 
 		result, err := svc.UpdateWorkflowRun(ctx, testNamespace, update)
 		require.NoError(t, err)
-		assert.Equal(t, "other-workflow", result.Spec.Workflow.Name)
+		assert.Equal(t, `{"foo":"bar"}`, string(result.Spec.Workflow.Parameters.Raw))
+	})
+
+	t.Run("rejects changing the referenced workflow name", func(t *testing.T) {
+		existing := testutil.NewWorkflowRun(testNamespace, testWorkflowName, testRunName)
+		svc := newService(t, existing)
+
+		update := testutil.NewWorkflowRun(testNamespace, "other-workflow", testRunName)
+
+		_, err := svc.UpdateWorkflowRun(ctx, testNamespace, update)
+		var vErr *services.ValidationError
+		require.ErrorAs(t, err, &vErr)
+
+		stored := &openchoreov1alpha1.WorkflowRun{}
+		require.NoError(t, svc.(*workflowRunService).k8sClient.Get(ctx, client.ObjectKey{Name: testRunName, Namespace: testNamespace}, stored))
+		assert.Equal(t, testWorkflowName, stored.Spec.Workflow.Name)
+	})
+
+	t.Run("rejects changing the referenced workflow kind", func(t *testing.T) {
+		existing := testutil.NewWorkflowRun(testNamespace, testWorkflowName, testRunName)
+		existing.Spec.Workflow.Kind = openchoreov1alpha1.WorkflowRefKindWorkflow
+		svc := newService(t, existing)
+
+		update := testutil.NewWorkflowRun(testNamespace, testWorkflowName, testRunName)
+		update.Spec.Workflow.Kind = openchoreov1alpha1.WorkflowRefKindClusterWorkflow
+
+		_, err := svc.UpdateWorkflowRun(ctx, testNamespace, update)
+		var vErr *services.ValidationError
+		require.ErrorAs(t, err, &vErr)
+	})
+
+	t.Run("tolerates an omitted kind that normalizes to the stored value", func(t *testing.T) {
+		existing := testutil.NewWorkflowRun(testNamespace, testWorkflowName, testRunName)
+		existing.Spec.Workflow.Kind = openchoreov1alpha1.WorkflowRefKindClusterWorkflow
+		svc := newService(t, existing)
+
+		update := testutil.NewWorkflowRun(testNamespace, testWorkflowName, testRunName)
+		update.Spec.Workflow.Kind = "" // omitted by the caller, normalizes to ClusterWorkflow
+
+		result, err := svc.UpdateWorkflowRun(ctx, testNamespace, update)
+		require.NoError(t, err)
+		assert.Equal(t, testWorkflowName, result.Spec.Workflow.Name)
 	})
 
 	t.Run("rejects changing the project/component ownership labels", func(t *testing.T) {

--- a/internal/openchoreo-api/services/workflowrun/service_test.go
+++ b/internal/openchoreo-api/services/workflowrun/service_test.go
@@ -182,6 +182,11 @@ func TestUpdateWorkflowRun(t *testing.T) {
 		result, err := svc.UpdateWorkflowRun(ctx, testNamespace, update)
 		require.NoError(t, err)
 		assert.Equal(t, testWorkflowName, result.Spec.Workflow.Name)
+		assert.Equal(t, openchoreov1alpha1.WorkflowRefKindClusterWorkflow, result.Spec.Workflow.Kind)
+
+		stored := &openchoreov1alpha1.WorkflowRun{}
+		require.NoError(t, svc.(*workflowRunService).k8sClient.Get(ctx, client.ObjectKey{Name: testRunName, Namespace: testNamespace}, stored))
+		assert.Equal(t, openchoreov1alpha1.WorkflowRefKindClusterWorkflow, stored.Spec.Workflow.Kind)
 	})
 
 	t.Run("rejects changing the project/component ownership labels", func(t *testing.T) {


### PR DESCRIPTION
## Purpose

`UpdateWorkflowRun` authorized requests using the project/component labels and workflow reference from the request body, instead of the values on the stored `WorkflowRun`. This meant authorization could be evaluated against a hierarchy the caller doesn't actually own. It also allowed the project/component ownership labels to be changed freely on update, with no immutability guard.

## Approach

- `service_authz.go`: `UpdateWorkflowRun` now fetches the existing run first and builds the authz hierarchy and workflow attribute from its stored labels/spec, matching the existing pattern in `workload`, `releasebinding`, `projectreleasebinding`, and `resourcereleasebinding`.
- `service.go`: the project/component labels are now immutable on update, consistent with `spec.workflow.kind`/`name`. A request that omits these labels reuses the stored values (backward compatible for callers that don't send them), while a request that explicitly supplies a different value — or that adds ownership labels to a previously standalone run — is rejected.

## Related Issues

N/A

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [ ] This PR includes AI-generated code or content

## Remarks

No API-type or OpenAPI-spec changes; `make code.gen` is a no-op for this change.
