### PR TITLE
fix(controller): re-enqueue RenderedRelease when its DataPlane is repointed

### DIFF
--- a/internal/controller/renderedrelease/controller.go
+++ b/internal/controller/renderedrelease/controller.go
@@ -17,8 +17,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	kubernetesClient "github.com/openchoreo/openchoreo/internal/clients/kubernetes"
@@ -665,10 +668,23 @@ func addJitter(base time.Duration, maxJitter time.Duration) time.Duration {
 	return base + jitter
 }
 
-// SetupWithManager sets up the controller with the Manager.
+// SetupWithManager sets up the controller with the Manager. Watches on
+// DataPlane / ClusterDataPlane recover a repointed data plane: the release
+// resolves its plane client from the referenced Environment at apply time,
+// but without these handlers nothing re-enqueues it when that resolution
+// changes to a different physical cluster. Filtered to generation changes
+// (spec, where planeID lives) so the DataPlane controller's frequent
+// status-only heartbeat updates don't inflate the reconcile/remote-apply
+// cadence for every release tied to that data plane.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&openchoreov1alpha1.RenderedRelease{}).
+		Watches(&openchoreov1alpha1.DataPlane{},
+			handler.EnqueueRequestsFromMapFunc(r.releasesForDataPlane),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(&openchoreov1alpha1.ClusterDataPlane{},
+			handler.EnqueueRequestsFromMapFunc(r.releasesForClusterDataPlane),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Named("renderedrelease").
 		Complete(r)
 }

--- a/internal/controller/renderedrelease/controller_watch.go
+++ b/internal/controller/renderedrelease/controller_watch.go
@@ -1,0 +1,100 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package renderedrelease
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+// Reconcile resolves the target plane client from the RenderedRelease's
+// EnvironmentName at apply time (see getDPClient/getOPClient), but this
+// controller only watches RenderedRelease itself. Repointing a DataPlane
+// (or ClusterDataPlane) to a different physical cluster leaves the rendered
+// manifests byte-identical, so the owning ProjectReleaseBinding's re-render
+// is a no-op and never produces an event here. Without the handlers below,
+// the release only picks up the new plane client on its next periodic
+// requeue (or never, if Spec.Interval disables it), leaving the namespace
+// and workloads never (re)created on the new cluster. This closes that loop.
+
+// releasesForDataPlane re-enqueues every RenderedRelease in the DataPlane's
+// namespace whose referenced Environment uses this DataPlane.
+func (r *Reconciler) releasesForDataPlane(ctx context.Context, obj client.Object) []reconcile.Request {
+	dp := obj.(*openchoreov1alpha1.DataPlane)
+	return r.releasesForReferencedEnvironments(ctx, dp.Namespace, func(env *openchoreov1alpha1.Environment) bool {
+		ref := env.Spec.DataPlaneRef
+		return ref != nil &&
+			ref.Kind != openchoreov1alpha1.DataPlaneRefKindClusterDataPlane &&
+			ref.Name == dp.Name
+	})
+}
+
+// releasesForClusterDataPlane re-enqueues every RenderedRelease (cluster-wide)
+// whose referenced Environment uses this ClusterDataPlane.
+func (r *Reconciler) releasesForClusterDataPlane(ctx context.Context, obj client.Object) []reconcile.Request {
+	cdp := obj.(*openchoreov1alpha1.ClusterDataPlane)
+	return r.releasesForReferencedEnvironments(ctx, "", func(env *openchoreov1alpha1.Environment) bool {
+		ref := env.Spec.DataPlaneRef
+		return ref != nil &&
+			ref.Kind == openchoreov1alpha1.DataPlaneRefKindClusterDataPlane &&
+			ref.Name == cdp.Name
+	})
+}
+
+// releasesForReferencedEnvironments lists Environments in `namespace` (or
+// cluster-wide if empty) whose spec matches the predicate, then enqueues
+// every RenderedRelease whose spec.environmentName points to one of those
+// envs in the env's own namespace.
+func (r *Reconciler) releasesForReferencedEnvironments(
+	ctx context.Context,
+	namespace string,
+	match func(*openchoreov1alpha1.Environment) bool,
+) []reconcile.Request {
+	envListOpts := []client.ListOption{}
+	if namespace != "" {
+		envListOpts = append(envListOpts, client.InNamespace(namespace))
+	}
+	envs := &openchoreov1alpha1.EnvironmentList{}
+	if err := r.List(ctx, envs, envListOpts...); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to list Environments for RenderedRelease watch")
+		return nil
+	}
+
+	type nsenv struct {
+		namespace string
+		name      string
+	}
+	matched := make(map[nsenv]struct{})
+	for i := range envs.Items {
+		e := &envs.Items[i]
+		if match(e) {
+			matched[nsenv{namespace: e.Namespace, name: e.Name}] = struct{}{}
+		}
+	}
+	if len(matched) == 0 {
+		return nil
+	}
+
+	releases := &openchoreov1alpha1.RenderedReleaseList{}
+	if err := r.List(ctx, releases, envListOpts...); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to list RenderedReleases for RenderedRelease watch")
+		return nil
+	}
+	var requests []reconcile.Request
+	for i := range releases.Items {
+		rel := &releases.Items[i]
+		if _, ok := matched[nsenv{namespace: rel.Namespace, name: rel.Spec.EnvironmentName}]; ok {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: rel.Name, Namespace: rel.Namespace},
+			})
+		}
+	}
+	return requests
+}

--- a/internal/controller/renderedrelease/controller_watch_test.go
+++ b/internal/controller/renderedrelease/controller_watch_test.go
@@ -1,0 +1,141 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package renderedrelease
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+// ─────────────────────────────────────────────────────────────
+// releasesForDataPlane / releasesForClusterDataPlane
+// ─────────────────────────────────────────────────────────────
+
+func TestReleasesForDataPlane(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := openchoreov1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+
+	dataPlane := &openchoreov1alpha1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "dp-a", Namespace: "ns1"},
+	}
+	envOnDP := &openchoreov1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "ns1"},
+		Spec: openchoreov1alpha1.EnvironmentSpec{
+			DataPlaneRef: &openchoreov1alpha1.DataPlaneRef{
+				Kind: openchoreov1alpha1.DataPlaneRefKindDataPlane,
+				Name: "dp-a",
+			},
+		},
+	}
+	envOnOtherDP := &openchoreov1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env-2", Namespace: "ns1"},
+		Spec: openchoreov1alpha1.EnvironmentSpec{
+			DataPlaneRef: &openchoreov1alpha1.DataPlaneRef{
+				Kind: openchoreov1alpha1.DataPlaneRefKindDataPlane,
+				Name: "dp-b",
+			},
+		},
+	}
+	releaseOnEnv1 := &openchoreov1alpha1.RenderedRelease{
+		ObjectMeta: metav1.ObjectMeta{Name: "rel-1", Namespace: "ns1"},
+		Spec:       openchoreov1alpha1.RenderedReleaseSpec{EnvironmentName: "env-1"},
+	}
+	releaseOnEnv2 := &openchoreov1alpha1.RenderedRelease{
+		ObjectMeta: metav1.ObjectMeta{Name: "rel-2", Namespace: "ns1"},
+		Spec:       openchoreov1alpha1.RenderedReleaseSpec{EnvironmentName: "env-2"},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(dataPlane, envOnDP, envOnOtherDP, releaseOnEnv1, releaseOnEnv2).
+		Build()
+	r := &Reconciler{Client: fakeClient}
+
+	requests := r.releasesForDataPlane(context.Background(), dataPlane)
+	if len(requests) != 1 {
+		t.Fatalf("expected 1 request, got %d: %+v", len(requests), requests)
+	}
+	if requests[0].Name != "rel-1" || requests[0].Namespace != "ns1" {
+		t.Errorf("expected rel-1/ns1, got %+v", requests[0])
+	}
+}
+
+func TestReleasesForClusterDataPlane(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := openchoreov1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+
+	cdp := &openchoreov1alpha1.ClusterDataPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "cdp-a"},
+	}
+	envOnCDP := &openchoreov1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env-1", Namespace: "ns1"},
+		Spec: openchoreov1alpha1.EnvironmentSpec{
+			DataPlaneRef: &openchoreov1alpha1.DataPlaneRef{
+				Kind: openchoreov1alpha1.DataPlaneRefKindClusterDataPlane,
+				Name: "cdp-a",
+			},
+		},
+	}
+	// Same name as the ClusterDataPlane but scoped to a namespaced DataPlane instead;
+	// must not match since Kind differs.
+	envOnDP := &openchoreov1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env-2", Namespace: "ns1"},
+		Spec: openchoreov1alpha1.EnvironmentSpec{
+			DataPlaneRef: &openchoreov1alpha1.DataPlaneRef{
+				Kind: openchoreov1alpha1.DataPlaneRefKindDataPlane,
+				Name: "cdp-a",
+			},
+		},
+	}
+	releaseOnEnv1 := &openchoreov1alpha1.RenderedRelease{
+		ObjectMeta: metav1.ObjectMeta{Name: "rel-1", Namespace: "ns1"},
+		Spec:       openchoreov1alpha1.RenderedReleaseSpec{EnvironmentName: "env-1"},
+	}
+	releaseOnEnv2 := &openchoreov1alpha1.RenderedRelease{
+		ObjectMeta: metav1.ObjectMeta{Name: "rel-2", Namespace: "ns1"},
+		Spec:       openchoreov1alpha1.RenderedReleaseSpec{EnvironmentName: "env-2"},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(cdp, envOnCDP, envOnDP, releaseOnEnv1, releaseOnEnv2).
+		Build()
+	r := &Reconciler{Client: fakeClient}
+
+	requests := r.releasesForClusterDataPlane(context.Background(), cdp)
+	if len(requests) != 1 {
+		t.Fatalf("expected 1 request, got %d: %+v", len(requests), requests)
+	}
+	if requests[0].Name != "rel-1" || requests[0].Namespace != "ns1" {
+		t.Errorf("expected rel-1/ns1, got %+v", requests[0])
+	}
+}
+
+func TestReleasesForDataPlaneNoMatchingEnvironment(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := openchoreov1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+
+	dataPlane := &openchoreov1alpha1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "dp-unreferenced", Namespace: "ns1"},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(dataPlane).Build()
+	r := &Reconciler{Client: fakeClient}
+
+	requests := r.releasesForDataPlane(context.Background(), dataPlane)
+	if len(requests) != 0 {
+		t.Errorf("expected no requests, got %+v", requests)
+	}
+}


### PR DESCRIPTION
## Purpose
Repointing a namespace-scoped `DataPlane` object to a different physical cluster (with the `Environment`'s `DataPlaneRef` unchanged) never created the project's namespace on the new cluster. `ProjectReleaseBinding` stayed stale `Ready=True` while downstream component `ReleaseBinding`s failed with `namespaces "dp-<...>" not found` — deadlocked until an operator forced a reconcile.

## Approach
`ProjectReleaseBinding` already watches `DataPlane`/`ClusterDataPlane` and re-renders on a repoint, but the rendered manifest content (namespace name, resources) never depends on which physical cluster a `DataPlane` points to, so its `CreateOrUpdate` on the owned `RenderedRelease` is a no-op and fires no `Update` event. The `RenderedRelease` controller performs the actual apply against a plane client resolved fresh from the `Environment` on every reconcile, but it only watched `RenderedRelease` itself, so a repoint went unnoticed until its own periodic timer (~5-6 min) happened to fire.

This adds `Watches()` on `DataPlane` and `ClusterDataPlane` to the `RenderedRelease` controller's `SetupWithManager`, mirroring the existing mapper pattern in `projectreleasebinding/controller_watch.go`, so a repoint promptly re-triggers the release to re-resolve its plane client and apply all resources (including the namespace) to the new cluster. The watch is filtered to `GenerationChangedPredicate` so the `DataPlane` controller's frequent status-only connection-heartbeat updates don't inflate the reconcile/remote-apply cadence for every release tied to that data plane. Because `ProjectReleaseBinding` already `Owns(&RenderedRelease{})`, the resulting status update also re-triggers it, fixing the stale `Ready=True` readiness reporting.

**Validation performed:**
- `go build ./...` passes.
- `go vet ./internal/controller/renderedrelease/... ./internal/controller/projectreleasebinding/...` is clean.
- Added `internal/controller/renderedrelease/controller_watch_test.go` covering the new mapper functions (match by `DataPlane`, by `ClusterDataPlane`, and no-match).
- Full envtest suites for both affected packages pass with no regressions.
- `golangci-lint run ./internal/controller/renderedrelease/...` reports 0 issues; `gofmt -l` is clean.
- `make manifests` produces no diff — the aggregated ClusterRole already grants the needed verbs via other controllers' existing RBAC markers.
- **Disclosed limitation**: did not run a full multi-cluster e2e repro (would need two live plane clusters); the mapper logic and the reconcile's existing per-call plane-client resolution are covered by the envtest suites and unit tests above.

## Related Issues
Fixes https://github.com/openchoreo/openchoreo/issues/4622

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks
None.

Fixes #4622