### PR TITLE
refactor: replace GET method API in Observer used to fetch span details with a POST method API Backport to release-v1.1) (#4546)

### DIFF
--- a/cmd/observer/main.go
+++ b/cmd/observer/main.go
@@ -280,7 +280,7 @@ func main() {
 	api.HandleFunc("POST /api/v1alpha1/metrics/runtime-topology", newAPIHandler.QueryRuntimeTopology)
 	api.HandleFunc("POST /api/v1alpha1/traces/query", newAPIHandler.QueryTraces)
 	api.HandleFunc("POST /api/v1alpha1/traces/{traceId}/spans/query", newAPIHandler.QuerySpansForTrace)
-	api.HandleFunc("GET /api/v1alpha1/traces/{traceId}/spans/{spanId}", newAPIHandler.GetSpanDetailsForTrace)
+	api.HandleFunc("POST /api/v1alpha1/traces/{traceId}/spans/{spanId}", newAPIHandler.QuerySpanDetailsForTrace)
 	api.HandleFunc("POST /api/v1alpha1/alerts/query", newAPIHandler.QueryAlerts)
 	api.HandleFunc("POST /api/v1alpha1/incidents/query", newAPIHandler.QueryIncidents)
 	api.HandleFunc("PUT /api/v1alpha1/incidents/{incidentId}", newAPIHandler.UpdateIncident)

--- a/internal/observer/api/gen/client.gen.go
+++ b/internal/observer/api/gen/client.gen.go
@@ -150,8 +150,10 @@ type ClientInterface interface {
 
 	QuerySpansForTrace(ctx context.Context, traceId string, body QuerySpansForTraceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// GetSpanDetailsForTrace request
-	GetSpanDetailsForTrace(ctx context.Context, traceId string, spanId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// QuerySpanDetailsForTraceWithBody request with any body
+	QuerySpanDetailsForTraceWithBody(ctx context.Context, traceId string, spanId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	QuerySpanDetailsForTrace(ctx context.Context, traceId string, spanId string, body QuerySpanDetailsForTraceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// Health request
 	Health(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -445,8 +447,20 @@ func (c *Client) QuerySpansForTrace(ctx context.Context, traceId string, body Qu
 	return c.Client.Do(req)
 }
 
-func (c *Client) GetSpanDetailsForTrace(ctx context.Context, traceId string, spanId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewGetSpanDetailsForTraceRequest(c.Server, traceId, spanId)
+func (c *Client) QuerySpanDetailsForTraceWithBody(ctx context.Context, traceId string, spanId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewQuerySpanDetailsForTraceRequestWithBody(c.Server, traceId, spanId, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) QuerySpanDetailsForTrace(ctx context.Context, traceId string, spanId string, body QuerySpanDetailsForTraceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewQuerySpanDetailsForTraceRequest(c.Server, traceId, spanId, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1026,8 +1040,19 @@ func NewQuerySpansForTraceRequestWithBody(server string, traceId string, content
 	return req, nil
 }
 
-// NewGetSpanDetailsForTraceRequest generates requests for GetSpanDetailsForTrace
-func NewGetSpanDetailsForTraceRequest(server string, traceId string, spanId string) (*http.Request, error) {
+// NewQuerySpanDetailsForTraceRequest calls the generic QuerySpanDetailsForTrace builder with application/json body
+func NewQuerySpanDetailsForTraceRequest(server string, traceId string, spanId string, body QuerySpanDetailsForTraceJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewQuerySpanDetailsForTraceRequestWithBody(server, traceId, spanId, "application/json", bodyReader)
+}
+
+// NewQuerySpanDetailsForTraceRequestWithBody generates requests for QuerySpanDetailsForTrace with any type of body
+func NewQuerySpanDetailsForTraceRequestWithBody(server string, traceId string, spanId string, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -1059,10 +1084,12 @@ func NewGetSpanDetailsForTraceRequest(server string, traceId string, spanId stri
 		return nil, err
 	}
 
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	req, err := http.NewRequest("POST", queryURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -1198,8 +1225,10 @@ type ClientWithResponsesInterface interface {
 
 	QuerySpansForTraceWithResponse(ctx context.Context, traceId string, body QuerySpansForTraceJSONRequestBody, reqEditors ...RequestEditorFn) (*QuerySpansForTraceResp, error)
 
-	// GetSpanDetailsForTraceWithResponse request
-	GetSpanDetailsForTraceWithResponse(ctx context.Context, traceId string, spanId string, reqEditors ...RequestEditorFn) (*GetSpanDetailsForTraceResp, error)
+	// QuerySpanDetailsForTraceWithBodyWithResponse request with any body
+	QuerySpanDetailsForTraceWithBodyWithResponse(ctx context.Context, traceId string, spanId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*QuerySpanDetailsForTraceResp, error)
+
+	QuerySpanDetailsForTraceWithResponse(ctx context.Context, traceId string, spanId string, body QuerySpanDetailsForTraceJSONRequestBody, reqEditors ...RequestEditorFn) (*QuerySpanDetailsForTraceResp, error)
 
 	// HealthWithResponse request
 	HealthWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*HealthResp, error)
@@ -1537,7 +1566,7 @@ func (r QuerySpansForTraceResp) StatusCode() int {
 	return 0
 }
 
-type GetSpanDetailsForTraceResp struct {
+type QuerySpanDetailsForTraceResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *TraceSpanDetailsResponse
@@ -1548,7 +1577,7 @@ type GetSpanDetailsForTraceResp struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r GetSpanDetailsForTraceResp) Status() string {
+func (r QuerySpanDetailsForTraceResp) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1556,7 +1585,7 @@ func (r GetSpanDetailsForTraceResp) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r GetSpanDetailsForTraceResp) StatusCode() int {
+func (r QuerySpanDetailsForTraceResp) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -1796,13 +1825,21 @@ func (c *ClientWithResponses) QuerySpansForTraceWithResponse(ctx context.Context
 	return ParseQuerySpansForTraceResp(rsp)
 }
 
-// GetSpanDetailsForTraceWithResponse request returning *GetSpanDetailsForTraceResp
-func (c *ClientWithResponses) GetSpanDetailsForTraceWithResponse(ctx context.Context, traceId string, spanId string, reqEditors ...RequestEditorFn) (*GetSpanDetailsForTraceResp, error) {
-	rsp, err := c.GetSpanDetailsForTrace(ctx, traceId, spanId, reqEditors...)
+// QuerySpanDetailsForTraceWithBodyWithResponse request with arbitrary body returning *QuerySpanDetailsForTraceResp
+func (c *ClientWithResponses) QuerySpanDetailsForTraceWithBodyWithResponse(ctx context.Context, traceId string, spanId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*QuerySpanDetailsForTraceResp, error) {
+	rsp, err := c.QuerySpanDetailsForTraceWithBody(ctx, traceId, spanId, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseGetSpanDetailsForTraceResp(rsp)
+	return ParseQuerySpanDetailsForTraceResp(rsp)
+}
+
+func (c *ClientWithResponses) QuerySpanDetailsForTraceWithResponse(ctx context.Context, traceId string, spanId string, body QuerySpanDetailsForTraceJSONRequestBody, reqEditors ...RequestEditorFn) (*QuerySpanDetailsForTraceResp, error) {
+	rsp, err := c.QuerySpanDetailsForTrace(ctx, traceId, spanId, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseQuerySpanDetailsForTraceResp(rsp)
 }
 
 // HealthWithResponse request returning *HealthResp
@@ -2474,15 +2511,15 @@ func ParseQuerySpansForTraceResp(rsp *http.Response) (*QuerySpansForTraceResp, e
 	return response, nil
 }
 
-// ParseGetSpanDetailsForTraceResp parses an HTTP response from a GetSpanDetailsForTraceWithResponse call
-func ParseGetSpanDetailsForTraceResp(rsp *http.Response) (*GetSpanDetailsForTraceResp, error) {
+// ParseQuerySpanDetailsForTraceResp parses an HTTP response from a QuerySpanDetailsForTraceWithResponse call
+func ParseQuerySpanDetailsForTraceResp(rsp *http.Response) (*QuerySpanDetailsForTraceResp, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &GetSpanDetailsForTraceResp{
+	response := &QuerySpanDetailsForTraceResp{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/internal/observer/api/gen/models.gen.go
+++ b/internal/observer/api/gen/models.gen.go
@@ -984,6 +984,11 @@ type RuntimeTopologySummary struct {
 	StartTime   time.Time `json:"startTime"`
 }
 
+// TraceSpanDetailsRequest defines model for TraceSpanDetailsRequest.
+type TraceSpanDetailsRequest struct {
+	SearchScope ComponentSearchScope `json:"searchScope"`
+}
+
 // TraceSpanDetailsResponse defines model for TraceSpanDetailsResponse.
 type TraceSpanDetailsResponse struct {
 	Attributes *[]struct {
@@ -1173,6 +1178,9 @@ type QueryTracesJSONRequestBody = TracesQueryRequest
 
 // QuerySpansForTraceJSONRequestBody defines body for QuerySpansForTrace for application/json ContentType.
 type QuerySpansForTraceJSONRequestBody = TracesQueryRequest
+
+// QuerySpanDetailsForTraceJSONRequestBody defines body for QuerySpanDetailsForTrace for application/json ContentType.
+type QuerySpanDetailsForTraceJSONRequestBody = TraceSpanDetailsRequest
 
 // AsComponentSearchScope returns the union data inside the LogsQueryRequest_SearchScope as a ComponentSearchScope
 func (t LogsQueryRequest_SearchScope) AsComponentSearchScope() (ComponentSearchScope, error) {

--- a/internal/observer/api/gen/server.gen.go
+++ b/internal/observer/api/gen/server.gen.go
@@ -64,8 +64,8 @@ type ServerInterface interface {
 	// (POST /api/v1alpha1/traces/{traceId}/spans/query)
 	QuerySpansForTrace(w http.ResponseWriter, r *http.Request, traceId string)
 	// Get details of a span for a trace
-	// (GET /api/v1alpha1/traces/{traceId}/spans/{spanId})
-	GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request, traceId string, spanId string)
+	// (POST /api/v1alpha1/traces/{traceId}/spans/{spanId})
+	QuerySpanDetailsForTrace(w http.ResponseWriter, r *http.Request, traceId string, spanId string)
 	// Health check
 	// (GET /health)
 	Health(w http.ResponseWriter, r *http.Request)
@@ -427,8 +427,8 @@ func (siw *ServerInterfaceWrapper) QuerySpansForTrace(w http.ResponseWriter, r *
 	handler.ServeHTTP(w, r)
 }
 
-// GetSpanDetailsForTrace operation middleware
-func (siw *ServerInterfaceWrapper) GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request) {
+// QuerySpanDetailsForTrace operation middleware
+func (siw *ServerInterfaceWrapper) QuerySpanDetailsForTrace(w http.ResponseWriter, r *http.Request) {
 
 	var err error
 
@@ -457,7 +457,7 @@ func (siw *ServerInterfaceWrapper) GetSpanDetailsForTrace(w http.ResponseWriter,
 	r = r.WithContext(ctx)
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.GetSpanDetailsForTrace(w, r, traceId, spanId)
+		siw.Handler.QuerySpanDetailsForTrace(w, r, traceId, spanId)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -614,7 +614,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/metrics/runtime-topology", wrapper.QueryRuntimeTopology)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/traces/query", wrapper.QueryTraces)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/traces/{traceId}/spans/query", wrapper.QuerySpansForTrace)
-	m.HandleFunc("GET "+options.BaseURL+"/api/v1alpha1/traces/{traceId}/spans/{spanId}", wrapper.GetSpanDetailsForTrace)
+	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/traces/{traceId}/spans/{spanId}", wrapper.QuerySpanDetailsForTrace)
 	m.HandleFunc("GET "+options.BaseURL+"/health", wrapper.Health)
 
 	return m
@@ -1262,54 +1262,55 @@ func (response QuerySpansForTrace500JSONResponse) VisitQuerySpansForTraceRespons
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetSpanDetailsForTraceRequestObject struct {
+type QuerySpanDetailsForTraceRequestObject struct {
 	TraceId string `json:"traceId"`
 	SpanId  string `json:"spanId"`
+	Body    *QuerySpanDetailsForTraceJSONRequestBody
 }
 
-type GetSpanDetailsForTraceResponseObject interface {
-	VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error
+type QuerySpanDetailsForTraceResponseObject interface {
+	VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error
 }
 
-type GetSpanDetailsForTrace200JSONResponse TraceSpanDetailsResponse
+type QuerySpanDetailsForTrace200JSONResponse TraceSpanDetailsResponse
 
-func (response GetSpanDetailsForTrace200JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response QuerySpanDetailsForTrace200JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetSpanDetailsForTrace400JSONResponse ErrorResponse
+type QuerySpanDetailsForTrace400JSONResponse ErrorResponse
 
-func (response GetSpanDetailsForTrace400JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response QuerySpanDetailsForTrace400JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(400)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetSpanDetailsForTrace401JSONResponse ErrorResponse
+type QuerySpanDetailsForTrace401JSONResponse ErrorResponse
 
-func (response GetSpanDetailsForTrace401JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response QuerySpanDetailsForTrace401JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(401)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetSpanDetailsForTrace403JSONResponse ErrorResponse
+type QuerySpanDetailsForTrace403JSONResponse ErrorResponse
 
-func (response GetSpanDetailsForTrace403JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response QuerySpanDetailsForTrace403JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(403)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type GetSpanDetailsForTrace500JSONResponse ErrorResponse
+type QuerySpanDetailsForTrace500JSONResponse ErrorResponse
 
-func (response GetSpanDetailsForTrace500JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response QuerySpanDetailsForTrace500JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(500)
 
@@ -1388,8 +1389,8 @@ type StrictServerInterface interface {
 	// (POST /api/v1alpha1/traces/{traceId}/spans/query)
 	QuerySpansForTrace(ctx context.Context, request QuerySpansForTraceRequestObject) (QuerySpansForTraceResponseObject, error)
 	// Get details of a span for a trace
-	// (GET /api/v1alpha1/traces/{traceId}/spans/{spanId})
-	GetSpanDetailsForTrace(ctx context.Context, request GetSpanDetailsForTraceRequestObject) (GetSpanDetailsForTraceResponseObject, error)
+	// (POST /api/v1alpha1/traces/{traceId}/spans/{spanId})
+	QuerySpanDetailsForTrace(ctx context.Context, request QuerySpanDetailsForTraceRequestObject) (QuerySpanDetailsForTraceResponseObject, error)
 	// Health check
 	// (GET /health)
 	Health(ctx context.Context, request HealthRequestObject) (HealthResponseObject, error)
@@ -1828,26 +1829,33 @@ func (sh *strictHandler) QuerySpansForTrace(w http.ResponseWriter, r *http.Reque
 	}
 }
 
-// GetSpanDetailsForTrace operation middleware
-func (sh *strictHandler) GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request, traceId string, spanId string) {
-	var request GetSpanDetailsForTraceRequestObject
+// QuerySpanDetailsForTrace operation middleware
+func (sh *strictHandler) QuerySpanDetailsForTrace(w http.ResponseWriter, r *http.Request, traceId string, spanId string) {
+	var request QuerySpanDetailsForTraceRequestObject
 
 	request.TraceId = traceId
 	request.SpanId = spanId
 
+	var body QuerySpanDetailsForTraceJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
 	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.GetSpanDetailsForTrace(ctx, request.(GetSpanDetailsForTraceRequestObject))
+		return sh.ssi.QuerySpanDetailsForTrace(ctx, request.(QuerySpanDetailsForTraceRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "GetSpanDetailsForTrace")
+		handler = middleware(handler, "QuerySpanDetailsForTrace")
 	}
 
 	response, err := handler(r.Context(), w, r, request)
 
 	if err != nil {
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(GetSpanDetailsForTraceResponseObject); ok {
-		if err := validResponse.VisitGetSpanDetailsForTraceResponse(w); err != nil {
+	} else if validResponse, ok := response.(QuerySpanDetailsForTraceResponseObject); ok {
+		if err := validResponse.VisitQuerySpanDetailsForTraceResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
@@ -1882,106 +1890,107 @@ func (sh *strictHandler) Health(w http.ResponseWriter, r *http.Request) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+w97W7buJavQmgHaAMoTtpOF2gu9kcmzczk3k7aTdLbH+NgQ0u0zRuJVEnKqScIsA+x",
-	"T7hPsuCnKJmyJcdOszP+0yYRdXh4eL54eM7RfZTQvKAEEcGjo/uIJ1OUQ/XjcYaYuCgzdIG+logL+beC",
-	"0QIxgZEakVCSYoEpWXyECBxlKJU/pognDBd6XPRlisQUMSCmCEA5A2BlhgDmwL4SR2JeoOgoGlGaIUii",
-	"hzjCRCA2g9kivKspAvYpoGMgcI6AoOBridgcjGlzpgo8FwyTiYQuEYeCsjB0+1RCLTkKw0SkzKOj36OJ",
-	"iOJoIuSfMqH+UU+/RnFE0NfoOjC7mDLEpzRLw9O7x2AGsxItxcLAJmU+QkzCvsMkpXdhwPrZejR7iCOG",
-	"vpaYyS3+Paq2zkzo7ZhHXn+tFSXo6F8oERLbHAmYQgFDnGaY9DNuIdPHApGTKWWIAjcYfD5779YVxdGY",
-	"shyK6CgqS5yGGAGRGWaU5B0n8ob3norAHIUnkE/UrqzkWzmSFzBZAkg9XoQGTi5CAAtG5V50WbsZ2nPd",
+	"H4sIAAAAAAAC/+w97W7buJavQmgHaAMoTtpOF2gu9kcmzczk3k7bTdLbH+NgQ0u0zRuJVEnKqScIsA+x",
+	"T7hPsuCnKJmyJcdOsjP+0yYRdXh4eL54eM7RXZTQvKAEEcGjo7uIJ1OUQ/XjcYaYOC8zdI6+lYgL+beC",
+	"0QIxgZEakVCSYoEpWXyECBxlKJU/pognDBd6XPR1isQUMSCmCEA5A2BlhgDmwL4SR2JeoOgoGlGaIUii",
+	"+zjCRCA2g9kivMspAvYpoGMgcI6AoOBbidgcjGlzpgo8FwyTiYQuEYeCsjB0+1RCLTkKw0SkzKOj36OJ",
+	"iOJoIuSfMqH+UU+/RXFE0LfoKjC7mDLEpzRLw9O7x2AGsxItxcLAJmU+QkzCvsUkpbdhwPrZejS7jyOG",
+	"vpWYyS3+Paq2zkzo7ZhHXn+tFSXo6F8oERLbHAmYQgFDnGaY9AtuIdOnApGTKWWIAjcYfDl779YVxdGY",
+	"shyK6CgqS5yGGAGRGWaU5B0n8ob3norAHIUnkE/UrqzkWzmSFzBZAkg9XoQGTs5DAAtG5V50WbsZ2nPd",
 	"Db5RRPDXUUNhYT/iOh+EWIjTkml61BkoR4LhJLwq/awuAOZvI8hRqunGPSlPivK/Sg4nEuEc5ZTN3a+j",
-	"Mp0gERR0TaMgCnpiQQH6hpJSaPHO6KSJwKLyUH8I6o154TbeUKVaQEYnCnVFlCVIN/ZLPV0ke2OUE2O3",
-	"HbFnKkK75pkaXlDC0c7W7GyNx4M7S/FXtBQ75b515b6oyMO6+QsaTSm9bT0JqDVc4RxxAfOiBWf7uMZk",
-	"PiekUKB9OSxEDDX6n1IthcFrjdUAvaCkJEufb0CgLJz1hKobu9cp32YYc8QVd7Zwv3pYx+BOgwwtiwso",
-	"Sh6GpZ+1gbLMx8skQVzJE2OUdWI7s1RMJtIHuJyTpH25MLFOwCKG+hkQ8BYRIH9os5wJQ1Ao818Wqf2J",
-	"JFNIJurnFGVI/jUk6BnkQqKI0mPRkdHlK4DPSdLGST/B5BaR9KxFmY70Y3D2HryUWnTMaA7oiEtHZIQz",
-	"LOZ2yF537v1AJziBWducmX6s5pSc3BFyXwZqbAxXhJU6AeIsuAGt3MP/U6rZVg2FSCr1UxgzSVzlmBjc",
-	"FmzUUs2U4RwbVhjDMhPR0avDwzgkjfAbzsscaHUkJ8MC5VyaBoZEyYhU23qMgnEYRzkm5lc3sfRAJ1qb",
-	"cQRZMr1MqLYTPzA0jo6ifzuoYjoHJqBzcGL/dOm9o2wqEx9ZilhtAQr5KLQGOR5Q+UKTWHYPoXszKD9c",
-	"QG0qWpmEibU3o3ESqeaKHQPUqXa9ip1a9ZC22mHZwVxI7J1lV9vcAqNNALV8nL3ftC2soGCS4BQRcdr/",
-	"/JRQMsaTkqFUMq9geDJBDFiAHNxNEQFjtQ2hI1a7+w7tSXDFCXBxze6xQw6q30Lqpg54+YEPSWJqUO7s",
-	"9xINJgMwjF7lwygGw+htPoz2+p/2pJhChrnE0h78SukSSgexmrd55Mv8c9/Gj3xTKOyG8uW+1LIDnxJg",
-	"c+qTq4GTCUMTTUZLvbeGeq+mQeqFNH1totC83l+6n4we6wxyNEMMixb33z5davgwGdMoju4gIxJoHCUM",
-	"C2mAwzrUHYRCClo+6y0EHc5QjjX17/urji8rj0QOYEYn+5s5DOkVbvlIlMERyviS2EO3E4YbHlru6jiG",
-	"9AQDkPqELrrh6b2wbijEw7UOrVP0Q52iuuHqh5LbghbdIJnB6wQ/vNVWUHrHO0KcR6jAY5wooT6ZQkIM",
-	"HwaW4o0EiRlak5IBOM0LMQd4DLS3LU25em0+8H2WFQQPzNMuvhFkDM7V71sMFoQotzA/pbe/8SXGS58i",
-	"XdzI4cABJiDHWYY5kj6Hp6w8z1xQ0eZQqEfeGaCp8hyU0DKcG/+BTk6J0Pq1roUyNENZ66EO6MehYwyd",
-	"tL9lowyB93xnLmg71FN3FqYTgBTicX/tGQzdKm5UbssEEelFSU7WM62nWNsDxG2TrNRiCSUCYoJY+9rc",
-	"kL4L6qTPW2LR60+1VtR7bfp1sALevFXkref6Cpq2T/CPcoQYQQJxUNB0TdB94oWNCXvMtcrOBaLzfZez",
-	"Zvx/TQ4IavSeFsTXPOtakWAUpd0PlL8sE6Lg89pdTRvhA88Cd+saTCjGccoYZe3RDRW7PaFpW7xMPgYJ",
-	"TZEfi0QMyP+w9ry/wbyQx/jo40+X+/98tf9h//XrsPloiV//WuaQ7DMEUzjK7JyVHaom+A1zjskE2NWD",
-	"MUZZysELF/55ASBJwQsTAnoR9E+wyJau1pvZHCpGMLXhxjgqCSzFlDL8h45fUjbCaYrk4Z1Q8TMtic5f",
-	"IOMMK39QBRMIzC4V5U57BMt/FaL4TR1luFzOJWJm1xp+ABSIJPNPbw9VkMO6c8uChAtQzwTKQ96Thf1u",
-	"m7DfbR52jiD5oOFvHjjTzHBCSy3Zm4VuLlbGZXax1XlK8jQzhTj7zAQQP5WiNZC/TgjIBiaDrgUVAcDR",
-	"ufwzgJzTBCtbdYfFdCWw7tcfHhQXOE8EnkkFA5NbQu8ylOrbKIY4zWZttyGNeLec/noVadsv16qJV99u",
-	"qSCvvxZwBzloIN/jcrctEl6dpnV0xw9RGidi2Z5smmHss9XodoFypddxjE8oF8cEZnOOeXso/vgMJJQL",
-	"AM1IRfKKFjafZnHmWoJTY+qLBC6d8eLkeJ15dmGyXZhs+2GyDWtwq2zXVX9OWXdVfU9tMuLIifG6a3QA",
-	"HnGSsvZod22/u7bfzLV9k6PanBx3S7388r4a1n5/v3OXdu7Szl3auUs7d+nP7C71jDN783Zb0rPwxzZx",
-	"P1rlf234itS3xV1uST/QyV/Rr8zo5AOaGSPifBbL/O9Pf/r8SxRHZ+c/f4zi6MvxxXkUR6cXFx8vwnzv",
-	"c0QclQR/LdGZhipYiZwj+2nKIA/fVjQ8XUrQx3F09PtaPu/yl75QdjvO6F3tneudp3y9XDzanOSMTnhr",
-	"NgBXKGOUgipUnMkVVPvbKVK8mMywqIg6grLb3w7pek2lpta7YX2WQ5FMMZm4O0mMeAwSWBQoBVAAKewd",
-	"VZ2Jtn83bbcsb9Am5jULoDxZkpbX5OpNhSjCArWB4/I2ZVKCR0UbZFTUYEoypEgglmOCtHPp2KKgWBpP",
-	"p/8H4HQwGYBXeQze5jF4Jf95cyh/mq7UDC7XcT0VUWerSkt00+AXZlcXbylXqfHw3aYS3vC90gKv93XX",
-	"1K5zBVDZ386bPuuYf790AlqOQtW0IUlvJ+rikbEoP0gvhG/+ejApSqNmtgP8s00G2PTFb07ZfFtE0dC3",
-	"RxcNfyukCXJaSSTTXtGCZnQyP01D6RnHxKZ9pEAwOB7jBEgLrDNCoM1DJzRV9d4QCMgmSKg/DBZrMAKH",
-	"3kuhEj+U54/HGDEXR5HntgE4oWQmH1FyNCT7Vbhif1geHr5B7vcjcPPDPWeJMw4PR+r3S52s8mDG/3Cf",
-	"clEbk3Jhx9zIGSZQoDs4X4QPwI15dvTDvfnpHOY9QDeRR990dsgR6Ia8G//D/ZRyIYG2W+uVvNNgAMNK",
-	"JkghaEIDfs4XzFRgQj22uq/JIQPP9Lfbe1fd0APHc5qiCzRWDK4Ybd33G3ZURVWcj2JAX68Wmt8qSjfk",
-	"xlTCIPDr1dUnU0vBAZ2ZQiuTRYJSv4ZmMLRpK9q2cACZPG8D45CClwklHHOhQgJYTMEBLPDB7NWBgX+g",
-	"nI+9gWKLZXlCdWTfHoopKBBLpJxlDjlg3ok9FAZd7Fozc6g+27vtzfYuMNu7Tc/WyC6qT/cbgmQDczST",
-	"jBrOR+OgoVjMvMIracQ6iGR4q9vEy/KCGpFEN73/DnhJKNl//e3bXgOr/sh0sFnnwdzFY22OmnRg+l0g",
-	"zMuxFiEsuKtbQ6mV1EF74nowBNIMua+MTUv9HYR0i0nqB3T8+LwxOiovUluCoGp9tP635XIby1ptxr1X",
-	"ksemmK5MgFXkuu7GKlLzL3DLBRojhkhi/BfFOi0cMwDqsDeFBQIpKpBUyZSAG4nDjfJO5E//4bskPl/c",
-	"AMwBzO7gnIOCFmWmA/A22JtCAYcESCcBceNfESVF+9Z8mPr/v3lwb2zhPuZgjLMMpRKGA+pydhOll1QA",
-	"HGAxcMhaj0Z6NxKQQtLl2NoiTp3GioQu5cREMKh+26sAeb4MFCBDkAtAiTof3UhmvwGU+Xgf1GkjseZT",
-	"WmYpGMmDlPgbuDE8c3NwU3GPwg+TJCtTn3jadksg6jGAIMVjtbHC3qOErGJNqOt8cVIvPXmppqrvbyyX",
-	"pKp4zdpBwijn+zYXXiPF9wb9L+naqlMG4JPjHMUiwlVueuxRcjQusyGRuHHtX7tglCPZtJ55rVaJOSgJ",
-	"nEGcyb9pinVWZY3EbsqFTzVLozA1NqD1wjW+v+iXFzbRAA1js6SRkivvMHVxKQIZnslDPxksue9bBPTJ",
-	"L8kI0Ekls1es3c7Xe4O+94zhso1Bl7329HLjYEDZbUZhChBJVYSrXWxCCK+p1b1YaFOraxdsRFPdDerT",
-	"x8sr6y7DrJjCymk2an7fqfkh8QJnIC+5sBqnuiOOLelitVF+EdT//vf/WNMxJBao3D/zxn7zjX0uJ0q1",
-	"eaFqCVKXWHoNiSp1iAEeS8UYSz0uMRfqYrXMdDBRnpa5SQOhZTLVPzogIe3XP2AMXOfPbtEzQ7ZTK7f+",
-	"5YxgJYrbelFQR3GzLnqg1F3lxgBaCo5TVD9ODYnl6Jd1XUylqzreLzIoJOp7A/BeI8J1b4vSaLtgZohE",
-	"xCgSvs4ajLIB5hjvqXS1ugAuQUx6hMgbcrKRQHm/zW/eYXkYhMPVncS9ilEvot1016R0qOEDIL0/rsVO",
-	"sZMpwwSUZHMgT4ZSJKSeGJK7KZbCY2Jdd9A7UKWlXNqS8zu4FFCoPnQagyF5eWf1onYY1eF+wmAxVR7b",
-	"+ceryplRXqfyvjTafwNYaO0zQkMyRiKZohRwVEAGBcrmlQPgKfTjT2dBUZfL7hxVDIUGAwFLaf3WBqrO",
-	"bsEKmDyHuuK5D4ObtxbYzvy9A3M1iv1glq19i33dVqRX+QP1CsHrADoVHZohBlNrrf88sizpy6jhUc1H",
-	"iokl7qXQWWqDZZagm2J31Z06m6VzVk+ldjZ2D+6jEtrmKwYTdFlA8h4JiDO+pDBGCIZHpWgwdaBrkxvo",
-	"2jMWcFHoblFLY5RbVPWJsaAec/m0BEiXLKDUNJA5b1lu2mgwIxcrtRWBhFZ35W5DMRH//mPw8ryXw2FI",
-	"2o21CihdYrnLbRmoeoTGPdxviy95e8Vr/zDHl8BWY5I2VhSE0C2xsBVCX4Pei7jLsvH0Zb9kjnpenpxg",
-	"AD7qAMAworc6dKCqbOWPlIFhVBKOxDDy7wt0m0lVJxvr5x3rZZ2Yr0p6kZityArXQ9ozwmt6Aqa6IxnM",
-	"PnmjQp6hYyQPQKj91U4cbdKpPPkeP4LaFsYKim9F8jvJ7U7yHy/5m0hqVRK/tQQwBX3N1C+l175f5pc5",
-	"ndSF0J1/xzDjXQ7ADa3nAuzugOYfgBXQ8Al4V83158pRrTF3m8FeR56FArw1gdbgO0h0HOmhy/0NM6bV",
-	"4ejrESh423cJ1DSdNckUctX/ZEkhFyRz581U65hCDiAxDVq0rQlrB0ap53MsOhTmsTXZrQPO264/JW5t",
-	"d/K1HE9nTnwyBZRKXwHtR3E1us2v0bQNOzbqWTe/pLG47nY6NGIhvzuUsb5W+7rv0UYqVKywsKDlN+oC",
-	"8ttWbrwz8C/KNo7t0SxKmbikZFjML6Ud09j9hCBD7LgUU/nbSP32syXH379cLditv3+5AoJKdaz6AZdi",
-	"iogwjSMH4My4A4px1CgjIsemq5LWYlMEpdGDHLzQCAAVN0/UKzqE/kJqAGVwlQ5Qo6pdUUlnDw/KfRlT",
-	"01ZaQH0Np+8J/UuwKwTzhaLYZoOzj/Ym/fjTGSgYneEUcXfbpYLH2v6YjH8eD4k1E5C4xBIdtHU7od+r",
-	"nAh3rcQX7pUkQMjBHcoySRpVsaCAWT7ggyE5E6p/9YRB6WapBBcbMG58SyCnaZkh7XAhkegiQJiIEmYq",
-	"FQHMMBwSudgEZpm+mZAjUlgIyrglQQpG2uIaeDr4nOEEGVtuyH1cwGSKwOuBtJIly8wu8aODg7u7uwFU",
-	"jweUTQ7Mu/zgw9nJ6fnl6f7rweFgKvLMa+AVtWxMFEczxLjewFeDw8Gh6c9NYIGjo+jN4HDwJpLnUzFV",
-	"DG4T6CQ1D1wr4yJ4o63cFI/utfyKqieabvKNqTJD+qUPdMIjl9X1E03nlidN6gEsisxIycG/uK7J1u7k",
-	"KmdzoQjuoS71pobLetpq0a8PD7cxv/HfFAJ1yn1orSZ6iKMfO2HjGsHV2tZFkddabr0WcYahvDZvD3HH",
-	"tdfb6wXWfUZmMMOpvS3Sq321odVa4JSB3CxcKUhvUbV2dZtb1ucG2B8P32xoTZelMkdG33+b/2EuTKUL",
-	"SCgoEFNLpcrbn2F0p8WRjkGVlzGmNAY2u2IEWQyqVJ4R/EOanFPvtj5FM5TRwlaoG8pVnf02R7affZhv",
-	"H8P1VbPFdzXyeQsINR7cJGObJBUNHhj4/vWdpy5VSvWESxdEacJrOTCYurxK+daMaHf9a1Mbt6OCQ8V5",
-	"T6yFg4VcgX0z4x6pi7+3dvyuauz7KYMnl93ciY0VXytIvgSbbCrd4LybGJsW6z2l+Ni2UN+GEAe+LvXE",
-	"Mhz6IFFg+/SwnQTvJLiDBFdfHTACbGSoXX5NzvLBvf7hal6ghwMmT3ZKqCGDORKIcZUZ0/pdmsWPtahv",
-	"Sr3M6CQ2akVdBOlPtOypRsnRkTqWRTaTN6owiJpy6Dsyvb/+ch23KKcT9cFAAEntO1ikm4rSL7tvHG9T",
-	"Tfmf6++kpF5tdv7QJxzbNJUmovkU4zPUVu+ebn6PHjBjCKZzgL5hLvizVCBWGGrfxHq8Fjm4tx9VfdAC",
-	"mCERCDO/V39fUxT1y3VR3KbR7i8P5tOjz1Aefvwu8kCoAGPVPf85ioJlxqWiEEemHLlRf4LEmlz8CxJP",
-	"x8K1z/Iv3ysmLSya7bj3/wn3Kg5cwbp/Cr8u7vV9xwBi7rPhy9AKeZNlQPA/q29Oryn7+uXn6Ux+d+Np",
-	"vub97NTPs5N8y4JruXD2o++toZxfIUnVBaJrgNsM60Czv7YwdYHNNQj/C/jb5HT3kf3vx+zN7/y3Mrqh",
-	"PpgqCu14vY3XTcpCdPT7tc/5a/HmatFwHUq7hTmrTqk9I51nXifUbYhDuC3/EwtESyf34P5bOu6inruo",
-	"5+qoZ62RsBHqSqSWyvV91cj+oVPAc7GxPRDUuChhL9Nrlb9ZP9Mh0M/LPKs6WW9T13hf+/pOisb/KNYS",
-	"LfNs/cu/qJJ50lO9Y4LnfaY3Qu/37O+i59o6XrQ7MheqWILrnFg8M+3sbHW8q7RXyZ6umYjqUzLBM0T8",
-	"/MWjIYEu412VjoOXfuKjaZLA46qdjsuu3FN5W9Xrqpx9SF660nwTn7ANFkwXSr9jJd+LAYLJVCdFLnb8",
-	"GpKXtm9bQksiYvf9U/WL6eXmtZLje1VR9WJfvyGpN/YLO3qNmu8tqeCWpilPrIbbejkEROCi2clh5/ft",
-	"/L7Vfl+zAYinFpuCFlCOOlm728nOlBf1PNZd2TKfbQh5oE7wiQU8VMwV2E89bCfSO5HuINKuMs4KspGh",
-	"dvm9N1VPDweqCKubPOt6Le3F6MKonqKtGg/8TNmVKYfqcW60FVSBo6It4Op5TvwTq5dAg4cAf6lROw2z",
-	"0zAdNMyC6D9G2dzrThIqdNSaDpDqPkRS/qEud11P8fyChNfW6Fkon3j5bKb3ROhOWJft9lZ029Y1zZ5R",
-	"LcrG7elO5+x0zqpkjKXy36Z9pghmugo3qFdOpii51W191cBGT5amLhksXsVq+I+UqUanJdc9xtUxRRq9",
-	"eZcK6oCoaewB5sDCUZv85hFI6o4zNRxpgUwH2COQUEJQosqSxxBnKF3eJqcCUpJNLbWCtPTKU+97IhnB",
-	"YyKzr9cPjXfrtd2/X0t1at65X6zetElffkyuUt6qqGtR9/sYhV4zqD1cP/xfAAAA//+SqF3soKwAAA==",
+	"Mp0gERR0TaMgCnpiQQH6jpJSaPHO6KSJwKLyUH8I6o154TbeUKVaQEYnCnVFlCVIN/ZLPV0ke2OUE2O3",
+	"HbFnKkK75pkaXlDC0c7W7GyNx4M7S/FXtBQ75b515b6oyMO6+SsaTSm9aT0JqDVc4hxxAfOiBWf7uMZk",
+	"PiekUKB9OSxEDDX6n1IthcFrjdUAvaCkJEt/3IBAWTjrCVU3dq9Tvs0w5ogr7mzhfvWwjsGtBhlaFhdQ",
+	"lDwMSz9rA2WZj5dJgriSJ8Yo68R2ZqmYTKQPcDEnSftyYWKdgEUM9TMg4A0iQP7QZjkThqBQ5r8sUvsT",
+	"SaaQTNTPKcqQ/GtI0DPIhUQRpceiI6PLVwCfk6SNk36CyQ0i6VmLMh3px+DsPXgpteiY0RzQEZeOyAhn",
+	"WMztkL3u3PuBTnACs7Y5M/1YzSk5uSPkvgzU2BiuCCt1AsRZcANauYf/p1SzrRoKkVTqpzBmkrjKMTG4",
+	"LdiopZopwzk2rDCGZSaio1eHh3FIGuF3nJc50OpIToYFyrk0DQyJkhGptvUYBeMwjnJMzK9uYumBTrQ2",
+	"4wiyZHqRUG0nfmBoHB1F/3ZQxXQOTEDn4MT+6cJ7R9lUJj6xFLHaAhTyUWgNcjyg8oUmseweQvdmUH64",
+	"gNpUtDIJE2tvRuMkUs0VOwaoU+1qFTu16iFttcOyg7mQ2DvLrra5BUabAGr5OHu/aVtYQcEkwSki4rT/",
+	"+SmhZIwnJUOpZF7B8GSCGLAAObidIgLGahtCR6x29x3ak+CKE+Dimt1jhxxUv4XUTR3w8gMfksTUoNzZ",
+	"7yUaTAZgGL3Kh1EMhtHbfBjt9T/tSTGFDHOJpT34ldIllA5iNW/zyJf5576NH/mmUNgN5ct9qWUHPiXA",
+	"5tQnVwMnE4YmmoyWem8N9V5Ng9QLafraRKF5vb90Pxk91BnkaIYYFi3uv3261PBhMqZRHN1CRiTQOEoY",
+	"FtIAh3WoOwiFFLR81lsIOpyhHGvq3/dXHV9WHokcwIxO9jdzGNIr3PKRKIMjlPElsYduJww3PLTc1XEM",
+	"6QkGIPUJXXTD03th3VCIh2sdWqfohzpFdcPVDyW3BS26QTKD1wl+eKutoPSOd4Q4j1CBxzhRQn0yhYQY",
+	"PgwsxRsJEjO0JiUDcJoXYg7wGGhvW5py9dp84PssKwgemKddfCPIGJyr37cYLAhRbmF+Sm9+40uMlz5F",
+	"uriRw4EDTECOswxzJH0OT1l5nrmgos2hUI+8M0BT5TkooWU4N/4DnZwSofVrXQtlaIay1kMd0I9Dxxg6",
+	"aX/LRhkC7/nOXNB2qKfuLEwnACnE4/7aMxi6Vdyo3JYJItKLkpysZ1pPsbYHiNsmWanFEkoExASx9rW5",
+	"IX0X1Emft8Si159qraj32vTrYAW8eavIW8/1FTRtn+Af5QgxggTioKDpmqD7xAsbE/aYa5WdC0Tn+y5n",
+	"zfj/mhwQ1Og9LYiveda1IsEoSrsfKH9ZJkTB57W7mjbCB54F7tY1mFCM45QxytqjGyp2e0LTtniZfAwS",
+	"miI/FokYkP9h7Xl/h3khj/HRp58u9v/5av/D/uvXYfPREr/+tcwh2WcIpnCU2TkrO1RN8BvmHJMJsKsH",
+	"Y4yylIMXLvzzAkCSghcmBPQi6J9gkS1drTezOVSMYGrDjXFUEliKKWX4Dx2/pGyE0xTJwzuh4mdaEp2/",
+	"QMYZVv6gCiYQmF0oyp32CJb/KkTxmzrKcLmcC8TMrjX8ACgQSeaf3x6qIId155YFCRegngmUh7wnC/vd",
+	"NmG/2zzsHEHyQcPfPHCmmeGEllqyNwvdXKyMy+x8q/OU5HFmCnH2mQkgfi5FayB/nRCQDUwGXQsqAoCj",
+	"j/LPAHJOE6xs1S0W05XAul9/eFBc4DwReCYVDExuCL3NUKpvoxjiNJu13YY04t1y+qtVpG2/XKsmXn27",
+	"pYK8/lrALeSggXyPy922SHh1mtbRHT9EaZyIZXuyaYaxz1aj2wXKpV7HMT6hXBwTmM055u2h+OMzkFAu",
+	"ADQjFckrWth8msWZawlOjanPE7h0xvOT43Xm2YXJdmGy7YfJNqzBrbJdV/05Zd1V9T22yYgjJ8brrtEB",
+	"eMBJytqj3bX97tp+M9f2TY5qc3LcLfXyy/tqWPv9/c5d2rlLO3dp5y7t3KU/s7vUM87szdttSc/CH9vE",
+	"/WiV/7XhK1LfFne5Jf1AJ39FvzKjkw9oZoyI81ks878//enLL1EcnX38+VMUR1+Pzz9GcXR6fv7pPMz3",
+	"PkfEUUnwtxKdaaiClcg5sp+nDPLwbUXD06UEfRpHR7+v5fMuf+krZTfjjN7W3rnaecpXy8WjzUnO6IS3",
+	"ZgNwhTJGKahCxZlcQbW/nSLFi8kMi4qoIyi7/e2QrtZUamq9G9ZnORTJFJOJu5PEiMcggUWBUgAFkMLe",
+	"UdWZaPuTabtleYM2Ma9ZAOXJkrS8JldvKkQRFqgNHJe3KZMSPCraIKOiBlOSIUUCsRwTpJ1LxxYFxdJ4",
+	"Ov0/AKeDyQC8ymPwNo/BK/nPm0P503SlZnC5juupiDpbVVqimwY/N7u6eEu5So2H7zaV8IbvlRZ4va+7",
+	"pnadK4DK/nbe9FnH/PulE9ByFKqmDUl6O1EXj4xF+UF6IXzz14NJURo1sx3gX2wywKYvfnPK5tsiioa+",
+	"Pbpo+FshTZDTSiKZ9pIWNKOT+WkaSs84JjbtIwWCwfEYJ0BaYJ0RAm0eOqGpqveGQEA2QUL9YbBYgxE4",
+	"9F4IlfihPH88xoi5OIo8tw3ACSUz+YiSoyHZr8IV+8Py8PANcr8fgesf7jhLnHG4P1K/X+hklXsz/oe7",
+	"lIvamJQLO+ZazjCBAt3C+SJ8AK7Ns6Mf7sxPH2HeA3QTefRdZ4ccgW7Iu/E/3E0pFxJou7VeyTsNBjCs",
+	"ZIIUgiY04Od8xUwFJtRjq/uaHDLwTH+7vXfVDT1w/EhTdI7GisEVo637fsOOqqiK81EM6KvVQvNbRemG",
+	"3JhKGAR+vbz8bGopOKAzU2hlskhQ6tfQDIY2bUXbFg4gk+dtYBxS8DKhhGMuVEgAiyk4gAU+mL06MPAP",
+	"lPOxN1BssSxPqI7s20MxBQViiZSzzCEHzDuxh8Kgi11rZg7VZ3u3vdneBWZ7t+nZGtlF9el+Q5BsYI5m",
+	"klHD+WgcNBSLmVd4JY1YB5EMb3WbeFleUCOS6Kb33wEvCSX7r79/32tg1R+ZDjbrYzB38ViboyYdmH4X",
+	"CPNyrEUIC+7q1lBqJXXQnrgeDIE0Q+4rY9NSfwch3WCS+gEdPz5vjI7Ki9SWIKhaH6z/bbncxrJWm3Hv",
+	"leSxKaYrE2AVua66sYrU/Avcco7GiCGSGP9FsU4LxwyAOuxNYYFAigokVTIl4FricK28E/nTf/guic8X",
+	"1wBzALNbOOegoEWZ6QC8DfamUMAhAdJJQNz4V0RJ0b41H6b+/28e3GtbuI85GOMsQ6mE4YC6nN1E6SUV",
+	"AAdYDByy1qOR3o0EpJB0Oba2iFOnsSKhSzkxEQyq3/YqQJ4vAwXIEOQCUKLOR9eS2a8BZT7eB3XaSKz5",
+	"lJZZCkbyICX+Bq4Nz1wfXFfco/DDJMnK1Ceett0SiHoMIEjxWG2ssPcoIatYE+o6X5zUS09eqqnq+xvL",
+	"JakqXrN2kDDK+b7NhddI8b1B/0u6tuqUAfjsOEexiHCVmx57lByNy2xIJG5c+9cuGOVINq1nXqtVYg5K",
+	"AmcQZ/JvmmKdVVkjsZty4VPN0ihMjQ1ovXCN7y/65YVNNEDD2CxppOTKO0xdXIpAhmfy0E8GS+77FgF9",
+	"9ksyAnRSyewVa7fz9d6g7z1juGxj0GWvPb3cOBhQdpNRmAJEUhXhahebEMJranUvFtrU6toFG9FUd4P6",
+	"/Oni0rrLMCumsHKajZrfd2p+SLzAGchLLqzGqe6IY0u6WG2UXwT1v//9P9Z0DIkFKvfPvLHffGOfy4lS",
+	"bV6oWoLUJZZeQ6JKHWKAx1IxxlKPS8yFulgtMx1MlKdlbtJAaJlM9Y8OSEj79Q8YA9f5s1v0zJDt1Mqt",
+	"fzkjWInitl4U1FHcrIseKHVXuTGAloLjFNWPU0NiOfplXRdT6aqO94sMCon63gC814hw3duiNNoumBki",
+	"ETGKhK+zBqNsgDnGeypdrS6ASxCTHiHyhpxsJFDeb/Obd1geBuFwdSdxr2LUi2g33TUpHWr4AEjvj2ux",
+	"U+xkyjABJdkcyJOhFAmpJ4bkdoql8JhY1y30DlRpKZe25PwOLgQUqg+dxmBIXt5avagdRnW4nzBYTJXH",
+	"9vHTZeXMKK9TeV8a7b8BLLT2GaEhGSORTFEKOCoggwJl88oB8BT68eezoKjLZXeOKoZCg4GApbR+awNV",
+	"Z7dgBUyeQ13x3IfBzVsLbGf+3oG5GsV+MMvWvsW+aivSq/yBeoXgVQCdig7NEIOptdZ/HlmW9GXU8Kjm",
+	"I8XEEvdS6Cy1wTJL0E2xu+pOnc3SOaunUjsbuwf3UQlt8yWDCbooIHmPBMQZb70/ffAN5BKV1w2x1ood",
+	"IRgelaIhbYF2Um6g6xtZwEVtcINaOrbcoKqBjQX1kFuxJUC6pCelprPNx5blpo3ON3KxUo0SSGh1ie84",
+	"DRPx7z8Gb/V7eUKGpN14voDSV5e73JYaq0do3MONwPiSt1e89g9zrgpsNSZpY0VBCN0yHlsh9PU0ehF3",
+	"WZqgzkKQzFFPGJQTDMAnHZkYRvRGxzRU+a/8kTIwjErCkRhG/kWG7n+pCnhj/bxjIa8T81XZOBKzFenq",
+	"ekh7qnpNT8BUt0qD2WdvVMhldYzkAQj15dqJo82GlUfy4wdQ28JYQfGtSH4nud1J/sMlfxPZtkrit5aZ",
+	"pqCvmZOm9NrTpaSZY1NdCN3BfAwz3uVk3tB6LvLvTo7+yVwBDR/Nd2Vmf67k2RpztxnsdeRZKMBbE2gN",
+	"voNEx5EeutzfMGNaHY6+HoGCt32XQE3TWZNMIVeNWZZUmEEyd95MtY4p5AAS0zlG25qwdmCUej7HokNh",
+	"HluT3TrgY9u9rMStLVmglnzqzIlPpoBS6Sug/SiuRrf5NZq2YcdGPevmlzQW191Oh0YsJJ6HUunX6qv3",
+	"FP2tQlUUCwtaftUvIL9p5cZbA/+8bOPYHl2slIlLSobF/ELaMY3dTwgyxI5LMZW/jdRvP1ty/P3r5YLd",
+	"+vvXSyCoVMeqUXEppogI09FyAM6MO6AYR40yInJs2j1pLTZFUBo9yMELjQBQAf1EvaJj+y+kBlAGV+kA",
+	"NaraFZUNd3+v3JcxNf2uBdT3g/oC07+du0QwX6jWbXZe+2Sv+I8/n4GC0RlOEXfXcCqqre2PKUXg8ZBY",
+	"MwGJy3jR0WS3E/q9yolw91184cJLAoQc3KIsk6RRpRQKmOUDPhiSM6Eaa08YlG6WyryxkezGRw5ympYZ",
+	"0g4XEomuToSJKGGmciTADMMhkYtNYJbpKxM5IoWFoIxbEqRgpC2ugaej4hlOkLHlhtzHBUymCLweSCtZ",
+	"sszsEj86OLi9vR1A9XhA2eTAvMsPPpydnH68ON1/PTgcTEWeeZ3FopaNieJohhjXG/hqcDg4NI3DCSxw",
+	"dBS9GRwO3kTyfCqmisFtZp+k5oHrsVwEr9qVm+LRvZb4UTVr093HMVVmSL/0gU545NLNfqLp3PKkyYmA",
+	"RZEZKTn4F9fF4tqdXOVsLlTn3del3hSXWU9bLfr14eE25jf+m0KgTrkPrWVO93H0YydsXIe6Wj+9KPJ6",
+	"3q3Xu84wlNd/7j7uuPZ637/Aus/IDGY4tddYerWvNrRaC5wykJuFKwXpLarWR29zy/rSAPvj4ZsNremi",
+	"VObI6Pvv8z/MTa50AQkFBWJqqVR5+zOMbrU40jGoEkbGlMbApn2MIItBlWM0gn9Ik3PqpRGkaIYyWtjS",
+	"eUO5quXg5sj2sw/z7UO4vuoC+a5GPm8BoY6Im2Rskz2jwQMD379X9NSlyvWecOmCKE14JQcGc6pXKd+a",
+	"Ee2uf23O5XZUcKhq8JG1cLDCLLBvZtwDdfFTa8cnVWNPpwweXXZzJzZWfK0g+RJs0rx05/VuYmx6v/eU",
+	"4mPb230bQhz47NUjy3DoS0mB7dPDdhK8k+AOElx9DsEIsJGhdvk1ydQHd/qHy3mB7g+YPNkpoYYM5kgg",
+	"xlXKTusHcxa/IqM+dvUyo5PYqBV1EaS/HbOnOjhHR+pYFtkU46jCIGrKoe/I9P4szVXcopxO1JcMASS1",
+	"D3SRbipKv+w+vrxNNaU/7txDSb3a7Pyhb0u2aSpNRPONyGeord493vwePWDGEEznAH3HXPBnqUCsMNQ+",
+	"1vVwLXJwZ7/2eq8FMEMiEGZ+r/6+pijql+uiuE2j3V8ezDdRn6E8/Pgk8kCoAGPV1v85ioJlxqWiEEem",
+	"TrpRGIPEmlz8CxKPx8LapHTaKyYtLJrtuPf/CfcqDlzBun8Kvy7u9eHJAGLue+bL0Ap5k2VA8L+oj2Gv",
+	"Kfv65efpTD658TSfGX926ufZSb5lwbVcOPs1+tZQzq+QpOoC0XXmbYZ1oNlfWzG7wOYahP9p/m1yuvv6",
+	"/9Mxu0NhFaMb6oOpotCO19t43aQsREe/X/mcvxZvrhYN1zq1W5izauHaM9J55rVo3YY4hL8X8MgC0dJi",
+	"Prj/lo67qOcu6rk66lnrcGyEuhKppXJ9V3XYv+8U8FzsuA8ENS5K2Mv0evhv1s90CPTzMs+qFtvb1DXe",
+	"Z8ieSNH4X+taomWerX/5F1Uyj3qqd0zwvM/0Ruj9jwl00XNtrTjaHZlzVSzBdU4snpk+e7Zs37UAUMme",
+	"rsuJaqAywTNE/PzFoyGBLuNd1bSDl37io+newOOqz4/LrtxTeVvV66rOfkheup4BJj5hOz+Y9ph+K02+",
+	"FwMEk6lOilxsRTYkL21DuYSWRMTuw6zqF9Nkzutxx/eqau/FhoNDUu84GHb0GsXoW1LBLd1cHlkNtzWZ",
+	"CIjAebPFxM7v2/l9q/2+ZmcSTy02BS2gHHWydreTnSkv6nmsu7RlPtsQ8kCd4CMLeKiYK7CfethOpHci",
+	"3UGkXWWcFWQjQ+3ye2eqnu4PVBFWN3nW9Vrai9GFUT1FWzUe+JmyS1MO1ePcaCuoAkdFW8DV85z4J1Yv",
+	"gQYPAf5So3YaZqdhOmiYBdF/iLK5050k7tv1zS9IgFQ3IpIKAOp61/r0LfrF9C96FlomXj6baTIRuvzV",
+	"9bnPRaMFGlY9lVprtqdq0WuOe3bqbafeVuV9rNI0QUU3RTDTBb/BjKaTKUpudGtjNbDR/qXpLw0Wb301",
+	"/AfKVKOpk2tU40qmIo3evEuxdkDUNPYAc2DhqE1+8wAkdXObGo60QKYL7hFIKCEoURXQY4gzlC7vyFMB",
+	"KcmmllpBWnq7qvc9kYzgMZHZ16v7xrv1MvLfr6RCN+/cLRaK2vwyP/xXmQ9VP7ZofXyMQq8Z1O6v7v8v",
+	"AAD//4boqLakrQAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/observer/api/handlers/scope_auth_test.go
+++ b/internal/observer/api/handlers/scope_auth_test.go
@@ -191,23 +191,23 @@ func TestQuerySpans_ScopeAuthFailed_Returns500WithCode(t *testing.T) {
 	assertScopeAuthFailedResponse(t, rr)
 }
 
-func TestGetSpanDetails_ScopeAuthFailed_Returns500WithCode(t *testing.T) {
+func TestQuerySpanDetails_ScopeAuthFailed_Returns500WithCode(t *testing.T) {
 	t.Parallel()
 
 	svc := servicemocks.NewMockTracesQuerier(t)
-	svc.On("GetSpanDetails", mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("%w: token expired after idle", service.ErrScopeAuthFailed))
+	svc.On("QuerySpanDetails", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("%w: token expired after idle", service.ErrScopeAuthFailed))
 
 	h := &Handler{
 		baseHandler:   baseHandler{logger: noopLogger()},
 		tracesService: svc,
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/span-1", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/trace-1/spans/span-1", spanDetailsBody("test-ns"))
 	req.SetPathValue("traceId", "trace-1")
 	req.SetPathValue("spanId", "span-1")
 	rr := httptest.NewRecorder()
 
-	h.GetSpanDetailsForTrace(rr, req)
+	h.QuerySpanDetailsForTrace(rr, req)
 
 	assertScopeAuthFailedResponse(t, rr)
 }

--- a/internal/observer/api/handlers/traces.go
+++ b/internal/observer/api/handlers/traces.go
@@ -210,14 +210,22 @@ func (h *Handler) QuerySpansForTrace(w http.ResponseWriter, r *http.Request) {
 	h.writeJSON(w, http.StatusOK, genResp)
 }
 
-// GetSpanDetailsForTrace handles GET /api/v1alpha1/traces/{traceId}/spans/{spanId}
-func (h *Handler) GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request) {
+// QuerySpanDetailsForTrace handles POST /api/v1alpha1/traces/{traceId}/spans/{spanId}
+func (h *Handler) QuerySpanDetailsForTrace(w http.ResponseWriter, r *http.Request) {
 	traceID := r.PathValue("traceId")
 	spanID := r.PathValue("spanId")
 
-	h.logger.Debug("GetSpanDetailsForTrace called", "traceId", traceID, "spanId", spanID)
+	h.logger.Debug("QuerySpanDetailsForTrace called", "traceId", traceID, "spanId", spanID)
 
-	// 1. VALIDATE PATH PARAMETERS
+	// 1. BIND REQUEST (from generated type)
+	var genReq gen.TraceSpanDetailsRequest
+	if err := httputil.BindJSON(r, &genReq); err != nil {
+		h.logger.Error("Failed to bind request", "error", err)
+		h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, "", "Invalid request format")
+		return
+	}
+
+	// 2. VALIDATE REQUEST
 	if traceID == "" {
 		h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, types.ErrorCodeV1TracesInvalidRequest, "traceId is required")
 		return
@@ -226,8 +234,23 @@ func (h *Handler) GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request)
 		h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, types.ErrorCodeV1TracesInvalidRequest, "spanId is required")
 		return
 	}
+	if genReq.SearchScope.Namespace == "" {
+		h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, types.ErrorCodeV1TracesInvalidRequest, "searchScope.namespace is required")
+		return
+	}
 
-	// 2. CHECK SERVICE INITIALIZATION
+	scope := types.ComponentSearchScope{
+		Namespace:   genReq.SearchScope.Namespace,
+		Project:     derefString(genReq.SearchScope.Project),
+		Component:   derefString(genReq.SearchScope.Component),
+		Environment: derefString(genReq.SearchScope.Environment),
+	}
+	if scope.Component != "" && scope.Project == "" {
+		h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, types.ErrorCodeV1TracesInvalidRequest, "searchScope.project is required when searchScope.component is provided")
+		return
+	}
+
+	// 3. CHECK SERVICE INITIALIZATION
 	if h.tracesService == nil {
 		h.logger.Error("Traces service is not initialized")
 		h.writeErrorResponse(
@@ -240,10 +263,18 @@ func (h *Handler) GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// 3. CALL SERVICE
+	// 4. CALL SERVICE (authorization is enforced by the service layer)
 	ctx := r.Context()
-	spanInfo, err := h.tracesService.GetSpanDetails(ctx, traceID, spanID)
+	spanInfo, err := h.tracesService.QuerySpanDetails(ctx, traceID, spanID, scope)
 	if err != nil {
+		if errors.Is(err, observerAuthz.ErrAuthzForbidden) {
+			h.writeErrorResponse(w, http.StatusForbidden, gen.Forbidden, "", "Access denied")
+			return
+		}
+		if errors.Is(err, observerAuthz.ErrAuthzUnauthorized) {
+			h.writeErrorResponse(w, http.StatusUnauthorized, gen.Unauthorized, "", "Unauthorized")
+			return
+		}
 		h.logger.Error("Failed to get span details", "error", err)
 		errorCode := types.ErrorCodeV1TracesInternalGeneric
 		switch {
@@ -276,7 +307,7 @@ func (h *Handler) GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// 4. CONVERT TO GENERATED TYPE AND RETURN
+	// 5. CONVERT TO GENERATED TYPE AND RETURN
 	genResp := convertSpanDetailsToGen(spanInfo)
 	h.writeJSON(w, http.StatusOK, genResp)
 }

--- a/internal/observer/api/handlers/traces_handler_test.go
+++ b/internal/observer/api/handlers/traces_handler_test.go
@@ -4,7 +4,7 @@
 package handlers
 
 // traces_handler_test.go covers the HTTP handler paths for QueryTraces,
-// QuerySpansForTrace, and GetSpanDetailsForTrace that are NOT already covered
+// QuerySpansForTrace, and QuerySpanDetailsForTrace that are NOT already covered
 // by scope_auth_test.go (scope-auth error) or traces_test.go (conversion functions).
 
 import (
@@ -338,148 +338,52 @@ func TestQuerySpansForTrace_GenericError(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesInternalGeneric)
 }
 
-// GetSpanDetailsForTrace tests ---------------------------------------------------
+// QuerySpanDetailsForTrace tests -------------------------------------------------
 
-func TestGetSpanDetailsForTrace_Success(t *testing.T) {
+func spanDetailsBody(namespace string) *strings.Reader {
+	return strings.NewReader(`{"searchScope":{"namespace":"` + namespace + `"}}`)
+}
+
+func TestQuerySpanDetailsForTrace_Success(t *testing.T) {
 	t.Parallel()
 
 	svc := servicemocks.NewMockTracesQuerier(t)
-	svc.On("GetSpanDetails", mock.Anything, mock.Anything, mock.Anything).Return(&types.SpanInfo{SpanID: "span-1"}, nil)
+	svc.On("QuerySpanDetails", mock.Anything, "trace-1", "span-1", types.ComponentSearchScope{Namespace: "test-ns"}).
+		Return(&types.SpanInfo{SpanID: "span-1"}, nil)
 
 	h := &Handler{
 		baseHandler:   baseHandler{logger: noopLogger()},
 		tracesService: svc,
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/span-1", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/trace-1/spans/span-1", spanDetailsBody("test-ns"))
 	req.SetPathValue("traceId", "trace-1")
 	req.SetPathValue("spanId", "span-1")
 	rr := httptest.NewRecorder()
 
-	h.GetSpanDetailsForTrace(rr, req)
+	h.QuerySpanDetailsForTrace(rr, req)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
-func TestGetSpanDetailsForTrace_EmptyTraceID(t *testing.T) {
-	t.Parallel()
-
-	h := &Handler{
-		baseHandler:   baseHandler{logger: noopLogger()},
-		tracesService: servicemocks.NewMockTracesQuerier(t),
-	}
-
-	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces//spans/span-1", nil)
-	req.SetPathValue("traceId", "")
-	req.SetPathValue("spanId", "span-1")
-	rr := httptest.NewRecorder()
-
-	h.GetSpanDetailsForTrace(rr, req)
-
-	require.Equal(t, http.StatusBadRequest, rr.Code)
-	assert.Contains(t, rr.Body.String(), "traceId is required")
-}
-
-func TestGetSpanDetailsForTrace_EmptySpanID(t *testing.T) {
-	t.Parallel()
-
-	h := &Handler{
-		baseHandler:   baseHandler{logger: noopLogger()},
-		tracesService: servicemocks.NewMockTracesQuerier(t),
-	}
-
-	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/", nil)
-	req.SetPathValue("traceId", "trace-1")
-	req.SetPathValue("spanId", "")
-	rr := httptest.NewRecorder()
-
-	h.GetSpanDetailsForTrace(rr, req)
-
-	require.Equal(t, http.StatusBadRequest, rr.Code)
-	assert.Contains(t, rr.Body.String(), "spanId is required")
-}
-
-func TestGetSpanDetailsForTrace_ServiceNotInitialized(t *testing.T) {
-	t.Parallel()
-
-	h := &Handler{
-		baseHandler:   baseHandler{logger: noopLogger()},
-		tracesService: nil,
-	}
-
-	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/span-1", nil)
-	req.SetPathValue("traceId", "trace-1")
-	req.SetPathValue("spanId", "span-1")
-	rr := httptest.NewRecorder()
-
-	h.GetSpanDetailsForTrace(rr, req)
-
-	require.Equal(t, http.StatusInternalServerError, rr.Code)
-	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesServiceNotReady)
-}
-
-func TestGetSpanDetailsForTrace_SpanNotFound(t *testing.T) {
+func TestQuerySpanDetailsForTrace_AuthzForbidden(t *testing.T) {
 	t.Parallel()
 
 	svc := servicemocks.NewMockTracesQuerier(t)
-	svc.On("GetSpanDetails", mock.Anything, mock.Anything, mock.Anything).Return(nil, service.ErrSpanNotFound)
+	svc.On("QuerySpanDetails", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, observerAuthz.ErrAuthzForbidden)
 
 	h := &Handler{
 		baseHandler:   baseHandler{logger: noopLogger()},
 		tracesService: svc,
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/span-99", nil)
-	req.SetPathValue("traceId", "trace-1")
-	req.SetPathValue("spanId", "span-99")
-	rr := httptest.NewRecorder()
-
-	h.GetSpanDetailsForTrace(rr, req)
-
-	require.Equal(t, http.StatusNotFound, rr.Code)
-	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesSpanNotFound)
-}
-
-func TestGetSpanDetailsForTrace_RetrievalError(t *testing.T) {
-	t.Parallel()
-
-	svc := servicemocks.NewMockTracesQuerier(t)
-	svc.On("GetSpanDetails", mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("%w: backend", service.ErrTracesRetrieval))
-
-	h := &Handler{
-		baseHandler:   baseHandler{logger: noopLogger()},
-		tracesService: svc,
-	}
-
-	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/span-1", nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/trace-1/spans/span-1", spanDetailsBody("test-ns"))
 	req.SetPathValue("traceId", "trace-1")
 	req.SetPathValue("spanId", "span-1")
 	rr := httptest.NewRecorder()
 
-	h.GetSpanDetailsForTrace(rr, req)
+	h.QuerySpanDetailsForTrace(rr, req)
 
-	require.Equal(t, http.StatusInternalServerError, rr.Code)
-	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesRetrievalFailed)
-}
-
-func TestGetSpanDetailsForTrace_GenericError(t *testing.T) {
-	t.Parallel()
-
-	svc := servicemocks.NewMockTracesQuerier(t)
-	svc.On("GetSpanDetails", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("unexpected"))
-
-	h := &Handler{
-		baseHandler:   baseHandler{logger: noopLogger()},
-		tracesService: svc,
-	}
-
-	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/span-1", nil)
-	req.SetPathValue("traceId", "trace-1")
-	req.SetPathValue("spanId", "span-1")
-	rr := httptest.NewRecorder()
-
-	h.GetSpanDetailsForTrace(rr, req)
-
-	require.Equal(t, http.StatusInternalServerError, rr.Code)
-	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesInternalGeneric)
+	assert.Equal(t, http.StatusForbidden, rr.Code)
 }

--- a/internal/observer/mcp/handlers.go
+++ b/internal/observer/mcp/handlers.go
@@ -187,8 +187,15 @@ func (h *MCPHandler) QueryTraceSpans(ctx context.Context, traceID, namespace, pr
 	return h.tracesService.QuerySpans(ctx, traceID, req)
 }
 
-func (h *MCPHandler) GetSpanDetails(ctx context.Context, traceID, spanID string) (any, error) {
-	return h.tracesService.GetSpanDetails(ctx, traceID, spanID)
+func (h *MCPHandler) GetSpanDetails(ctx context.Context, traceID, spanID,
+	namespace, project, component, environment string) (any, error) {
+	scope := types.ComponentSearchScope{
+		Namespace:   namespace,
+		Project:     project,
+		Component:   component,
+		Environment: environment,
+	}
+	return h.tracesService.QuerySpanDetails(ctx, traceID, spanID, scope)
 }
 
 func (h *MCPHandler) QueryAlerts(ctx context.Context, namespace, project, component, environment,

--- a/internal/observer/mcp/server.go
+++ b/internal/observer/mcp/server.go
@@ -263,14 +263,28 @@ func registerTools(s *mcpsdk.Server, handler *MCPHandler) {
 		Name:        "get_span_details",
 		Description: "Get full details for a specific span within a trace in OpenChoreo. Returns complete span information including attributes, resource attributes, parent span ID, and timing details. Use trace_id and span_id from query_trace_spans results.",
 		InputSchema: createSchema(map[string]any{
-			"trace_id": stringProperty("Trace ID containing the span (required)"),
-			"span_id":  stringProperty("Span ID to retrieve details for (required)"),
-		}, []string{"trace_id", "span_id"}),
+			"trace_id":    stringProperty("Trace ID containing the span (required)"),
+			"span_id":     stringProperty("Span ID to retrieve details for (required)"),
+			"namespace":   stringProperty("Organization namespace (required)"),
+			"project":     stringProperty("Project name"),
+			"component":   stringProperty("Component name"),
+			"environment": stringProperty("Environment name"),
+		}, []string{"trace_id", "span_id", "namespace"}),
 	}, func(ctx context.Context, req *mcpsdk.CallToolRequest, args struct {
-		TraceID string `json:"trace_id"`
-		SpanID  string `json:"span_id"`
+		TraceID     string `json:"trace_id"`
+		SpanID      string `json:"span_id"`
+		Namespace   string `json:"namespace"`
+		Project     string `json:"project"`
+		Component   string `json:"component"`
+		Environment string `json:"environment"`
 	}) (*mcpsdk.CallToolResult, any, error) {
-		result, err := handler.GetSpanDetails(ctx, args.TraceID, args.SpanID)
+		if err := validateComponentScope(args.Namespace, args.Project, args.Component); err != nil {
+			return nil, nil, err
+		}
+		result, err := handler.GetSpanDetails(ctx,
+			args.TraceID, args.SpanID,
+			args.Namespace, args.Project, args.Component, args.Environment,
+		)
 		return handleToolResult(result, err)
 	})
 

--- a/internal/observer/mcp/server_test.go
+++ b/internal/observer/mcp/server_test.go
@@ -112,6 +112,7 @@ type MockTracesQuerier struct {
 	spansRequests       []*types.TracesQueryRequest
 	spanDetailsTraceIDs []string
 	spanDetailsSpanIDs  []string
+	spanDetailsScopes   []types.ComponentSearchScope
 	tracesResponse      *types.TracesQueryResponse
 	spansResponse       *types.SpansQueryResponse
 	spanInfo            *types.SpanInfo
@@ -162,9 +163,12 @@ func (m *MockTracesQuerier) QuerySpans(_ context.Context, traceID string, req *t
 	return m.spansResponse, nil
 }
 
-func (m *MockTracesQuerier) GetSpanDetails(_ context.Context, traceID string, spanID string) (*types.SpanInfo, error) {
+func (m *MockTracesQuerier) QuerySpanDetails(_ context.Context, traceID string, spanID string,
+	scope types.ComponentSearchScope,
+) (*types.SpanInfo, error) {
 	m.spanDetailsTraceIDs = append(m.spanDetailsTraceIDs, traceID)
 	m.spanDetailsSpanIDs = append(m.spanDetailsSpanIDs, spanID)
+	m.spanDetailsScopes = append(m.spanDetailsScopes, scope)
 	if m.spanDetailsErr != nil {
 		return nil, m.spanDetailsErr
 	}
@@ -190,6 +194,7 @@ func (m *MockTracesQuerier) reset() {
 	m.spansRequests = nil
 	m.spanDetailsTraceIDs = nil
 	m.spanDetailsSpanIDs = nil
+	m.spanDetailsScopes = nil
 }
 
 type MockAlertIncidentService struct {
@@ -525,19 +530,29 @@ var allToolSpecs = []toolTestSpec{
 		name:                "get_span_details",
 		descriptionKeywords: []string{"span"},
 		descriptionMinLen:   20,
-		requiredParams:      []string{"trace_id", "span_id"},
-		optionalParams:      []string{},
+		requiredParams:      []string{"trace_id", "span_id", "namespace"},
+		optionalParams:      []string{"project", "component", "environment"},
 		testArgs: map[string]any{
-			"trace_id": testTraceID,
-			"span_id":  testSpanID,
+			"trace_id":    testTraceID,
+			"span_id":     testSpanID,
+			"namespace":   testNamespace,
+			"project":     testProject,
+			"component":   testComponent,
+			"environment": testEnvironment,
 		},
 		validateCall: func(t *testing.T, svcs *testServices) {
 			t.Helper()
-			require.NotEmpty(t, svcs.traces.spanDetailsTraceIDs, "Expected GetSpanDetails to be called")
-			require.NotEmpty(t, svcs.traces.spanDetailsSpanIDs, "Expected GetSpanDetails to be called")
+			require.NotEmpty(t, svcs.traces.spanDetailsTraceIDs, "Expected QuerySpanDetails to be called")
+			require.NotEmpty(t, svcs.traces.spanDetailsSpanIDs, "Expected QuerySpanDetails to be called")
+			require.NotEmpty(t, svcs.traces.spanDetailsScopes, "Expected QuerySpanDetails scope to be recorded")
 			lastIdx := len(svcs.traces.spanDetailsSpanIDs) - 1
 			assert.Equal(t, testTraceID, svcs.traces.spanDetailsTraceIDs[lastIdx])
 			assert.Equal(t, testSpanID, svcs.traces.spanDetailsSpanIDs[lastIdx])
+			scope := svcs.traces.spanDetailsScopes[lastIdx]
+			assert.Equal(t, testNamespace, scope.Namespace)
+			assert.Equal(t, testProject, scope.Project)
+			assert.Equal(t, testComponent, scope.Component)
+			assert.Equal(t, testEnvironment, scope.Environment)
 		},
 	},
 	{
@@ -924,8 +939,9 @@ func TestMinimalParameterSets(t *testing.T) {
 			name:     "get_span_details_minimal",
 			toolName: "get_span_details",
 			args: map[string]any{
-				"trace_id": testTraceID,
-				"span_id":  testSpanID,
+				"trace_id":  testTraceID,
+				"span_id":   testSpanID,
+				"namespace": testNamespace,
 			},
 		},
 	}
@@ -1054,8 +1070,9 @@ func TestHandlerErrorPropagation(t *testing.T) {
 			name:     "span_details_service_error",
 			toolName: "get_span_details",
 			args: map[string]any{
-				"trace_id": testTraceID,
-				"span_id":  testSpanID,
+				"trace_id":  testTraceID,
+				"span_id":   testSpanID,
+				"namespace": testNamespace,
 			},
 			setupErr: func(s *testServices) { s.traces.spanDetailsErr = errors.New("span not found") },
 		},
@@ -1386,8 +1403,12 @@ func TestSchemaPropertyTypes(t *testing.T) {
 			"sort_order":  "string",
 		},
 		"get_span_details": {
-			"trace_id": "string",
-			"span_id":  "string",
+			"trace_id":    "string",
+			"span_id":     "string",
+			"namespace":   "string",
+			"project":     "string",
+			"component":   "string",
+			"environment": "string",
 		},
 	}
 

--- a/internal/observer/service/authz_test.go
+++ b/internal/observer/service/authz_test.go
@@ -294,18 +294,41 @@ func TestTracesAuthz_QuerySpans_Denied(t *testing.T) {
 	assert.ErrorIs(t, err, observerAuthz.ErrAuthzForbidden)
 }
 
-func TestTracesAuthz_GetSpanDetails_PassThrough(t *testing.T) {
+func TestTracesAuthz_QuerySpanDetails_Allowed(t *testing.T) {
+	scope := types.ComponentSearchScope{Namespace: "ns", Project: "proj", Component: "comp", Environment: "env"}
+
 	inner := mocks.NewMockTracesQuerier(t)
 	expected := &types.SpanInfo{SpanID: "span-1"}
-	inner.EXPECT().GetSpanDetails(mock.Anything, "trace-1", "span-1").Return(expected, nil)
+	inner.EXPECT().QuerySpanDetails(mock.Anything, "trace-1", "span-1", scope).Return(expected, nil)
 
-	// PDP with no Evaluate expectation — testify will fail if Evaluate is called
+	var gotReq *authzcore.EvaluateRequest
 	pdp := coremocks.NewMockPDP(t)
+	pdp.EXPECT().Evaluate(mock.Anything, mock.Anything).
+		Run(func(_ context.Context, req *authzcore.EvaluateRequest) { gotReq = req }).
+		Return(&authzcore.Decision{Decision: true}, nil).Once()
+
 	svc := NewTracesServiceWithAuthz(inner, pdp, testLogger())
 
-	resp, err := svc.GetSpanDetails(context.Background(), "trace-1", "span-1")
+	resp, err := svc.QuerySpanDetails(authedCtx(), "trace-1", "span-1", scope)
 	require.NoError(t, err)
 	assert.Equal(t, expected, resp)
+
+	require.NotNil(t, gotReq)
+	assert.Equal(t, string(observerAuthz.ActionViewTraces), gotReq.Action)
+	assert.Equal(t, string(observerAuthz.ResourceTypeComponent), gotReq.Resource.Type)
+	assert.Equal(t, "comp", gotReq.Resource.ID)
+	assert.Equal(t, authzcore.ResourceHierarchy{Namespace: "ns", Project: "proj", Component: "comp"}, gotReq.Resource.Hierarchy)
+	assert.Equal(t, "ns/env", gotReq.Context.Resource.Environment)
+}
+
+func TestTracesAuthz_QuerySpanDetails_Denied(t *testing.T) {
+	inner := mocks.NewMockTracesQuerier(t)
+
+	svc := NewTracesServiceWithAuthz(inner, mockPDPDeny(t), testLogger())
+
+	_, err := svc.QuerySpanDetails(authedCtx(), "trace-1", "span-1",
+		types.ComponentSearchScope{Namespace: "ns", Project: "proj"})
+	assert.ErrorIs(t, err, observerAuthz.ErrAuthzForbidden)
 }
 
 // --- MetricsQuerier QueryRuntimeTopology Authz Tests ---

--- a/internal/observer/service/interfaces.go
+++ b/internal/observer/service/interfaces.go
@@ -30,7 +30,7 @@ type MetricsQuerier interface {
 type TracesQuerier interface {
 	QueryTraces(ctx context.Context, req *types.TracesQueryRequest) (*types.TracesQueryResponse, error)
 	QuerySpans(ctx context.Context, traceID string, req *types.TracesQueryRequest) (*types.SpansQueryResponse, error)
-	GetSpanDetails(ctx context.Context, traceID string, spanID string) (*types.SpanInfo, error)
+	QuerySpanDetails(ctx context.Context, traceID string, spanID string, scope types.ComponentSearchScope) (*types.SpanInfo, error)
 }
 
 // AlertsQuerier is the interface for querying alerts.

--- a/internal/observer/service/mocks/tracesquerier.go
+++ b/internal/observer/service/mocks/tracesquerier.go
@@ -23,29 +23,29 @@ func (_m *MockTracesQuerier) EXPECT() *MockTracesQuerier_Expecter {
 	return &MockTracesQuerier_Expecter{mock: &_m.Mock}
 }
 
-// GetSpanDetails provides a mock function with given fields: ctx, traceID, spanID
-func (_m *MockTracesQuerier) GetSpanDetails(ctx context.Context, traceID string, spanID string) (*types.SpanInfo, error) {
-	ret := _m.Called(ctx, traceID, spanID)
+// QuerySpanDetails provides a mock function with given fields: ctx, traceID, spanID, scope
+func (_m *MockTracesQuerier) QuerySpanDetails(ctx context.Context, traceID string, spanID string, scope types.ComponentSearchScope) (*types.SpanInfo, error) {
+	ret := _m.Called(ctx, traceID, spanID, scope)
 
 	if len(ret) == 0 {
-		panic("no return value specified for GetSpanDetails")
+		panic("no return value specified for QuerySpanDetails")
 	}
 
 	var r0 *types.SpanInfo
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*types.SpanInfo, error)); ok {
-		return rf(ctx, traceID, spanID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, types.ComponentSearchScope) (*types.SpanInfo, error)); ok {
+		return rf(ctx, traceID, spanID, scope)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) *types.SpanInfo); ok {
-		r0 = rf(ctx, traceID, spanID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, types.ComponentSearchScope) *types.SpanInfo); ok {
+		r0 = rf(ctx, traceID, spanID, scope)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*types.SpanInfo)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, traceID, spanID)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, types.ComponentSearchScope) error); ok {
+		r1 = rf(ctx, traceID, spanID, scope)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -53,32 +53,33 @@ func (_m *MockTracesQuerier) GetSpanDetails(ctx context.Context, traceID string,
 	return r0, r1
 }
 
-// MockTracesQuerier_GetSpanDetails_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSpanDetails'
-type MockTracesQuerier_GetSpanDetails_Call struct {
+// MockTracesQuerier_QuerySpanDetails_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'QuerySpanDetails'
+type MockTracesQuerier_QuerySpanDetails_Call struct {
 	*mock.Call
 }
 
-// GetSpanDetails is a helper method to define mock.On call
+// QuerySpanDetails is a helper method to define mock.On call
 //   - ctx context.Context
 //   - traceID string
 //   - spanID string
-func (_e *MockTracesQuerier_Expecter) GetSpanDetails(ctx interface{}, traceID interface{}, spanID interface{}) *MockTracesQuerier_GetSpanDetails_Call {
-	return &MockTracesQuerier_GetSpanDetails_Call{Call: _e.mock.On("GetSpanDetails", ctx, traceID, spanID)}
+//   - scope types.ComponentSearchScope
+func (_e *MockTracesQuerier_Expecter) QuerySpanDetails(ctx interface{}, traceID interface{}, spanID interface{}, scope interface{}) *MockTracesQuerier_QuerySpanDetails_Call {
+	return &MockTracesQuerier_QuerySpanDetails_Call{Call: _e.mock.On("QuerySpanDetails", ctx, traceID, spanID, scope)}
 }
 
-func (_c *MockTracesQuerier_GetSpanDetails_Call) Run(run func(ctx context.Context, traceID string, spanID string)) *MockTracesQuerier_GetSpanDetails_Call {
+func (_c *MockTracesQuerier_QuerySpanDetails_Call) Run(run func(ctx context.Context, traceID string, spanID string, scope types.ComponentSearchScope)) *MockTracesQuerier_QuerySpanDetails_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(types.ComponentSearchScope))
 	})
 	return _c
 }
 
-func (_c *MockTracesQuerier_GetSpanDetails_Call) Return(_a0 *types.SpanInfo, _a1 error) *MockTracesQuerier_GetSpanDetails_Call {
+func (_c *MockTracesQuerier_QuerySpanDetails_Call) Return(_a0 *types.SpanInfo, _a1 error) *MockTracesQuerier_QuerySpanDetails_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockTracesQuerier_GetSpanDetails_Call) RunAndReturn(run func(context.Context, string, string) (*types.SpanInfo, error)) *MockTracesQuerier_GetSpanDetails_Call {
+func (_c *MockTracesQuerier_QuerySpanDetails_Call) RunAndReturn(run func(context.Context, string, string, types.ComponentSearchScope) (*types.SpanInfo, error)) *MockTracesQuerier_QuerySpanDetails_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/observer/service/traces.go
+++ b/internal/observer/service/traces.go
@@ -200,8 +200,8 @@ func (s *TracesService) QuerySpans(ctx context.Context, traceID string, req *typ
 	return s.convertSpansToResponse(result), nil
 }
 
-// GetSpanDetails retrieves detailed information about a specific span
-func (s *TracesService) GetSpanDetails(ctx context.Context, traceID string, spanID string) (*types.SpanInfo, error) {
+// QuerySpanDetails retrieves detailed information about a specific span within a scope.
+func (s *TracesService) QuerySpanDetails(ctx context.Context, traceID string, spanID string, scope types.ComponentSearchScope) (*types.SpanInfo, error) {
 	if traceID == "" {
 		return nil, fmt.Errorf("%w: traceId is required", ErrTracesInvalidRequest)
 	}
@@ -209,33 +209,36 @@ func (s *TracesService) GetSpanDetails(ctx context.Context, traceID string, span
 		return nil, fmt.Errorf("%w: spanId is required", ErrTracesInvalidRequest)
 	}
 
-	s.logger.Info("GetSpanDetails called",
+	s.logger.Debug("QuerySpanDetails called",
 		"traceId", traceID,
 		"spanId", spanID)
+
+	projectUID, componentUID, environmentUID, err := s.resolveSearchScope(ctx, &scope)
+	if err != nil {
+		s.logger.Error("Failed to resolve search scope", "error", err)
+		return nil, fmt.Errorf("%w: %w", ErrTracesResolveSearchScope, err)
+	}
+
+	params := observability.TracesQueryParams{
+		Namespace:     scope.Namespace,
+		ProjectID:     projectUID,
+		ComponentID:   componentUID,
+		EnvironmentID: environmentUID,
+	}
 
 	// Route to tracing adapter or OpenSearch
 	if s.config.Adapters.TracingAdapterEnabled && s.tracingAdapter != nil {
 		s.logger.Debug("Using tracing adapter for span details")
-		detail, err := s.tracingAdapter.GetSpanDetails(ctx, traceID, spanID)
+		detail, err := s.tracingAdapter.QuerySpanDetails(ctx, traceID, spanID, params)
 		if err != nil {
 			s.logger.Error("Failed to retrieve span details", "error", err)
+			// Pass through ErrSpanNotFound without wrapping so handlers can detect it
 			if errors.Is(err, ErrSpanNotFound) {
 				return nil, err
 			}
 			return nil, fmt.Errorf("%w: %w", ErrTracesRetrieval, err)
 		}
-		return &types.SpanInfo{
-			SpanID:             detail.SpanID,
-			SpanName:           detail.SpanName,
-			SpanKind:           detail.SpanKind,
-			ParentSpanID:       detail.ParentSpanID,
-			StartTime:          &detail.StartTime,
-			EndTime:            &detail.EndTime,
-			DurationNs:         detail.DurationNs,
-			Status:             detail.Status,
-			Attributes:         detail.Attributes,
-			ResourceAttributes: detail.ResourceAttributes,
-		}, nil
+		return spanDetailToInfo(detail), nil
 	}
 
 	if s.defaultAdaptor == nil {
@@ -265,6 +268,21 @@ func (s *TracesService) GetSpanDetails(ctx context.Context, traceID string, span
 		Attributes:         span.Attributes,
 		ResourceAttributes: span.ResourceAttributes,
 	}, nil
+}
+
+func spanDetailToInfo(detail *observability.SpanDetail) *types.SpanInfo {
+	return &types.SpanInfo{
+		SpanID:             detail.SpanID,
+		SpanName:           detail.SpanName,
+		SpanKind:           detail.SpanKind,
+		ParentSpanID:       detail.ParentSpanID,
+		StartTime:          &detail.StartTime,
+		EndTime:            &detail.EndTime,
+		DurationNs:         detail.DurationNs,
+		Status:             detail.Status,
+		Attributes:         detail.Attributes,
+		ResourceAttributes: detail.ResourceAttributes,
+	}
 }
 
 func (s *TracesService) convertToResponse(result *observability.TracesQueryResult) *types.TracesQueryResponse {

--- a/internal/observer/service/traces_authz.go
+++ b/internal/observer/service/traces_authz.go
@@ -64,8 +64,18 @@ func (s *tracesServiceWithAuthz) QuerySpans(ctx context.Context, traceID string,
 	return s.internal.QuerySpans(ctx, traceID, req)
 }
 
-// GetSpanDetails passes through without an authz check — traceID+spanID alone do not
-// carry enough scope context (namespace/project/component) to evaluate authorization.
-func (s *tracesServiceWithAuthz) GetSpanDetails(ctx context.Context, traceID string, spanID string) (*types.SpanInfo, error) {
-	return s.internal.GetSpanDetails(ctx, traceID, spanID)
+func (s *tracesServiceWithAuthz) QuerySpanDetails(ctx context.Context, traceID string, spanID string, scope types.ComponentSearchScope) (*types.SpanInfo, error) {
+	resourceType, resourceName, hierarchy := observerAuthz.ComponentScopeAuthz(scope.Namespace, scope.Project, scope.Component)
+
+	if err := observerAuthz.CheckAuthorization(
+		ctx, s.logger, s.pdp,
+		observerAuthz.ActionViewTraces,
+		resourceType, resourceName, hierarchy,
+		authzcore.Context{Resource: authzcore.ResourceAttribute{
+			Environment: observerAuthz.FormatDualScopedResourceName(scope.Namespace, scope.Environment, false),
+		}},
+	); err != nil {
+		return nil, err
+	}
+	return s.internal.QuerySpanDetails(ctx, traceID, spanID, scope)
 }

--- a/internal/observer/service/traces_test.go
+++ b/internal/observer/service/traces_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/openchoreo/openchoreo/pkg/observability"
 )
 
+const testSpanID1 = "span-1"
+
 func newTestTracesService() *TracesService {
 	cfg := &config.Config{}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -60,7 +62,7 @@ func TestTracesService_ConvertToResponse(t *testing.T) {
 				StartTime:    now,
 				EndTime:      now.Add(1 * time.Second),
 				DurationNs:   1000000000,
-				RootSpanID:   "span-1",
+				RootSpanID:   testSpanID1,
 				RootSpanName: "http.request",
 				TraceName:    "http.request",
 				RootSpanKind: "INTERNAL",
@@ -104,7 +106,7 @@ func TestTracesService_ConvertToResponse_MultipleTraces(t *testing.T) {
 				StartTime:    now,
 				EndTime:      now.Add(100 * time.Millisecond),
 				DurationNs:   100000000,
-				RootSpanID:   "span-1",
+				RootSpanID:   testSpanID1,
 				RootSpanName: "http.request",
 				TraceName:    "http.request",
 			},
@@ -171,7 +173,7 @@ func TestTracesService_ConvertSpansToResponse(t *testing.T) {
 				SpanCount: 2,
 				Spans: []observability.TraceSpan{
 					{
-						SpanID:    "span-1",
+						SpanID:    testSpanID1,
 						Name:      "http.request",
 						SpanKind:  "SERVER",
 						StartTime: now,
@@ -181,7 +183,7 @@ func TestTracesService_ConvertSpansToResponse(t *testing.T) {
 						SpanID:       "span-2",
 						Name:         "db.query",
 						SpanKind:     "CLIENT",
-						ParentSpanID: "span-1",
+						ParentSpanID: testSpanID1,
 						StartTime:    now.Add(20 * time.Millisecond),
 						EndTime:      now.Add(80 * time.Millisecond),
 					},
@@ -207,7 +209,7 @@ func TestTracesService_ConvertSpansToResponse(t *testing.T) {
 		t.Errorf("Expected total 2, got %d", resp.Total)
 	}
 
-	if resp.Spans[0].SpanID != "span-1" {
+	if resp.Spans[0].SpanID != testSpanID1 {
 		t.Errorf("Expected first span ID 'span-1', got %s", resp.Spans[0].SpanID)
 	}
 	if resp.Spans[0].SpanKind != "SERVER" {
@@ -229,7 +231,7 @@ func TestTracesService_ConvertSpansToResponse_MultipleTraces(t *testing.T) {
 				TraceID: "trace-1",
 				Spans: []observability.TraceSpan{
 					{
-						SpanID: "span-1",
+						SpanID: testSpanID1,
 						Name:   "http.request",
 					},
 					{

--- a/internal/observer/service/tracing_adapter.go
+++ b/internal/observer/service/tracing_adapter.go
@@ -128,9 +128,24 @@ func (t *TracingAdapter) GetSpans(ctx context.Context, traceID string, params ob
 	return convertSpansAdapterResponse(resp.JSON200), nil
 }
 
-// GetSpanDetails implements observability.TracingAdapter interface
-func (t *TracingAdapter) GetSpanDetails(ctx context.Context, traceID string, spanID string) (*observability.SpanDetail, error) {
-	resp, err := t.client.GetSpanDetailsForTraceWithResponse(ctx, traceID, spanID)
+// QuerySpanDetails implements observability.TracingAdapter interface
+func (t *TracingAdapter) QuerySpanDetails(ctx context.Context, traceID string, spanID string, params observability.TracesQueryParams) (*observability.SpanDetail, error) {
+	reqBody := gen.QuerySpanDetailsForTraceJSONRequestBody{
+		SearchScope: gen.ComponentSearchScope{
+			Namespace: params.Namespace,
+		},
+	}
+	if params.ProjectID != "" {
+		reqBody.SearchScope.Project = &params.ProjectID
+	}
+	if params.ComponentID != "" {
+		reqBody.SearchScope.Component = &params.ComponentID
+	}
+	if params.EnvironmentID != "" {
+		reqBody.SearchScope.Environment = &params.EnvironmentID
+	}
+
+	resp, err := t.client.QuerySpanDetailsForTraceWithResponse(ctx, traceID, spanID, reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute request: %w", err)
 	}

--- a/internal/observer/service/tracing_adapter_test.go
+++ b/internal/observer/service/tracing_adapter_test.go
@@ -4,11 +4,15 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/openchoreo/openchoreo/internal/observer/api/gen"
+	"github.com/openchoreo/openchoreo/pkg/observability"
 )
 
 func TestNewTracingAdapter_DefaultTimeout(t *testing.T) {
@@ -80,6 +84,55 @@ func TestNewTracingAdapter_ClientInitialized(t *testing.T) {
 	}
 	if adapter.client == nil {
 		t.Fatal("Expected non-nil client")
+	}
+}
+
+func TestTracingAdapter_QuerySpanDetails_ForwardsScopeAndConverts(t *testing.T) {
+	var gotPath, gotMethod string
+	var gotBody map[string]interface{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"spanId":"span-1","spanName":"http.request"}`))
+	}))
+	defer srv.Close()
+
+	adapter, err := NewTracingAdapter(TracingAdapterConfig{BaseURL: srv.URL, Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("failed to create adapter: %v", err)
+	}
+
+	detail, err := adapter.QuerySpanDetails(context.Background(), "trace-1", "span-1",
+		observability.TracesQueryParams{Namespace: "ns", ProjectID: "proj-uid", ComponentID: "comp-uid", EnvironmentID: "env-uid"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", gotMethod)
+	}
+	if gotPath != "/api/v1alpha1/traces/trace-1/spans/span-1" {
+		t.Errorf("unexpected path: %s", gotPath)
+	}
+	scope, _ := gotBody["searchScope"].(map[string]interface{})
+	if scope == nil {
+		t.Fatalf("expected searchScope in body, got %v", gotBody)
+	}
+	if scope["namespace"] != "ns" {
+		t.Errorf("expected namespace=ns, got %v", scope["namespace"])
+	}
+	if scope["project"] != "proj-uid" {
+		t.Errorf("expected project=proj-uid, got %v", scope["project"])
+	}
+	if scope["component"] != "comp-uid" {
+		t.Errorf("expected component=comp-uid, got %v", scope["component"])
+	}
+	if scope["environment"] != "env-uid" {
+		t.Errorf("expected environment=env-uid, got %v", scope["environment"])
+	}
+	if detail.SpanID != "span-1" {
+		t.Errorf("expected spanId=span-1, got %s", detail.SpanID)
 	}
 }
 

--- a/openapi/observability-tracing-adapter-api.yaml
+++ b/openapi/observability-tracing-adapter-api.yaml
@@ -152,12 +152,12 @@ paths:
 
 
   /api/v1alpha1/traces/{traceId}/spans/{spanId}:
-    get:
+    post:
       tags:
         - Traces
       summary: Get details of a span for a trace
       description: Get details of a span for a trace
-      operationId: getSpanDetailsForTrace
+      operationId: querySpanDetailsForTrace
       parameters:
         - name: traceId
           in: path
@@ -169,6 +169,12 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TraceSpanDetailsRequest"
       responses:
         "200":
           description: Span details queried successfully
@@ -272,6 +278,14 @@ components:
           description: Whether to include span attributes in the response. Defaults to false.
           default: false
       required: [startTime, endTime, searchScope]
+
+
+    TraceSpanDetailsRequest:
+      type: object
+      properties:
+        searchScope:
+          $ref: "#/components/schemas/ComponentSearchScope"
+      required: [searchScope]
 
 
     TracesQueryResponse:

--- a/openapi/observer-api.yaml
+++ b/openapi/observer-api.yaml
@@ -318,12 +318,12 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
 
   /api/v1alpha1/traces/{traceId}/spans/{spanId}:
-    get:
+    post:
       tags:
         - Traces
       summary: Get details of a span for a trace
-      description: Get details of a span for a trace from the observer service
-      operationId: getSpanDetailsForTrace
+      description: Get details of a span for a trace
+      operationId: querySpanDetailsForTrace
       parameters:
         - name: traceId
           in: path
@@ -337,6 +337,12 @@ paths:
           description: The ID of the span
           schema:
             type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TraceSpanDetailsRequest"
       responses:
         "200":
           description: Span details queried successfully
@@ -1196,6 +1202,13 @@ components:
           description: Whether to include span attributes in the response. Defaults to false.
           default: false
       required: [startTime, endTime, searchScope]
+
+    TraceSpanDetailsRequest:
+      type: object
+      properties:
+        searchScope:
+          $ref: "#/components/schemas/ComponentSearchScope"
+      required: [searchScope]
 
     # Response schemas for traces
     TracesQueryResponse:

--- a/pkg/observability/traces.go
+++ b/pkg/observability/traces.go
@@ -14,8 +14,8 @@ type TracingAdapter interface {
 	GetTraces(ctx context.Context, params TracesQueryParams) (*TracesQueryResult, error)
 	// GetSpans retrieves spans for a specific trace
 	GetSpans(ctx context.Context, traceID string, params TracesQueryParams) (*SpansResult, error)
-	// GetSpanDetails retrieves detailed information about a specific span
-	GetSpanDetails(ctx context.Context, traceID string, spanID string) (*SpanDetail, error)
+	// QuerySpanDetails retrieves detailed information about a specific span within a scope
+	QuerySpanDetails(ctx context.Context, traceID string, spanID string, params TracesQueryParams) (*SpanDetail, error)
 }
 
 // SpanDetail represents detailed information about a single span


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Backport https://github.com/openchoreo/openchoreo/pull/4546 to version 1.1

## Approach
cherry-picked commit a65229baa14f7751ef234eae38229c275a45c988 and created this PR. For the approach followed for the actual implementation, please refer the original PR

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [ ] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
