### PR TITLE
ci: make artifact publishing configurable

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,6 +17,10 @@ permissions:
   contents: read
 
 env:
+  OCI_REGISTRY_HOST: ${{ vars.OCI_REGISTRY_HOST || 'ghcr.io' }}
+  IMAGE_REPO_PREFIX: ${{ vars.IMAGE_REPO_PREFIX || 'ghcr.io/openchoreo' }}
+  HELM_OCI_REGISTRY: ${{ vars.HELM_OCI_REGISTRY || 'oci://ghcr.io/openchoreo/helm-charts' }}
+  PUBLISH_LATEST: ${{ vars.PUBLISH_LATEST || 'true' }}
   IMAGE_PLATFORMS: ${{ github.event_name == 'push' && 'linux/amd64 linux/arm64' || 'linux/amd64' }}
   CLI_EXTRA_PLATFORMS: ${{ github.event_name == 'push' && 'darwin/amd64 darwin/arm64 windows/amd64 windows/arm64' || '' }}
 
@@ -170,6 +174,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [ lint, gen-check, test, build, agent-tests ]
     permissions:
+      contents: read
       packages: write
     steps:
       - name: Clone the code
@@ -236,13 +241,13 @@ jobs:
         # See: https://github.com/actions/download-artifact/issues/14
         run: find bin/dist -type f -exec chmod +x {} +
           
-      - name: Login to GitHub container registry
+      - name: Login to container registry
         if: github.event_name == 'push'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ${{ env.OCI_REGISTRY_HOST }}
+          username: ${{ env.OCI_REGISTRY_HOST == 'ghcr.io' && (secrets.OCI_REGISTRY_USERNAME || github.actor) || secrets.OCI_REGISTRY_USERNAME }}
+          password: ${{ env.OCI_REGISTRY_HOST == 'ghcr.io' && (secrets.OCI_REGISTRY_PASSWORD || github.token) || secrets.OCI_REGISTRY_PASSWORD }}
 
       - name: Setup docker multiarch
         if: github.event_name == 'push'
@@ -259,7 +264,7 @@ jobs:
           SHA=$(git rev-parse --short=8 HEAD)
           ALL_EXIST=true
           for IMG in controller quick-start openchoreo-api observer event-forwarder sre-agent finops-agent portal-assistant openchoreo-cli cluster-gateway cluster-agent remote-agent remote-agent-router; do
-            if docker buildx imagetools inspect "ghcr.io/openchoreo/${IMG}:${SHA}" >/dev/null 2>&1; then
+            if docker buildx imagetools inspect "${IMAGE_REPO_PREFIX}/${IMG}:${SHA}" >/dev/null 2>&1; then
               echo "  ✅ ${IMG}:${SHA} exists"
             else
               echo "  ❌ ${IMG}:${SHA} not found"
@@ -280,7 +285,7 @@ jobs:
           make docker.push-multiarch TAG=${{ env.GIT_SHA_SHORT }}
 
           # Retag images as latest-dev for main branch only
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+          if [[ "${GITHUB_REF}" == "refs/heads/main" && "${PUBLISH_LATEST}" == "true" ]]; then
             make docker.retag-registry SOURCE_TAG=${{ env.GIT_SHA_SHORT }} NEW_TAG=latest-dev
           fi
 
@@ -288,7 +293,7 @@ jobs:
           echo "Packaging and pushing Helm charts with SHA ${{ env.GIT_SHA_SHORT }}..."
           make helm-push TAG=${{ env.GIT_SHA_SHORT }} HELM_CHART_VERSION=0.0.0-${{ env.GIT_SHA_SHORT }}
 
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+          if [[ "${GITHUB_REF}" == "refs/heads/main" && "${PUBLISH_LATEST}" == "true" ]]; then
             make helm-push TAG=latest-dev HELM_CHART_VERSION=0.0.0-latest-dev
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,12 @@ on:
 permissions:
   contents: read
 
+env:
+  OCI_REGISTRY_HOST: ${{ vars.OCI_REGISTRY_HOST || 'ghcr.io' }}
+  IMAGE_REPO_PREFIX: ${{ vars.IMAGE_REPO_PREFIX || 'ghcr.io/openchoreo' }}
+  HELM_OCI_REGISTRY: ${{ vars.HELM_OCI_REGISTRY || 'oci://ghcr.io/openchoreo/helm-charts' }}
+  PUBLISH_LATEST: ${{ vars.PUBLISH_LATEST || 'true' }}
+
 jobs:
   # In the release job, try to use artifacts from the build job as much as possible
   # to keep the release deterministic. This will ensure the release includes the tested artifacts.
@@ -63,19 +69,19 @@ jobs:
             exit 1
           fi
 
-      - name: Login to GitHub container registry
+      - name: Login to container registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ${{ env.OCI_REGISTRY_HOST }}
+          username: ${{ env.OCI_REGISTRY_HOST == 'ghcr.io' && (secrets.OCI_REGISTRY_USERNAME || github.actor) || secrets.OCI_REGISTRY_USERNAME }}
+          password: ${{ env.OCI_REGISTRY_HOST == 'ghcr.io' && (secrets.OCI_REGISTRY_PASSWORD || github.token) || secrets.OCI_REGISTRY_PASSWORD }}
 
       - name: Retag and push existing images
         run: |
           make docker.retag-registry SOURCE_TAG=${{ env.GIT_SHA_SHORT }} NEW_TAG=${{ env.RELEASE_TAG }}
 
           # TODO: Move latest tagging to a separate workflow to have more manual control
-          if [ "${{ env.LATEST }}" == "true" ]; then
+          if [[ "${{ env.LATEST }}" == "true" && "${PUBLISH_LATEST}" == "true" ]]; then
               make docker.retag-registry SOURCE_TAG=${{ env.RELEASE_TAG }} NEW_TAG=latest
           fi
 
@@ -99,7 +105,7 @@ jobs:
             remote-agent-router
           )
           for image in "${IMAGES[@]}"; do
-            FULL_REF="ghcr.io/openchoreo/${image}:${{ env.RELEASE_TAG }}"
+            FULL_REF="${IMAGE_REPO_PREFIX}/${image}:${{ env.RELEASE_TAG }}"
             DIGEST=$(docker buildx imagetools inspect "${FULL_REF}" --format '{{json .Manifest}}' | jq -r '.digest')
             if [ -z "${DIGEST}" ] || [ "${DIGEST}" = "null" ]; then
               echo "ERROR: Failed to resolve digest for ${FULL_REF}"
@@ -110,7 +116,7 @@ jobs:
               -a "repo=${{ github.repository }}" \
               -a "workflow=${{ github.workflow }}" \
               -a "ref=${{ github.sha }}" \
-              "ghcr.io/openchoreo/${image}@${DIGEST}"
+              "${IMAGE_REPO_PREFIX}/${image}@${DIGEST}"
           done
 
       - name: Download occ artifact from the build workflow

--- a/.github/workflows/trivy-image-scan.yaml
+++ b/.github/workflows/trivy-image-scan.yaml
@@ -5,11 +5,16 @@ on:
 
 permissions: {}
 
+env:
+  OCI_REGISTRY_HOST: ${{ vars.OCI_REGISTRY_HOST || 'ghcr.io' }}
+  IMAGE_REPO_PREFIX: ${{ vars.IMAGE_REPO_PREFIX || 'ghcr.io/openchoreo' }}
+
 jobs:
   scan:
     name: Scan (${{ matrix.image }})
     runs-on: ubuntu-latest
     permissions:
+      packages: read
       security-events: write
     strategy:
       fail-fast: false
@@ -27,20 +32,27 @@ jobs:
           - finops-agent
           - portal-assistant
     steps:
+      - name: Login to container registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.OCI_REGISTRY_HOST }}
+          username: ${{ env.OCI_REGISTRY_HOST == 'ghcr.io' && (secrets.OCI_REGISTRY_USERNAME || github.actor) || secrets.OCI_REGISTRY_USERNAME }}
+          password: ${{ env.OCI_REGISTRY_HOST == 'ghcr.io' && (secrets.OCI_REGISTRY_PASSWORD || github.token) || secrets.OCI_REGISTRY_PASSWORD }}
+
       - name: Set image tag
         id: tag
         run: echo "sha=$(echo '${{ github.sha }}' | cut -c1-8)" >> "$GITHUB_OUTPUT"
 
       - name: Verify image exists
         run: |
-          docker manifest inspect ghcr.io/openchoreo/${{ matrix.image }}:${{ steps.tag.outputs.sha }} > /dev/null 2>&1 || \
-            (echo "::error::Image ghcr.io/openchoreo/${{ matrix.image }}:${{ steps.tag.outputs.sha }} not found. Ensure the build workflow has completed." && exit 1)
+          docker manifest inspect "${IMAGE_REPO_PREFIX}/${{ matrix.image }}:${{ steps.tag.outputs.sha }}" > /dev/null 2>&1 || \
+            (echo "::error::Image ${IMAGE_REPO_PREFIX}/${{ matrix.image }}:${{ steps.tag.outputs.sha }} not found. Ensure the build workflow has completed." && exit 1)
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
-          image-ref: ghcr.io/openchoreo/${{ matrix.image }}:${{ steps.tag.outputs.sha }}
+          image-ref: ${{ env.IMAGE_REPO_PREFIX }}/${{ matrix.image }}:${{ steps.tag.outputs.sha }}
           format: sarif
           output: ${{ matrix.image }}.sarif
 


### PR DESCRIPTION
## Purpose

Allow OpenChoreo artifacts to be published and scanned in another OCI registry while preserving the current GHCR defaults.

## Approach

- Resolve registry paths and mutable-tag publication from optional repository configuration.
- Use explicit credentials for alternate registries while retaining GitHub credentials as the GHCR fallback.
- Apply the configured image path consistently during build, release signing and vulnerability scanning.

## Related Issues

None.

## Checklist

- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks

Verified with `make lint`, `make code.gen-check` and workflow YAML parsing.
