### PR TITLE
feat(helm): stamp platform identity labels on openchoreo system pods

### DIFF
--- a/install/helm/openchoreo-control-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-control-plane/templates/_helpers.tpl
@@ -123,6 +123,26 @@ app.kubernetes.io/component: {{ .component }}
 {{- end }}
 
 {{/*
+Platform identity labels
+Attribution labels for platform components observability. They let the
+observability plane tell which OpenChoreo plane a log record came from.
+The control plane is a singleton, so it carries no plane-id.
+
+MUST be applied to pod templates ONLY - never to spec.selector.matchLabels or a
+Service's spec.selector. Selectors are immutable, so a label that reaches one
+makes `helm upgrade` fail on an existing install instead of adding the label.
+
+Usage:
+  {{ include "openchoreo-control-plane.platformIdentityLabels" . }}
+
+Parameters:
+  - The current Helm context (usually .)
+*/}}
+{{- define "openchoreo-control-plane.platformIdentityLabels" -}}
+openchoreo.dev/plane: controlplane
+{{- end }}
+
+{{/*
 Backstage resource name
 */}}
 {{- define "openchoreo-control-plane.backstage.name" -}}

--- a/install/helm/openchoreo-control-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-control-plane/templates/_helpers.tpl
@@ -143,6 +143,48 @@ openchoreo.dev/plane: controlplane
 {{- end }}
 
 {{/*
+Gateway infrastructure labels
+
+The labels kgateway stamps on the proxy pods it renders from the Gateway CR.
+Platform identity wins over values-supplied labels: an operator override must
+not be able to silently mis-attribute a proxy pod to the wrong plane.
+
+Gateway API caps spec.infrastructure.labels at 8 entries. The count is checked
+in validateGatewayLabels so an overflow fails with a readable message instead
+of an opaque CRD rejection at apply time.
+
+Usage:
+  {{ include "openchoreo-control-plane.gatewayInfrastructureLabels" . }}
+
+Parameters:
+  - The current Helm context (usually .)
+*/}}
+{{- define "openchoreo-control-plane.gatewayInfrastructureLabels" -}}
+{{- $infra := .Values.gateway.infrastructure | default dict -}}
+{{- $platform := include "openchoreo-control-plane.platformIdentityLabels" . | fromYaml -}}
+{{- toYaml (merge (dict) $platform ($infra.labels | default dict)) -}}
+{{- end }}
+
+{{/*
+Gateway infrastructure label count validation
+
+Usage:
+  {{ include "openchoreo-control-plane.validateGatewayLabels" . }}
+
+Parameters:
+  - The current Helm context (usually .)
+*/}}
+{{- define "openchoreo-control-plane.validateGatewayLabels" -}}
+{{- if .Values.gateway.enabled -}}
+{{- $labels := include "openchoreo-control-plane.gatewayInfrastructureLabels" . | fromYaml -}}
+{{- if gt (len $labels) 8 -}}
+  {{- $platform := include "openchoreo-control-plane.platformIdentityLabels" . | fromYaml -}}
+  {{- fail (printf "gateway.infrastructure.labels renders %d entries once the %d platform identity label(s) are merged in, but Gateway API caps spec.infrastructure.labels at 8. Remove %d label(s) from gateway.infrastructure.labels." (len $labels) (len $platform) (sub (len $labels) 8)) -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Backstage resource name
 */}}
 {{- define "openchoreo-control-plane.backstage.name" -}}

--- a/install/helm/openchoreo-control-plane/templates/authz/bootstrap-job.yaml
+++ b/install/helm/openchoreo-control-plane/templates/authz/bootstrap-job.yaml
@@ -19,6 +19,7 @@ spec:
       labels:
         {{- include "openchoreo-control-plane.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: authz-bootstrap
+        {{- include "openchoreo-control-plane.platformIdentityLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ $name }}
       restartPolicy: Never

--- a/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/backstage/deployment.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         app.kubernetes.io/component: backstage
         {{- include "openchoreo-control-plane.selectorLabels" . | nindent 8 }}
+        {{- include "openchoreo-control-plane.platformIdentityLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "openchoreo-control-plane.backstage.serviceAccountName" . }}
       {{- with .Values.global.imagePullSecrets }}

--- a/install/helm/openchoreo-control-plane/templates/cluster-gateway/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/cluster-gateway/deployment.yaml
@@ -21,6 +21,7 @@ spec:
         app: cluster-gateway
         app.kubernetes.io/component: cluster-gateway
         {{- include "openchoreo-control-plane.selectorLabels" . | nindent 8 }}
+        {{- include "openchoreo-control-plane.platformIdentityLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "openchoreo-control-plane.clusterGateway.serviceAccountName" . }}
       {{- with .Values.global.imagePullSecrets }}

--- a/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
@@ -21,6 +21,7 @@ spec:
     metadata:
       labels:
         {{- include "openchoreo-control-plane.componentSelectorLabels" (dict "context" . "component" .Values.controllerManager.name) | nindent 8 }}
+        {{- include "openchoreo-control-plane.platformIdentityLabels" . | nindent 8 }}
       annotations:
         kubectl.kubernetes.io/default-container: manager
     spec:

--- a/install/helm/openchoreo-control-plane/templates/event-forwarder/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/event-forwarder/deployment.yaml
@@ -24,6 +24,7 @@ spec:
       labels:
         app.kubernetes.io/component: event-forwarder
         {{- include "openchoreo-control-plane.selectorLabels" . | nindent 8 }}
+        {{- include "openchoreo-control-plane.platformIdentityLabels" . | nindent 8 }}
       annotations:
         # Trigger pod restart when config changes
         checksum/config: {{ include (print $.Template.BasePath "/event-forwarder/configmap.yaml") . | sha256sum }}

--- a/install/helm/openchoreo-control-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-control-plane/templates/gateway/gateway.yaml
@@ -10,10 +10,19 @@ metadata:
   {{- end }}
 spec:
   gatewayClassName: {{ .Values.gateway.gatewayClassName | default "kgateway" }}
-  {{- with .Values.gateway.infrastructure }}
+  {{- /*
+  kgateway renders the proxy pods from this Gateway, so chart label helpers never
+  reach them - platform identity has to travel via spec.infrastructure.labels.
+  Values-supplied labels win on conflict.
+  */}}
+  {{- $infra := .Values.gateway.infrastructure | default dict }}
+  {{- $gwLabels := merge (dict) ($infra.labels | default dict) (include "openchoreo-control-plane.platformIdentityLabels" . | fromYaml) }}
   infrastructure:
+    {{- with omit $infra "labels" }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
+    labels:
+      {{- toYaml $gwLabels | nindent 6 }}
   listeners:
     - name: http
       protocol: HTTP

--- a/install/helm/openchoreo-control-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-control-plane/templates/gateway/gateway.yaml
@@ -13,16 +13,15 @@ spec:
   {{- /*
   kgateway renders the proxy pods from this Gateway, so chart label helpers never
   reach them - platform identity has to travel via spec.infrastructure.labels.
-  Values-supplied labels win on conflict.
+  Platform identity labels win over values-supplied ones.
   */}}
   {{- $infra := .Values.gateway.infrastructure | default dict }}
-  {{- $gwLabels := merge (dict) ($infra.labels | default dict) (include "openchoreo-control-plane.platformIdentityLabels" . | fromYaml) }}
   infrastructure:
     {{- with omit $infra "labels" }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     labels:
-      {{- toYaml $gwLabels | nindent 6 }}
+      {{- include "openchoreo-control-plane.gatewayInfrastructureLabels" . | nindent 6 }}
   listeners:
     - name: http
       protocol: HTTP

--- a/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/openchoreo-api/deployment.yaml
@@ -23,6 +23,7 @@ spec:
       labels:
         app.kubernetes.io/component: api-server
         {{- include "openchoreo-control-plane.selectorLabels" . | nindent 8 }}
+        {{- include "openchoreo-control-plane.platformIdentityLabels" . | nindent 8 }}
       annotations:
         # Trigger pod restart when config changes
         checksum/config: {{ include (print $.Template.BasePath "/openchoreo-api/configmap.yaml") . | sha256sum }}

--- a/install/helm/openchoreo-control-plane/templates/portal-assistant/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/portal-assistant/deployment.yaml
@@ -26,6 +26,7 @@ spec:
       labels:
         {{- include "openchoreo-control-plane.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: portal-assistant
+        {{- include "openchoreo-control-plane.platformIdentityLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "openchoreo-control-plane.portalAssistant.serviceAccountName" . }}
       {{- with .Values.global.imagePullSecrets }}

--- a/install/helm/openchoreo-control-plane/templates/validate.yaml
+++ b/install/helm/openchoreo-control-plane/templates/validate.yaml
@@ -1,1 +1,2 @@
 {{- include "openchoreo-control-plane.validateHostnames" . -}}
+{{- include "openchoreo-control-plane.validateGatewayLabels" . -}}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2954,7 +2954,23 @@
         },
         "infrastructure": {
           "additionalProperties": true,
-          "description": "Gateway infrastructure configuration passed to the generated Service.\nUsed to configure cloud provider load balancer settings via annotations.\nExample for AWS with Elastic IP:\n  infrastructure:\n    annotations:\n      service.beta.kubernetes.io/aws-load-balancer-type: \"external\"\n      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: \"ip\"\n      service.beta.kubernetes.io/aws-load-balancer-scheme: \"internet-facing\"\n      service.beta.kubernetes.io/aws-load-balancer-eip-allocations: \"eipalloc-xxx\"\n\nThe chart always renders spec.infrastructure so platform identity labels\nreach the kgateway proxy pods. That field needs Gateway API \u003e= v1.2 - on\nolder CRDs it is pruned and the proxy pods lose plane attribution.\nlabels is capped at 8 entries by Gateway API, platform identity included.",
+          "description": "Gateway infrastructure configuration passed to the generated Service.\nUsed to configure cloud provider load balancer settings via annotations.\nExample for AWS with Elastic IP:\n  infrastructure:\n    annotations:\n      service.beta.kubernetes.io/aws-load-balancer-type: \"external\"\n      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: \"ip\"\n      service.beta.kubernetes.io/aws-load-balancer-scheme: \"internet-facing\"\n      service.beta.kubernetes.io/aws-load-balancer-eip-allocations: \"eipalloc-xxx\"\n\nThe chart always renders spec.infrastructure so platform identity labels\nreach the kgateway proxy pods. That field needs Gateway API \u003e= v1.2 - on\nolder CRDs it is pruned and the proxy pods lose plane attribution.\nlabels is capped at 8 entries by Gateway API, platform identity included.\n",
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "required": [],
+              "type": "object"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "required": [],
+              "type": "object"
+            }
+          },
           "required": [],
           "title": "infrastructure",
           "type": "object"

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -2954,7 +2954,7 @@
         },
         "infrastructure": {
           "additionalProperties": true,
-          "description": "Gateway infrastructure configuration passed to the generated Service.\nUsed to configure cloud provider load balancer settings via annotations.\nExample for AWS with Elastic IP:\n  infrastructure:\n    annotations:\n      service.beta.kubernetes.io/aws-load-balancer-type: \"external\"\n      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: \"ip\"\n      service.beta.kubernetes.io/aws-load-balancer-scheme: \"internet-facing\"\n      service.beta.kubernetes.io/aws-load-balancer-eip-allocations: \"eipalloc-xxx\"",
+          "description": "Gateway infrastructure configuration passed to the generated Service.\nUsed to configure cloud provider load balancer settings via annotations.\nExample for AWS with Elastic IP:\n  infrastructure:\n    annotations:\n      service.beta.kubernetes.io/aws-load-balancer-type: \"external\"\n      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: \"ip\"\n      service.beta.kubernetes.io/aws-load-balancer-scheme: \"internet-facing\"\n      service.beta.kubernetes.io/aws-load-balancer-eip-allocations: \"eipalloc-xxx\"\n\nThe chart always renders spec.infrastructure so platform identity labels\nreach the kgateway proxy pods. That field needs Gateway API \u003e= v1.2 - on\nolder CRDs it is pruned and the proxy pods lose plane attribution.\nlabels is capped at 8 entries by Gateway API, platform identity included.",
           "required": [],
           "title": "infrastructure",
           "type": "object"

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -4175,6 +4175,15 @@ gateway:
   #   reach the kgateway proxy pods. That field needs Gateway API >= v1.2 - on
   #   older CRDs it is pruned and the proxy pods lose plane attribution.
   #   labels is capped at 8 entries by Gateway API, platform identity included.
+  # properties:
+  #   labels:
+  #     type: object
+  #     additionalProperties:
+  #       type: string
+  #   annotations:
+  #     type: object
+  #     additionalProperties:
+  #       type: string
   # @schema
   infrastructure: {}
 

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -361,8 +361,8 @@ controllerManager:
     port: 8080
     # @schema
     # type: [integer, "null"]
-        # description: NodePort (only used if service.type is NodePort)
-        # @schema
+    # description: NodePort (only used if service.type is NodePort)
+    # @schema
     nodePort: null
 
   # @schema
@@ -1727,7 +1727,7 @@ openchoreoApi:
                 claim: groups
                 value: admins
               effect: allow
-            
+
             # Developer mapping - grants developers group developer access
             - name: developer-binding
               kind: ClusterAuthzRoleBinding
@@ -2160,8 +2160,8 @@ openchoreoApi:
     port: 8080
     # @schema
     # type: [integer, "null"]
-        # description: NodePort (only used if service.type is NodePort)
-        # @schema
+    # description: NodePort (only used if service.type is NodePort)
+    # @schema
     nodePort: null
 
   # @schema
@@ -2626,8 +2626,8 @@ backstage:
     port: 7007
     # @schema
     # type: [integer, "null"]
-        # description: NodePort (only used if service.type is NodePort)
-        # @schema
+    # description: NodePort (only used if service.type is NodePort)
+    # @schema
     nodePort: null
 
   # @schema
@@ -3810,25 +3810,25 @@ clusterGateway:
     # @schema
     port: 8443
     # type: [integer, "null"]
-        # description: NodePort (only used if service.type is NodePort)
+    # description: NodePort (only used if service.type is NodePort)
     # @schema
     # type: [integer, "null"]
-        # description: NodePort (only used if service.type is NodePort)
-        # @schema
+    # description: NodePort (only used if service.type is NodePort)
+    # @schema
     nodePort: null
     # type: [string, "null"]
-        # description: LoadBalancer IP (only used if service.type is LoadBalancer)
+    # description: LoadBalancer IP (only used if service.type is LoadBalancer)
     # @schema
     # type: [string, "null"]
-        # description: LoadBalancer IP (only used if service.type is LoadBalancer)
-        # @schema
+    # description: LoadBalancer IP (only used if service.type is LoadBalancer)
+    # @schema
     loadBalancerIP: null
     # type: [string, "null"]
-        # description: Cluster IP (set to None for headless service)
+    # description: Cluster IP (set to None for headless service)
     # @schema
     # type: [string, "null"]
-        # description: Cluster IP (set to None for headless service)
-        # @schema
+    # description: Cluster IP (set to None for headless service)
+    # @schema
     clusterIP: null
 
   # type: object
@@ -4170,6 +4170,11 @@ gateway:
   #         service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
   #         service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
   #         service.beta.kubernetes.io/aws-load-balancer-eip-allocations: "eipalloc-xxx"
+  #
+  #   The chart always renders spec.infrastructure so platform identity labels
+  #   reach the kgateway proxy pods. That field needs Gateway API >= v1.2 - on
+  #   older CRDs it is pruned and the proxy pods lose plane attribution.
+  #   labels is capped at 8 entries by Gateway API, platform identity included.
   # @schema
   infrastructure: {}
 

--- a/install/helm/openchoreo-data-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-data-plane/templates/_helpers.tpl
@@ -143,6 +143,48 @@ openchoreo.dev/plane-id: {{ .Values.clusterAgent.planeID | default .Release.Name
 {{- end }}
 
 {{/*
+Gateway infrastructure labels
+
+The labels kgateway stamps on the proxy pods it renders from the Gateway CR.
+Platform identity wins over values-supplied labels: an operator override must
+not be able to silently mis-attribute a proxy pod to the wrong plane.
+
+Gateway API caps spec.infrastructure.labels at 8 entries. The count is checked
+in validateGatewayLabels so an overflow fails with a readable message instead
+of an opaque CRD rejection at apply time.
+
+Usage:
+  {{ include "openchoreo-data-plane.gatewayInfrastructureLabels" . }}
+
+Parameters:
+  - The current Helm context (usually .)
+*/}}
+{{- define "openchoreo-data-plane.gatewayInfrastructureLabels" -}}
+{{- $infra := .Values.gateway.infrastructure | default dict -}}
+{{- $platform := include "openchoreo-data-plane.platformIdentityLabels" . | fromYaml -}}
+{{- toYaml (merge (dict) $platform ($infra.labels | default dict)) -}}
+{{- end }}
+
+{{/*
+Gateway infrastructure label count validation
+
+Usage:
+  {{ include "openchoreo-data-plane.validateGatewayLabels" . }}
+
+Parameters:
+  - The current Helm context (usually .)
+*/}}
+{{- define "openchoreo-data-plane.validateGatewayLabels" -}}
+{{- if .Values.gateway.enabled -}}
+{{- $labels := include "openchoreo-data-plane.gatewayInfrastructureLabels" . | fromYaml -}}
+{{- if gt (len $labels) 8 -}}
+  {{- $platform := include "openchoreo-data-plane.platformIdentityLabels" . | fromYaml -}}
+  {{- fail (printf "gateway.infrastructure.labels renders %d entries once the %d platform identity label(s) are merged in, but Gateway API caps spec.infrastructure.labels at 8. Remove %d label(s) from gateway.infrastructure.labels." (len $labels) (len $platform) (sub (len $labels) 8)) -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Cluster Agent name
 */}}
 {{- define "openchoreo-data-plane.clusterAgent.name" -}}

--- a/install/helm/openchoreo-data-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-data-plane/templates/_helpers.tpl
@@ -123,6 +123,26 @@ app.kubernetes.io/component: {{ .component }}
 {{- end }}
 
 {{/*
+Platform identity labels
+Attribution labels for platform components observability. They let the
+observability plane tell which OpenChoreo plane a log record came from.
+
+MUST be applied to pod templates ONLY - never to spec.selector.matchLabels or a
+Service's spec.selector. Selectors are immutable, so a label that reaches one
+makes `helm upgrade` fail on an existing install instead of adding the label.
+
+Usage:
+  {{ include "openchoreo-data-plane.platformIdentityLabels" . }}
+
+Parameters:
+  - The current Helm context (usually .)
+*/}}
+{{- define "openchoreo-data-plane.platformIdentityLabels" -}}
+openchoreo.dev/plane: dataplane
+openchoreo.dev/plane-id: {{ .Values.clusterAgent.planeID | default .Release.Name | quote }}
+{{- end }}
+
+{{/*
 Cluster Agent name
 */}}
 {{- define "openchoreo-data-plane.clusterAgent.name" -}}
@@ -198,4 +218,3 @@ Parameters:
 {{- end -}}
 {{- printf "%s:%s" $repo (.image.tag | default .context.Chart.AppVersion) -}}
 {{- end }}
-

--- a/install/helm/openchoreo-data-plane/templates/cluster-agent/deployment.yaml
+++ b/install/helm/openchoreo-data-plane/templates/cluster-agent/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         app: cluster-agent
         app.kubernetes.io/component: cluster-agent
         {{- include "openchoreo-data-plane.selectorLabels" . | nindent 8 }}
+        {{- include "openchoreo-data-plane.platformIdentityLabels" . | nindent 8 }}
       {{- with .Values.clusterAgent.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/install/helm/openchoreo-data-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-data-plane/templates/gateway/gateway.yaml
@@ -12,10 +12,19 @@ metadata:
   {{- end }}
 spec:
   gatewayClassName: {{ .Values.gateway.gatewayClassName | default "kgateway" }}
-  {{- with .Values.gateway.infrastructure }}
+  {{- /*
+  kgateway renders the proxy pods from this Gateway, so chart label helpers never
+  reach them - platform identity has to travel via spec.infrastructure.labels.
+  Values-supplied labels win on conflict.
+  */}}
+  {{- $infra := .Values.gateway.infrastructure | default dict }}
+  {{- $gwLabels := merge (dict) ($infra.labels | default dict) (include "openchoreo-data-plane.platformIdentityLabels" . | fromYaml) }}
   infrastructure:
+    {{- with omit $infra "labels" }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
+    labels:
+      {{- toYaml $gwLabels | nindent 6 }}
   listeners:
     - name: http
       protocol: HTTP

--- a/install/helm/openchoreo-data-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-data-plane/templates/gateway/gateway.yaml
@@ -15,16 +15,15 @@ spec:
   {{- /*
   kgateway renders the proxy pods from this Gateway, so chart label helpers never
   reach them - platform identity has to travel via spec.infrastructure.labels.
-  Values-supplied labels win on conflict.
+  Platform identity labels win over values-supplied ones.
   */}}
   {{- $infra := .Values.gateway.infrastructure | default dict }}
-  {{- $gwLabels := merge (dict) ($infra.labels | default dict) (include "openchoreo-data-plane.platformIdentityLabels" . | fromYaml) }}
   infrastructure:
     {{- with omit $infra "labels" }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     labels:
-      {{- toYaml $gwLabels | nindent 6 }}
+      {{- include "openchoreo-data-plane.gatewayInfrastructureLabels" . | nindent 6 }}
   listeners:
     - name: http
       protocol: HTTP

--- a/install/helm/openchoreo-data-plane/templates/remote-agent-router/router.yaml
+++ b/install/helm/openchoreo-data-plane/templates/remote-agent-router/router.yaml
@@ -59,6 +59,7 @@ spec:
     metadata:
       labels:
         app: {{ $name }}
+        {{- include "openchoreo-data-plane.platformIdentityLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ $name }}
       {{- with .Values.global.imagePullSecrets }}

--- a/install/helm/openchoreo-data-plane/templates/validate.yaml
+++ b/install/helm/openchoreo-data-plane/templates/validate.yaml
@@ -1,1 +1,2 @@
 {{- include "openchoreo-data-plane.validateHostnames" . -}}
+{{- include "openchoreo-data-plane.validateGatewayLabels" . -}}

--- a/install/helm/openchoreo-data-plane/values.schema.json
+++ b/install/helm/openchoreo-data-plane/values.schema.json
@@ -149,7 +149,7 @@
         },
         "planeID": {
           "default": "default",
-          "description": "Logical plane identifier shared across multiple CRs connecting to the same physical plane.\nDefaults to Helm release name if not specified. Rendered as the openchoreo.dev/plane-id\npod label, so it must be a valid Kubernetes label value.\n",
+          "description": "Logical plane identifier shared across multiple CRs connecting to the same physical plane.\nShips as the literal \"default\"; falls back to Helm release name if set as \"\". Rendered as\nthe openchoreo.dev/plane-id pod label, so it must be a valid Kubernetes label value.\n",
           "maxLength": 63,
           "pattern": "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$",
           "title": "planeID",

--- a/install/helm/openchoreo-data-plane/values.schema.json
+++ b/install/helm/openchoreo-data-plane/values.schema.json
@@ -149,7 +149,9 @@
         },
         "planeID": {
           "default": "default",
-          "description": "Logical plane identifier shared across multiple CRs connecting to the same physical plane. Defaults to Helm release name if not specified.",
+          "description": "Logical plane identifier shared across multiple CRs connecting to the same physical plane.\nDefaults to Helm release name if not specified. Rendered as the openchoreo.dev/plane-id\npod label, so it must be a valid Kubernetes label value.\n",
+          "maxLength": 63,
+          "pattern": "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$",
           "title": "planeID",
           "type": "string"
         },
@@ -753,7 +755,7 @@
         },
         "infrastructure": {
           "additionalProperties": true,
-          "description": "Gateway infrastructure configuration passed to the generated Service.\nUsed to configure cloud provider load balancer settings via annotations.\nExample for AWS with Elastic IP:\n  infrastructure:\n    annotations:\n      service.beta.kubernetes.io/aws-load-balancer-type: \"external\"\n      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: \"ip\"\n      service.beta.kubernetes.io/aws-load-balancer-scheme: \"internet-facing\"\n      service.beta.kubernetes.io/aws-load-balancer-eip-allocations: \"eipalloc-xxx\"",
+          "description": "Gateway infrastructure configuration passed to the generated Service.\nUsed to configure cloud provider load balancer settings via annotations.\nExample for AWS with Elastic IP:\n  infrastructure:\n    annotations:\n      service.beta.kubernetes.io/aws-load-balancer-type: \"external\"\n      service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: \"ip\"\n      service.beta.kubernetes.io/aws-load-balancer-scheme: \"internet-facing\"\n      service.beta.kubernetes.io/aws-load-balancer-eip-allocations: \"eipalloc-xxx\"\n\nThe chart always renders spec.infrastructure so platform identity labels\nreach the kgateway proxy pods. That field needs Gateway API \u003e= v1.2 - on\nolder CRDs it is pruned and the proxy pods lose plane attribution.\nlabels is capped at 8 entries by Gateway API, platform identity included.",
           "properties": {
             "labels": {
               "additionalProperties": {

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -76,6 +76,11 @@ gateway:
   #         service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
   #         service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
   #         service.beta.kubernetes.io/aws-load-balancer-eip-allocations: "eipalloc-xxx"
+  #
+  #   The chart always renders spec.infrastructure so platform identity labels
+  #   reach the kgateway proxy pods. That field needs Gateway API >= v1.2 - on
+  #   older CRDs it is pruned and the proxy pods lose plane attribution.
+  #   labels is capped at 8 entries by Gateway API, platform identity included.
   # @schema
   infrastructure:
     # @schema
@@ -178,7 +183,6 @@ gateway:
     # maximum: 65535
     # @schema
     port: 8443
-
 
   # @schema
   # type: object
@@ -418,8 +422,13 @@ clusterAgent:
 
   # @schema
   # type: string
-  # description: Logical plane identifier shared across multiple CRs connecting to the same physical plane. Defaults to Helm release name if not specified.
+  # description: |
+  #   Logical plane identifier shared across multiple CRs connecting to the same physical plane.
+  #   Defaults to Helm release name if not specified. Rendered as the openchoreo.dev/plane-id
+  #   pod label, so it must be a valid Kubernetes label value.
   # default: default
+  # pattern: "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
+  # maxLength: 63
   # @schema
   planeID: default
 

--- a/install/helm/openchoreo-data-plane/values.yaml
+++ b/install/helm/openchoreo-data-plane/values.yaml
@@ -424,8 +424,8 @@ clusterAgent:
   # type: string
   # description: |
   #   Logical plane identifier shared across multiple CRs connecting to the same physical plane.
-  #   Defaults to Helm release name if not specified. Rendered as the openchoreo.dev/plane-id
-  #   pod label, so it must be a valid Kubernetes label value.
+  #   Ships as the literal "default"; falls back to Helm release name if set as "". Rendered as
+  #   the openchoreo.dev/plane-id pod label, so it must be a valid Kubernetes label value.
   # default: default
   # pattern: "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
   # maxLength: 63

--- a/install/helm/openchoreo-observability-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-observability-plane/templates/_helpers.tpl
@@ -143,6 +143,48 @@ openchoreo.dev/plane-id: {{ .Values.clusterAgent.planeID | default .Release.Name
 {{- end }}
 
 {{/*
+Gateway infrastructure labels
+
+The labels kgateway stamps on the proxy pods it renders from the Gateway CR.
+Platform identity wins over values-supplied labels: an operator override must
+not be able to silently mis-attribute a proxy pod to the wrong plane.
+
+Gateway API caps spec.infrastructure.labels at 8 entries. The count is checked
+in validateGatewayLabels so an overflow fails with a readable message instead
+of an opaque CRD rejection at apply time.
+
+Usage:
+  {{ include "openchoreo-observability-plane.gatewayInfrastructureLabels" . }}
+
+Parameters:
+  - The current Helm context (usually .)
+*/}}
+{{- define "openchoreo-observability-plane.gatewayInfrastructureLabels" -}}
+{{- $infra := .Values.gateway.infrastructure | default dict -}}
+{{- $platform := include "openchoreo-observability-plane.platformIdentityLabels" . | fromYaml -}}
+{{- toYaml (merge (dict) $platform ($infra.labels | default dict)) -}}
+{{- end }}
+
+{{/*
+Gateway infrastructure label count validation
+
+Usage:
+  {{ include "openchoreo-observability-plane.validateGatewayLabels" . }}
+
+Parameters:
+  - The current Helm context (usually .)
+*/}}
+{{- define "openchoreo-observability-plane.validateGatewayLabels" -}}
+{{- if .Values.gateway.enabled -}}
+{{- $labels := include "openchoreo-observability-plane.gatewayInfrastructureLabels" . | fromYaml -}}
+{{- if gt (len $labels) 8 -}}
+  {{- $platform := include "openchoreo-observability-plane.platformIdentityLabels" . | fromYaml -}}
+  {{- fail (printf "gateway.infrastructure.labels renders %d entries once the %d platform identity label(s) are merged in, but Gateway API caps spec.infrastructure.labels at 8. Remove %d label(s) from gateway.infrastructure.labels." (len $labels) (len $platform) (sub (len $labels) 8)) -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Cluster Agent name
 */}}
 {{- define "openchoreo-observability-plane.clusterAgent.name" -}}

--- a/install/helm/openchoreo-observability-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-observability-plane/templates/_helpers.tpl
@@ -123,6 +123,26 @@ app.kubernetes.io/component: {{ .component }}
 {{- end }}
 
 {{/*
+Platform identity labels
+Attribution labels for platform components observability. They let the
+observability plane tell which OpenChoreo plane a log record came from.
+
+MUST be applied to pod templates ONLY - never to spec.selector.matchLabels or a
+Service's spec.selector. Selectors are immutable, so a label that reaches one
+makes `helm upgrade` fail on an existing install instead of adding the label.
+
+Usage:
+  {{ include "openchoreo-observability-plane.platformIdentityLabels" . }}
+
+Parameters:
+  - The current Helm context (usually .)
+*/}}
+{{- define "openchoreo-observability-plane.platformIdentityLabels" -}}
+openchoreo.dev/plane: observabilityplane
+openchoreo.dev/plane-id: {{ .Values.clusterAgent.planeID | default .Release.Name | quote }}
+{{- end }}
+
+{{/*
 Cluster Agent name
 */}}
 {{- define "openchoreo-observability-plane.clusterAgent.name" -}}

--- a/install/helm/openchoreo-observability-plane/templates/cluster-agent/deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/cluster-agent/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         app: cluster-agent
         app.kubernetes.io/component: cluster-agent
         {{- include "openchoreo-observability-plane.selectorLabels" . | nindent 8 }}
+        {{- include "openchoreo-observability-plane.platformIdentityLabels" . | nindent 8 }}
       {{- with .Values.clusterAgent.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/install/helm/openchoreo-observability-plane/templates/controller-manager/deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/controller-manager/deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       labels:
         {{- include "openchoreo-observability-plane.componentSelectorLabels" (dict "context" . "component" .Values.controllerManager.name) | nindent 8 }}
+        {{- include "openchoreo-observability-plane.platformIdentityLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ .Values.controllerManager.name }}
       {{- with .Values.global.imagePullSecrets }}

--- a/install/helm/openchoreo-observability-plane/templates/finops-agent/deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/finops-agent/deployment.yaml
@@ -35,6 +35,7 @@ spec:
         checksum/observer-auth-config: {{ include (print $.Template.BasePath "/observer/observer-auth-configmap.yaml") . | sha256sum }}
       labels:
         {{- include "openchoreo-observability-plane.componentSelectorLabels" (dict "context" . "component" "finops-agent") | nindent 8 }}
+        {{- include "openchoreo-observability-plane.platformIdentityLabels" . | nindent 8 }}
     spec:
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/install/helm/openchoreo-observability-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/gateway/gateway.yaml
@@ -10,10 +10,19 @@ metadata:
   {{- end }}
 spec:
   gatewayClassName: {{ .Values.gateway.gatewayClassName | default "kgateway" }}
-  {{- with .Values.gateway.infrastructure }}
+  {{- /*
+  kgateway renders the proxy pods from this Gateway, so chart label helpers never
+  reach them - platform identity has to travel via spec.infrastructure.labels.
+  Values-supplied labels win on conflict.
+  */}}
+  {{- $infra := .Values.gateway.infrastructure | default dict }}
+  {{- $gwLabels := merge (dict) ($infra.labels | default dict) (include "openchoreo-observability-plane.platformIdentityLabels" . | fromYaml) }}
   infrastructure:
+    {{- with omit $infra "labels" }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
+    labels:
+      {{- toYaml $gwLabels | nindent 6 }}
   listeners:
     - name: http
       protocol: HTTP

--- a/install/helm/openchoreo-observability-plane/templates/gateway/gateway.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/gateway/gateway.yaml
@@ -13,16 +13,15 @@ spec:
   {{- /*
   kgateway renders the proxy pods from this Gateway, so chart label helpers never
   reach them - platform identity has to travel via spec.infrastructure.labels.
-  Values-supplied labels win on conflict.
+  Platform identity labels win over values-supplied ones.
   */}}
   {{- $infra := .Values.gateway.infrastructure | default dict }}
-  {{- $gwLabels := merge (dict) ($infra.labels | default dict) (include "openchoreo-observability-plane.platformIdentityLabels" . | fromYaml) }}
   infrastructure:
     {{- with omit $infra "labels" }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
     labels:
-      {{- toYaml $gwLabels | nindent 6 }}
+      {{- include "openchoreo-observability-plane.gatewayInfrastructureLabels" . | nindent 6 }}
   listeners:
     - name: http
       protocol: HTTP

--- a/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/observer/observer-deployment.yaml
@@ -24,6 +24,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/observer/observer-config.yaml") . | sha256sum }}
       labels:
         {{- include "openchoreo-observability-plane.componentSelectorLabels" (dict "context" . "component" "observer") | nindent 8 }}
+        {{- include "openchoreo-observability-plane.platformIdentityLabels" . | nindent 8 }}
     spec:
       serviceAccountName: observer
       {{- with .Values.global.imagePullSecrets }}

--- a/install/helm/openchoreo-observability-plane/templates/sre-agent/deployment.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/sre-agent/deployment.yaml
@@ -29,6 +29,7 @@ spec:
         checksum/observer-auth-config: {{ include (print $.Template.BasePath "/observer/observer-auth-configmap.yaml") . | sha256sum }}
       labels:
         {{- include "openchoreo-observability-plane.componentSelectorLabels" (dict "context" . "component" .Values.rca.name) | nindent 8 }}
+        {{- include "openchoreo-observability-plane.platformIdentityLabels" . | nindent 8 }}
     spec:
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets:

--- a/install/helm/openchoreo-observability-plane/templates/validate.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/validate.yaml
@@ -1,1 +1,2 @@
 {{- include "openchoreo-observability-plane.validateHostnames" . -}}
+{{- include "openchoreo-observability-plane.validateGatewayLabels" . -}}

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -82,7 +82,9 @@
         },
         "planeID": {
           "default": "default",
-          "description": "Logical plane identifier for multi-tenancy. Multiple CRs with the same planeID share one agent.\nDefaults to Helm release name if not specified.\n",
+          "description": "Logical plane identifier for multi-tenancy. Multiple CRs with the same planeID share one agent.\nDefaults to Helm release name if not specified. Rendered as the openchoreo.dev/plane-id\npod label, so it must be a valid Kubernetes label value.\n",
+          "maxLength": 63,
+          "pattern": "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$",
           "title": "planeID",
           "type": "string"
         },
@@ -1184,7 +1186,7 @@
         },
         "infrastructure": {
           "additionalProperties": true,
-          "description": "Gateway infrastructure configuration passed to the generated Service.\nUsed to configure cloud provider load balancer settings via annotations.\nExample for AWS with Elastic IP:\n  infrastructure:\n    annotations:\n      service.beta.kubernetes.io/aws-load-balancer-type: \"external\"",
+          "description": "Gateway infrastructure configuration passed to the generated Service.\nUsed to configure cloud provider load balancer settings via annotations.\nExample for AWS with Elastic IP:\n  infrastructure:\n    annotations:\n      service.beta.kubernetes.io/aws-load-balancer-type: \"external\"\n\nThe chart always renders spec.infrastructure so platform identity labels\nreach the kgateway proxy pods. That field needs Gateway API \u003e= v1.2 - on\nolder CRDs it is pruned and the proxy pods lose plane attribution.\nlabels is capped at 8 entries by Gateway API, platform identity included.",
           "required": [],
           "title": "infrastructure",
           "type": "object"

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -82,7 +82,7 @@
         },
         "planeID": {
           "default": "default",
-          "description": "Logical plane identifier for multi-tenancy. Multiple CRs with the same planeID share one agent.\nDefaults to Helm release name if not specified. Rendered as the openchoreo.dev/plane-id\npod label, so it must be a valid Kubernetes label value.\n",
+          "description": "Logical plane identifier for multi-tenancy. Multiple CRs with the same planeID share one agent.\nShips as the literal \"default\"; falls back to Helm release name if set as \"\". Rendered as\nthe openchoreo.dev/plane-id pod label, so it must be a valid Kubernetes label value.\n",
           "maxLength": 63,
           "pattern": "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$",
           "title": "planeID",
@@ -1186,7 +1186,23 @@
         },
         "infrastructure": {
           "additionalProperties": true,
-          "description": "Gateway infrastructure configuration passed to the generated Service.\nUsed to configure cloud provider load balancer settings via annotations.\nExample for AWS with Elastic IP:\n  infrastructure:\n    annotations:\n      service.beta.kubernetes.io/aws-load-balancer-type: \"external\"\n\nThe chart always renders spec.infrastructure so platform identity labels\nreach the kgateway proxy pods. That field needs Gateway API \u003e= v1.2 - on\nolder CRDs it is pruned and the proxy pods lose plane attribution.\nlabels is capped at 8 entries by Gateway API, platform identity included.",
+          "description": "Gateway infrastructure configuration passed to the generated Service.\nUsed to configure cloud provider load balancer settings via annotations.\nExample for AWS with Elastic IP:\n  infrastructure:\n    annotations:\n      service.beta.kubernetes.io/aws-load-balancer-type: \"external\"\n\nThe chart always renders spec.infrastructure so platform identity labels\nreach the kgateway proxy pods. That field needs Gateway API \u003e= v1.2 - on\nolder CRDs it is pruned and the proxy pods lose plane attribution.\nlabels is capped at 8 entries by Gateway API, platform identity included.\n",
+          "properties": {
+            "annotations": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "required": [],
+              "type": "object"
+            },
+            "labels": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "required": [],
+              "type": "object"
+            }
+          },
           "required": [],
           "title": "infrastructure",
           "type": "object"

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -346,7 +346,6 @@ controllerManager:
 
 ## Values for dependent charts
 
-
 # @schema
 # type: object
 # additionalProperties: true
@@ -551,10 +550,10 @@ observer:
   #       description: Environment variable value
   # @schema
   extraEnvs:
-  - name: OBSERVER_BASE_URL
-    value: "http://observer.openchoreo.invalid:11080"
-  - name: AUTHZ_TIMEOUT
-    value: "30s"
+    - name: OBSERVER_BASE_URL
+      value: "http://observer.openchoreo.invalid:11080"
+    - name: AUTHZ_TIMEOUT
+      value: "30s"
 
   # @schema
   # type: object
@@ -715,7 +714,6 @@ observer:
   # @schema
   topologySpreadConstraints: []
 
-
 ## Values for local templates
 
 # @schema
@@ -774,8 +772,11 @@ clusterAgent:
   # type: string
   # description: |
   #   Logical plane identifier for multi-tenancy. Multiple CRs with the same planeID share one agent.
-  #   Defaults to Helm release name if not specified.
+  #   Defaults to Helm release name if not specified. Rendered as the openchoreo.dev/plane-id
+  #   pod label, so it must be a valid Kubernetes label value.
   # default: default
+  # pattern: "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
+  # maxLength: 63
   # @schema
   planeID: default
 
@@ -1115,7 +1116,6 @@ clusterAgent:
   # @schema
   topologySpreadConstraints: []
 
-
 # @schema
 # type: object
 # description: Gateway resource configuration for observability plane routing
@@ -1145,6 +1145,11 @@ gateway:
   #     infrastructure:
   #       annotations:
   #         service.beta.kubernetes.io/aws-load-balancer-type: "external"
+  #
+  #   The chart always renders spec.infrastructure so platform identity labels
+  #   reach the kgateway proxy pods. That field needs Gateway API >= v1.2 - on
+  #   older CRDs it is pruned and the proxy pods lose plane attribution.
+  #   labels is capped at 8 entries by Gateway API, platform identity included.
   # @schema
   infrastructure: {}
 
@@ -1227,7 +1232,6 @@ gateway:
     # default: 11443
     # @schema
     port: 11443
-
 
 # @schema
 # type: object
@@ -1496,7 +1500,6 @@ rca:
     # default: ""
     # @schema
     baseUrl: ""
-
 
   # @schema
   # description: Report storage backend type

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -772,8 +772,8 @@ clusterAgent:
   # type: string
   # description: |
   #   Logical plane identifier for multi-tenancy. Multiple CRs with the same planeID share one agent.
-  #   Defaults to Helm release name if not specified. Rendered as the openchoreo.dev/plane-id
-  #   pod label, so it must be a valid Kubernetes label value.
+  #   Ships as the literal "default"; falls back to Helm release name if set as "". Rendered as
+  #   the openchoreo.dev/plane-id pod label, so it must be a valid Kubernetes label value.
   # default: default
   # pattern: "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
   # maxLength: 63
@@ -1150,6 +1150,15 @@ gateway:
   #   reach the kgateway proxy pods. That field needs Gateway API >= v1.2 - on
   #   older CRDs it is pruned and the proxy pods lose plane attribution.
   #   labels is capped at 8 entries by Gateway API, platform identity included.
+  # properties:
+  #   labels:
+  #     type: object
+  #     additionalProperties:
+  #       type: string
+  #   annotations:
+  #     type: object
+  #     additionalProperties:
+  #       type: string
   # @schema
   infrastructure: {}
 

--- a/install/helm/openchoreo-workflow-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-workflow-plane/templates/_helpers.tpl
@@ -123,6 +123,26 @@ app.kubernetes.io/component: {{ .component }}
 {{- end }}
 
 {{/*
+Platform identity labels
+Attribution labels for platform components observability. They let the
+observability plane tell which OpenChoreo plane a log record came from.
+
+MUST be applied to pod templates ONLY - never to spec.selector.matchLabels or a
+Service's spec.selector. Selectors are immutable, so a label that reaches one
+makes `helm upgrade` fail on an existing install instead of adding the label.
+
+Usage:
+  {{ include "openchoreo-workflow-plane.platformIdentityLabels" . }}
+
+Parameters:
+  - The current Helm context (usually .)
+*/}}
+{{- define "openchoreo-workflow-plane.platformIdentityLabels" -}}
+openchoreo.dev/plane: workflowplane
+openchoreo.dev/plane-id: {{ .Values.clusterAgent.planeID | default .Release.Name | quote }}
+{{- end }}
+
+{{/*
 Cluster Agent name
 */}}
 {{- define "openchoreo-workflow-plane.clusterAgent.name" -}}
@@ -173,4 +193,3 @@ Parameters:
 {{- end -}}
 {{- printf "%s:%s" $repo (.image.tag | default .context.Chart.AppVersion) -}}
 {{- end }}
-

--- a/install/helm/openchoreo-workflow-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-workflow-plane/templates/_helpers.tpl
@@ -193,3 +193,36 @@ Parameters:
 {{- end -}}
 {{- printf "%s:%s" $repo (.image.tag | default .context.Chart.AppVersion) -}}
 {{- end }}
+
+{{/*
+Argo Workflows platform identity validation
+
+The argo-workflows subchart carries platform identity through its own
+commonLabels. Helm does not template subchart values, so those labels cannot
+read clusterAgent.planeID and have to repeat it literally. Fail the render
+when the two drift apart rather than let Argo pods report a plane-id that no
+workflow plane actually has.
+
+Usage:
+  {{ include "openchoreo-workflow-plane.validatePlatformIdentity" . }}
+
+Parameters:
+  - The current Helm context (usually .)
+*/}}
+{{- define "openchoreo-workflow-plane.validatePlatformIdentity" -}}
+{{- $errors := list -}}
+{{- $argo := index .Values "argo-workflows" | default (dict) -}}
+{{- $argoLabels := index $argo "commonLabels" | default (dict) -}}
+{{- $planeID := .Values.clusterAgent.planeID | default .Release.Name -}}
+{{- $argoPlaneID := index $argoLabels "openchoreo.dev/plane-id" | default "" -}}
+{{- if ne $argoPlaneID $planeID -}}
+  {{- $errors = append $errors (printf `argo-workflows.commonLabels["openchoreo.dev/plane-id"] is %q but clusterAgent.planeID resolves to %q - set both to the same value` $argoPlaneID $planeID) -}}
+{{- end -}}
+{{- $argoPlane := index $argoLabels "openchoreo.dev/plane" | default "" -}}
+{{- if ne $argoPlane "workflowplane" -}}
+  {{- $errors = append $errors (printf `argo-workflows.commonLabels["openchoreo.dev/plane"] is %q but must be "workflowplane"` $argoPlane) -}}
+{{- end -}}
+{{- if gt (len $errors) 0 -}}
+  {{- fail (printf "Argo Workflows platform identity labels are inconsistent. Without them the observability plane cannot attribute Argo pods to this workflow plane:\n  - %s" (join "\n  - " $errors)) -}}
+{{- end -}}
+{{- end }}

--- a/install/helm/openchoreo-workflow-plane/templates/_helpers.tpl
+++ b/install/helm/openchoreo-workflow-plane/templates/_helpers.tpl
@@ -203,6 +203,14 @@ read clusterAgent.planeID and have to repeat it literally. Fail the render
 when the two drift apart rather than let Argo pods report a plane-id that no
 workflow plane actually has.
 
+Both sides have to be set for the comparison to mean anything:
+  - an absent Argo label is a release upgraded with --reuse-values, which keeps
+    the old commonLabels map and never merges in keys the chart added later
+  - an empty planeID selects the .Release.Name fallback, which a static
+    subchart value cannot express
+Failing either case would block the upgrade without telling the operator
+anything they could act on, so both are skipped.
+
 Usage:
   {{ include "openchoreo-workflow-plane.validatePlatformIdentity" . }}
 
@@ -213,13 +221,13 @@ Parameters:
 {{- $errors := list -}}
 {{- $argo := index .Values "argo-workflows" | default (dict) -}}
 {{- $argoLabels := index $argo "commonLabels" | default (dict) -}}
-{{- $planeID := .Values.clusterAgent.planeID | default .Release.Name -}}
+{{- $planeID := .Values.clusterAgent.planeID | default "" -}}
 {{- $argoPlaneID := index $argoLabels "openchoreo.dev/plane-id" | default "" -}}
-{{- if ne $argoPlaneID $planeID -}}
-  {{- $errors = append $errors (printf `argo-workflows.commonLabels["openchoreo.dev/plane-id"] is %q but clusterAgent.planeID resolves to %q - set both to the same value` $argoPlaneID $planeID) -}}
+{{- if and $argoPlaneID $planeID (ne $argoPlaneID $planeID) -}}
+  {{- $errors = append $errors (printf `argo-workflows.commonLabels["openchoreo.dev/plane-id"] is %q but clusterAgent.planeID is %q - set both to the same value` $argoPlaneID $planeID) -}}
 {{- end -}}
 {{- $argoPlane := index $argoLabels "openchoreo.dev/plane" | default "" -}}
-{{- if ne $argoPlane "workflowplane" -}}
+{{- if and $argoPlane (ne $argoPlane "workflowplane") -}}
   {{- $errors = append $errors (printf `argo-workflows.commonLabels["openchoreo.dev/plane"] is %q but must be "workflowplane"` $argoPlane) -}}
 {{- end -}}
 {{- if gt (len $errors) 0 -}}

--- a/install/helm/openchoreo-workflow-plane/templates/cluster-agent/deployment.yaml
+++ b/install/helm/openchoreo-workflow-plane/templates/cluster-agent/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         app: cluster-agent
         app.kubernetes.io/component: cluster-agent
         {{- include "openchoreo-workflow-plane.selectorLabels" . | nindent 8 }}
+        {{- include "openchoreo-workflow-plane.platformIdentityLabels" . | nindent 8 }}
       {{- with .Values.clusterAgent.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/install/helm/openchoreo-workflow-plane/templates/validate.yaml
+++ b/install/helm/openchoreo-workflow-plane/templates/validate.yaml
@@ -1,0 +1,1 @@
+{{- include "openchoreo-workflow-plane.validatePlatformIdentity" . -}}

--- a/install/helm/openchoreo-workflow-plane/values.schema.json
+++ b/install/helm/openchoreo-workflow-plane/values.schema.json
@@ -11,9 +11,10 @@
             "type": "string"
           },
           "default": {
-            "openchoreo.dev/plane": "workflowplane"
+            "openchoreo.dev/plane": "workflowplane",
+            "openchoreo.dev/plane-id": "default"
           },
-          "description": "Labels applied to all Argo Workflows resources, pod templates included.\nCarries platform identity for system-component observability. Subchart\nvalues are not templated, so plane-id cannot be derived from\nclusterAgent.planeID here - set openchoreo.dev/plane-id explicitly when\nmore than one workflow plane shares a cluster.\n",
+          "description": "Labels applied to all Argo Workflows resources, pod templates included.\nCarries platform identity for system-component observability.\n\nSubchart values are not templated, therefore plane-id should be repeated\nin argo-workflows.commonLabels to match clusterAgent.planeID.\nThe chart fails the render when the two disagree.\n",
           "required": [],
           "title": "commonLabels",
           "type": "object"
@@ -227,7 +228,9 @@
         },
         "planeID": {
           "default": "default",
-          "description": "Logical plane identifier. Shared across multiple CRs connecting to the same physical plane for multi-tenancy.",
+          "description": "Logical plane identifier. Shared across multiple CRs connecting to the same physical plane\nfor multi-tenancy. Rendered as the openchoreo.dev/plane-id pod label, so it must be a valid\nKubernetes label value.\n",
+          "maxLength": 63,
+          "pattern": "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$",
           "title": "planeID",
           "type": "string"
         },

--- a/install/helm/openchoreo-workflow-plane/values.schema.json
+++ b/install/helm/openchoreo-workflow-plane/values.schema.json
@@ -14,7 +14,7 @@
             "openchoreo.dev/plane": "workflowplane",
             "openchoreo.dev/plane-id": "default"
           },
-          "description": "Labels applied to all Argo Workflows resources, pod templates included.\nCarries platform identity for system-component observability.\n\nSubchart values are not templated, therefore plane-id should be repeated\nin argo-workflows.commonLabels to match clusterAgent.planeID.\nThe chart fails the render when the two disagree.\n",
+          "description": "Labels applied to all Argo Workflows resources, pod templates included.\nCarries platform identity for system-component observability.\n\nSubchart values are not templated, therefore plane-id should be repeated\nhere to match clusterAgent.planeID. The chart fails the render when both\nare set and disagree.\n\nA release upgraded with --reuse-values keeps its old commonLabels map and\nnever gains keys the chart added later, so the check is skipped rather\nthan blocking the upgrade. Such a release renders Argo pods without a\nplane-id; set this label explicitly to restore their attribution.\n",
           "required": [],
           "title": "commonLabels",
           "type": "object"
@@ -228,7 +228,7 @@
         },
         "planeID": {
           "default": "default",
-          "description": "Logical plane identifier. Shared across multiple CRs connecting to the same physical plane\nfor multi-tenancy. Rendered as the openchoreo.dev/plane-id pod label, so it must be a valid\nKubernetes label value.\n",
+          "description": "Logical plane identifier. Shared across multiple CRs connecting to the same physical plane\nfor multi-tenancy. Ships as the literal \"default\"; falls back to Helm release name if set as \"\".\nRendered as the openchoreo.dev/plane-id pod label, so it must be a valid Kubernetes label value.\nSet argo-workflows.commonLabels[\"openchoreo.dev/plane-id\"] to match.\n",
           "maxLength": 63,
           "pattern": "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$",
           "title": "planeID",

--- a/install/helm/openchoreo-workflow-plane/values.schema.json
+++ b/install/helm/openchoreo-workflow-plane/values.schema.json
@@ -6,6 +6,18 @@
       "additionalProperties": true,
       "description": "Argo Workflows sub-chart configuration. See https://github.com/argoproj/argo-helm/tree/main/charts/argo-workflows for all options.",
       "properties": {
+        "commonLabels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {
+            "openchoreo.dev/plane": "workflowplane"
+          },
+          "description": "Labels applied to all Argo Workflows resources, pod templates included.\nCarries platform identity for system-component observability. Subchart\nvalues are not templated, so plane-id cannot be derived from\nclusterAgent.planeID here - set openchoreo.dev/plane-id explicitly when\nmore than one workflow plane shares a cluster.\n",
+          "required": [],
+          "title": "commonLabels",
+          "type": "object"
+        },
         "controller": {
           "additionalProperties": true,
           "description": "Argo Workflows controller configuration",

--- a/install/helm/openchoreo-workflow-plane/values.yaml
+++ b/install/helm/openchoreo-workflow-plane/values.yaml
@@ -51,8 +51,13 @@ argo-workflows:
   #   Carries platform identity for system-component observability.
   #
   #   Subchart values are not templated, therefore plane-id should be repeated
-  #   in argo-workflows.commonLabels to match clusterAgent.planeID.
-  #   The chart fails the render when the two disagree.
+  #   here to match clusterAgent.planeID. The chart fails the render when both
+  #   are set and disagree.
+  #
+  #   A release upgraded with --reuse-values keeps its old commonLabels map and
+  #   never gains keys the chart added later, so the check is skipped rather
+  #   than blocking the upgrade. Such a release renders Argo pods without a
+  #   plane-id; set this label explicitly to restore their attribution.
   # properties: {}
   # additionalProperties:
   #   type: string
@@ -223,8 +228,9 @@ clusterAgent:
   # type: string
   # description: |
   #   Logical plane identifier. Shared across multiple CRs connecting to the same physical plane
-  #   for multi-tenancy. Rendered as the openchoreo.dev/plane-id pod label, so it must be a valid
-  #   Kubernetes label value.
+  #   for multi-tenancy. Ships as the literal "default"; falls back to Helm release name if set as "".
+  #   Rendered as the openchoreo.dev/plane-id pod label, so it must be a valid Kubernetes label value.
+  #   Set argo-workflows.commonLabels["openchoreo.dev/plane-id"] to match.
   # default: default
   # pattern: "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
   # maxLength: 63

--- a/install/helm/openchoreo-workflow-plane/values.yaml
+++ b/install/helm/openchoreo-workflow-plane/values.yaml
@@ -48,17 +48,19 @@ argo-workflows:
   # type: object
   # description: |
   #   Labels applied to all Argo Workflows resources, pod templates included.
-  #   Carries platform identity for system-component observability. Subchart
-  #   values are not templated, so plane-id cannot be derived from
-  #   clusterAgent.planeID here - set openchoreo.dev/plane-id explicitly when
-  #   more than one workflow plane shares a cluster.
+  #   Carries platform identity for system-component observability.
+  #
+  #   Subchart values are not templated, therefore plane-id should be repeated
+  #   in argo-workflows.commonLabels to match clusterAgent.planeID.
+  #   The chart fails the render when the two disagree.
   # properties: {}
   # additionalProperties:
   #   type: string
-  # default: {"openchoreo.dev/plane": "workflowplane"}
+  # default: {"openchoreo.dev/plane": "workflowplane", "openchoreo.dev/plane-id": "default"}
   # @schema
   commonLabels:
     openchoreo.dev/plane: workflowplane
+    openchoreo.dev/plane-id: default
 
   # @schema
   # type: object
@@ -219,8 +221,13 @@ clusterAgent:
 
   # @schema
   # type: string
-  # description: Logical plane identifier. Shared across multiple CRs connecting to the same physical plane for multi-tenancy.
+  # description: |
+  #   Logical plane identifier. Shared across multiple CRs connecting to the same physical plane
+  #   for multi-tenancy. Rendered as the openchoreo.dev/plane-id pod label, so it must be a valid
+  #   Kubernetes label value.
   # default: default
+  # pattern: "^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$"
+  # maxLength: 63
   # @schema
   planeID: default
 

--- a/install/helm/openchoreo-workflow-plane/values.yaml
+++ b/install/helm/openchoreo-workflow-plane/values.yaml
@@ -46,6 +46,22 @@ argo-workflows:
 
   # @schema
   # type: object
+  # description: |
+  #   Labels applied to all Argo Workflows resources, pod templates included.
+  #   Carries platform identity for system-component observability. Subchart
+  #   values are not templated, so plane-id cannot be derived from
+  #   clusterAgent.planeID here - set openchoreo.dev/plane-id explicitly when
+  #   more than one workflow plane shares a cluster.
+  # properties: {}
+  # additionalProperties:
+  #   type: string
+  # default: {"openchoreo.dev/plane": "workflowplane"}
+  # @schema
+  commonLabels:
+    openchoreo.dev/plane: workflowplane
+
+  # @schema
+  # type: object
   # additionalProperties: true
   # description: Argo Workflows controller configuration
   # @schema

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -75,6 +75,13 @@ const (
 	// network access to user workloads. Used in NetworkPolicy rules to allow ingress from system components.
 	LabelKeySystemComponent = "openchoreo.dev/system-component"
 
+	// LabelKeyPlane and LabelKeyPlaneID attribute a platform (system component) pod to the
+	// OpenChoreo plane that owns it, for platform observability. Stamped by the plane Helm
+	// charts on pod templates.
+	// LabelKeyPlaneID is omitted on the control plane, which is a singleton.
+	LabelKeyPlane   = "openchoreo.dev/plane"
+	LabelKeyPlaneID = "openchoreo.dev/plane-id"
+
 	// AnnotationKeyDPResourceHash contains a hash of all dataplane resources (excluding the main workload)
 	// to trigger pod rollout when dependent ConfigMaps, Secrets, etc. change.
 	AnnotationKeyDPResourceHash = "openchoreo.dev/dp-resource-hash"


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request introduces standardized "platform identity" labels across the OpenChoreo Helm charts for the control plane, data plane, and observability plane. These labels are designed to improve observability by clearly attributing logs and metrics to their originating plane and, where applicable, to a specific plane instance. The implementation ensures these labels are only applied to pod templates and not to selectors, preventing Helm upgrade issues. The changes also handle special cases for gateway resources to ensure proxy pods receive the correct labels.

**Key changes include:**

### Platform Identity Label Helpers

* Added new helper template functions in `_helpers.tpl` for each plane (`openchoreo-control-plane`, `openchoreo-data-plane`, and `openchoreo-observability-plane`) to define and render standardized platform identity labels. These include `openchoreo.dev/plane` and, where relevant, `openchoreo.dev/plane-id`. [[1]](diffhunk://#diff-cc9be2ad96ae5dce5184683e0c3adbeabcc2810ffa6eec66d05ff25268f930b2R125-R144) [[2]](diffhunk://#diff-a9e6fff7de81d54b87ec4d2765bf8e392817e176e444a4a4bc4a95ffd9bede07R125-R144) [[3]](diffhunk://#diff-c2ade933845c611d00d80f770d7ac7485eff883c53c116ea309116e6f50dbea6R125-R144)

### Pod Template Label Application

* Updated all relevant deployment and job templates in each plane to include the new platform identity labels in their pod template `metadata.labels` section, ensuring consistent attribution across all components. [[1]](diffhunk://#diff-41c7949d2590562d873ecf791f3cd8285d365136ebb48f7ac348fc2fbbd52872R22) [[2]](diffhunk://#diff-6ebcbe56d2db84b3d19122f2f124ea4b80cfd2e1f69d0d437dd37c703eac836aR23) [[3]](diffhunk://#diff-a45d2be7e0c8d7a460e3ebfa78e9bb2c3215f5acc06e0f2b7f5b865fc287a7deR24) [[4]](diffhunk://#diff-d91ca347bc242625b313c1675af9bebe1b58eba269127615ae47f9ac392114e5R24) [[5]](diffhunk://#diff-ede85f70aae3cf586fc9e7416f60b9affbaa6ad7d14115e03a231c261680f837R27) [[6]](diffhunk://#diff-cf43fa4d9e932c0f37cf8bc798cafdb1346bd78315406354e976c28b54930d5bR26) [[7]](diffhunk://#diff-e2b553aaa8885095827ab408b5428de3e0087d4c7770bff872791826ff8a0af1R29) [[8]](diffhunk://#diff-4894598c663ef3d5b6f8fff89e3329f33b56289f60b00279cb76b1a8552b3f10R23) [[9]](diffhunk://#diff-db7e91a724e644211d4f0b6166f122d52169e9269ff07bd3d51dbf417c27378cR62) [[10]](diffhunk://#diff-059700323280c8d14db0c8e0b1f00b1800f220008bbaae9d9e93c82ed078a946R23) [[11]](diffhunk://#diff-d773a095dd6c37a8fba3f79d3481def35817268aec1299fabf7f2c9f572ba250R18) [[12]](diffhunk://#diff-c44b65324cb3025c8535acc1ee6a5d92c54df29d7195014394574e89040e37daR38) [[13]](diffhunk://#diff-f9a62b2edc4ff66205af1531e9988574d7f2f1cd01aabdf96b2383e89301a440R27) [[14]](diffhunk://#diff-27e7b53ea47b10cc6dcf2b9dff648a1db3cd9320b58f9c85e8dd42503a214144R32)

### Gateway Resource Handling

* Modified gateway templates for all planes to merge platform identity labels into `spec.infrastructure.labels`, ensuring that proxy pods (which are not rendered by the chart directly) also receive the correct labels. Values-supplied labels take precedence in case of conflicts. [[1]](diffhunk://#diff-8ba72a2a70717e93780e4598d11433469901143f8352b81bdff6cdaae8c911f4L13-R25) [[2]](diffhunk://#diff-a26ded2d6a36e686ab0ed587b6b5f667ebe1d123862790538ad8852e813cdccdL15-R27) [[3]](diffhunk://#diff-d3d547788fed8ee75d5938ece49abd0b9e2da2d520631f94505507ea9c6541f2L13-R25)

These changes standardize observability and attribution across the OpenChoreo platform, making it easier to identify the source of logs and metrics in multi-plane deployments.

## Approach
Adds a platformIdentityLabels helper to each plane chart and includes it in every pod template:

  `openchoreo.dev/plane`     controlplane | dataplane | workflowplane | observabilityplane
  `openchoreo.dev/plane-id`  the install's planeID, omitted on the control plane because it is a singleton

kgateway renders the gateway proxy pods from the Gateway CR, where no chart helper reaches them, so the same labels travel via `spec.infrastructure.labels.`

Upgrade note: this mutates pod templates, so it triggers one rolling restart of the control plane, agents and gateways. Selectors are untouched, so the upgrade itself succeeds.


## Related Issues
https://github.com/openchoreo/openchoreo/issues/4554
Epic: https://github.com/openchoreo/openchoreo/issues/4089

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
