### PR TITLE
revert: "refactor: replace GET method API in Observer used to fetch span details with a POST method API (Backport to release-v1.2) (#4546) (#4617)"

### DIFF
--- a/cmd/observer/main.go
+++ b/cmd/observer/main.go
@@ -266,7 +266,7 @@ func main() {
 	api.HandleFunc("POST /api/v1alpha1/metrics/runtime-topology", newAPIHandler.QueryRuntimeTopology)
 	api.HandleFunc("POST /api/v1alpha1/traces/query", newAPIHandler.QueryTraces)
 	api.HandleFunc("POST /api/v1alpha1/traces/{traceId}/spans/query", newAPIHandler.QuerySpansForTrace)
-	api.HandleFunc("POST /api/v1alpha1/traces/{traceId}/spans/{spanId}", newAPIHandler.QuerySpanDetailsForTrace)
+	api.HandleFunc("GET /api/v1alpha1/traces/{traceId}/spans/{spanId}", newAPIHandler.GetSpanDetailsForTrace)
 	api.HandleFunc("POST /api/v1alpha1/alerts/query", newAPIHandler.QueryAlerts)
 	api.HandleFunc("POST /api/v1alpha1/incidents/query", newAPIHandler.QueryIncidents)
 	api.HandleFunc("PUT /api/v1alpha1/incidents/{incidentId}", newAPIHandler.UpdateIncident)

--- a/internal/observer/api/gen/client.gen.go
+++ b/internal/observer/api/gen/client.gen.go
@@ -155,10 +155,8 @@ type ClientInterface interface {
 
 	QuerySpansForTrace(ctx context.Context, traceId string, body QuerySpansForTraceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// QuerySpanDetailsForTraceWithBody request with any body
-	QuerySpanDetailsForTraceWithBody(ctx context.Context, traceId string, spanId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	QuerySpanDetailsForTrace(ctx context.Context, traceId string, spanId string, body QuerySpanDetailsForTraceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// GetSpanDetailsForTrace request
+	GetSpanDetailsForTrace(ctx context.Context, traceId string, spanId string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// Health request
 	Health(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -476,20 +474,8 @@ func (c *Client) QuerySpansForTrace(ctx context.Context, traceId string, body Qu
 	return c.Client.Do(req)
 }
 
-func (c *Client) QuerySpanDetailsForTraceWithBody(ctx context.Context, traceId string, spanId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewQuerySpanDetailsForTraceRequestWithBody(c.Server, traceId, spanId, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) QuerySpanDetailsForTrace(ctx context.Context, traceId string, spanId string, body QuerySpanDetailsForTraceJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewQuerySpanDetailsForTraceRequest(c.Server, traceId, spanId, body)
+func (c *Client) GetSpanDetailsForTrace(ctx context.Context, traceId string, spanId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetSpanDetailsForTraceRequest(c.Server, traceId, spanId)
 	if err != nil {
 		return nil, err
 	}
@@ -1109,19 +1095,8 @@ func NewQuerySpansForTraceRequestWithBody(server string, traceId string, content
 	return req, nil
 }
 
-// NewQuerySpanDetailsForTraceRequest calls the generic QuerySpanDetailsForTrace builder with application/json body
-func NewQuerySpanDetailsForTraceRequest(server string, traceId string, spanId string, body QuerySpanDetailsForTraceJSONRequestBody) (*http.Request, error) {
-	var bodyReader io.Reader
-	buf, err := json.Marshal(body)
-	if err != nil {
-		return nil, err
-	}
-	bodyReader = bytes.NewReader(buf)
-	return NewQuerySpanDetailsForTraceRequestWithBody(server, traceId, spanId, "application/json", bodyReader)
-}
-
-// NewQuerySpanDetailsForTraceRequestWithBody generates requests for QuerySpanDetailsForTrace with any type of body
-func NewQuerySpanDetailsForTraceRequestWithBody(server string, traceId string, spanId string, contentType string, body io.Reader) (*http.Request, error) {
+// NewGetSpanDetailsForTraceRequest generates requests for GetSpanDetailsForTrace
+func NewGetSpanDetailsForTraceRequest(server string, traceId string, spanId string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -1153,12 +1128,10 @@ func NewQuerySpanDetailsForTraceRequestWithBody(server string, traceId string, s
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", queryURL.String(), body)
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
-
-	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -1299,10 +1272,8 @@ type ClientWithResponsesInterface interface {
 
 	QuerySpansForTraceWithResponse(ctx context.Context, traceId string, body QuerySpansForTraceJSONRequestBody, reqEditors ...RequestEditorFn) (*QuerySpansForTraceResp, error)
 
-	// QuerySpanDetailsForTraceWithBodyWithResponse request with any body
-	QuerySpanDetailsForTraceWithBodyWithResponse(ctx context.Context, traceId string, spanId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*QuerySpanDetailsForTraceResp, error)
-
-	QuerySpanDetailsForTraceWithResponse(ctx context.Context, traceId string, spanId string, body QuerySpanDetailsForTraceJSONRequestBody, reqEditors ...RequestEditorFn) (*QuerySpanDetailsForTraceResp, error)
+	// GetSpanDetailsForTraceWithResponse request
+	GetSpanDetailsForTraceWithResponse(ctx context.Context, traceId string, spanId string, reqEditors ...RequestEditorFn) (*GetSpanDetailsForTraceResp, error)
 
 	// HealthWithResponse request
 	HealthWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*HealthResp, error)
@@ -1667,7 +1638,7 @@ func (r QuerySpansForTraceResp) StatusCode() int {
 	return 0
 }
 
-type QuerySpanDetailsForTraceResp struct {
+type GetSpanDetailsForTraceResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *TraceSpanDetailsResponse
@@ -1678,7 +1649,7 @@ type QuerySpanDetailsForTraceResp struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r QuerySpanDetailsForTraceResp) Status() string {
+func (r GetSpanDetailsForTraceResp) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -1686,7 +1657,7 @@ func (r QuerySpanDetailsForTraceResp) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r QuerySpanDetailsForTraceResp) StatusCode() int {
+func (r GetSpanDetailsForTraceResp) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -1943,21 +1914,13 @@ func (c *ClientWithResponses) QuerySpansForTraceWithResponse(ctx context.Context
 	return ParseQuerySpansForTraceResp(rsp)
 }
 
-// QuerySpanDetailsForTraceWithBodyWithResponse request with arbitrary body returning *QuerySpanDetailsForTraceResp
-func (c *ClientWithResponses) QuerySpanDetailsForTraceWithBodyWithResponse(ctx context.Context, traceId string, spanId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*QuerySpanDetailsForTraceResp, error) {
-	rsp, err := c.QuerySpanDetailsForTraceWithBody(ctx, traceId, spanId, contentType, body, reqEditors...)
+// GetSpanDetailsForTraceWithResponse request returning *GetSpanDetailsForTraceResp
+func (c *ClientWithResponses) GetSpanDetailsForTraceWithResponse(ctx context.Context, traceId string, spanId string, reqEditors ...RequestEditorFn) (*GetSpanDetailsForTraceResp, error) {
+	rsp, err := c.GetSpanDetailsForTrace(ctx, traceId, spanId, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseQuerySpanDetailsForTraceResp(rsp)
-}
-
-func (c *ClientWithResponses) QuerySpanDetailsForTraceWithResponse(ctx context.Context, traceId string, spanId string, body QuerySpanDetailsForTraceJSONRequestBody, reqEditors ...RequestEditorFn) (*QuerySpanDetailsForTraceResp, error) {
-	rsp, err := c.QuerySpanDetailsForTrace(ctx, traceId, spanId, body, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseQuerySpanDetailsForTraceResp(rsp)
+	return ParseGetSpanDetailsForTraceResp(rsp)
 }
 
 // HealthWithResponse request returning *HealthResp
@@ -2690,15 +2653,15 @@ func ParseQuerySpansForTraceResp(rsp *http.Response) (*QuerySpansForTraceResp, e
 	return response, nil
 }
 
-// ParseQuerySpanDetailsForTraceResp parses an HTTP response from a QuerySpanDetailsForTraceWithResponse call
-func ParseQuerySpanDetailsForTraceResp(rsp *http.Response) (*QuerySpanDetailsForTraceResp, error) {
+// ParseGetSpanDetailsForTraceResp parses an HTTP response from a GetSpanDetailsForTraceWithResponse call
+func ParseGetSpanDetailsForTraceResp(rsp *http.Response) (*GetSpanDetailsForTraceResp, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &QuerySpanDetailsForTraceResp{
+	response := &GetSpanDetailsForTraceResp{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/internal/observer/api/gen/models.gen.go
+++ b/internal/observer/api/gen/models.gen.go
@@ -1080,11 +1080,6 @@ type SpanStatus struct {
 // SpanStatusCode The status code of the span. One of "ok", "error", or "unset".
 type SpanStatusCode string
 
-// TraceSpanDetailsRequest defines model for TraceSpanDetailsRequest.
-type TraceSpanDetailsRequest struct {
-	SearchScope ComponentSearchScope `json:"searchScope"`
-}
-
 // TraceSpanDetailsResponse defines model for TraceSpanDetailsResponse.
 type TraceSpanDetailsResponse struct {
 	// Attributes The span attributes
@@ -1269,9 +1264,6 @@ type QueryTracesJSONRequestBody = TracesQueryRequest
 
 // QuerySpansForTraceJSONRequestBody defines body for QuerySpansForTrace for application/json ContentType.
 type QuerySpansForTraceJSONRequestBody = TracesQueryRequest
-
-// QuerySpanDetailsForTraceJSONRequestBody defines body for QuerySpanDetailsForTrace for application/json ContentType.
-type QuerySpanDetailsForTraceJSONRequestBody = TraceSpanDetailsRequest
 
 // AsComponentSearchScope returns the union data inside the EventsQueryRequest_SearchScope as a ComponentSearchScope
 func (t EventsQueryRequest_SearchScope) AsComponentSearchScope() (ComponentSearchScope, error) {

--- a/internal/observer/api/gen/server.gen.go
+++ b/internal/observer/api/gen/server.gen.go
@@ -67,8 +67,8 @@ type ServerInterface interface {
 	// (POST /api/v1alpha1/traces/{traceId}/spans/query)
 	QuerySpansForTrace(w http.ResponseWriter, r *http.Request, traceId string)
 	// Get details of a span for a trace
-	// (POST /api/v1alpha1/traces/{traceId}/spans/{spanId})
-	QuerySpanDetailsForTrace(w http.ResponseWriter, r *http.Request, traceId string, spanId string)
+	// (GET /api/v1alpha1/traces/{traceId}/spans/{spanId})
+	GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request, traceId string, spanId string)
 	// Health check
 	// (GET /health)
 	Health(w http.ResponseWriter, r *http.Request)
@@ -450,8 +450,8 @@ func (siw *ServerInterfaceWrapper) QuerySpansForTrace(w http.ResponseWriter, r *
 	handler.ServeHTTP(w, r)
 }
 
-// QuerySpanDetailsForTrace operation middleware
-func (siw *ServerInterfaceWrapper) QuerySpanDetailsForTrace(w http.ResponseWriter, r *http.Request) {
+// GetSpanDetailsForTrace operation middleware
+func (siw *ServerInterfaceWrapper) GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request) {
 
 	var err error
 
@@ -480,7 +480,7 @@ func (siw *ServerInterfaceWrapper) QuerySpanDetailsForTrace(w http.ResponseWrite
 	r = r.WithContext(ctx)
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.QuerySpanDetailsForTrace(w, r, traceId, spanId)
+		siw.Handler.GetSpanDetailsForTrace(w, r, traceId, spanId)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -638,7 +638,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/metrics/runtime-topology", wrapper.QueryRuntimeTopology)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/traces/query", wrapper.QueryTraces)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/traces/{traceId}/spans/query", wrapper.QuerySpansForTrace)
-	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/traces/{traceId}/spans/{spanId}", wrapper.QuerySpanDetailsForTrace)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1alpha1/traces/{traceId}/spans/{spanId}", wrapper.GetSpanDetailsForTrace)
 	m.HandleFunc("GET "+options.BaseURL+"/health", wrapper.Health)
 
 	return m
@@ -1348,55 +1348,54 @@ func (response QuerySpansForTrace500JSONResponse) VisitQuerySpansForTraceRespons
 	return json.NewEncoder(w).Encode(response)
 }
 
-type QuerySpanDetailsForTraceRequestObject struct {
+type GetSpanDetailsForTraceRequestObject struct {
 	TraceId string `json:"traceId"`
 	SpanId  string `json:"spanId"`
-	Body    *QuerySpanDetailsForTraceJSONRequestBody
 }
 
-type QuerySpanDetailsForTraceResponseObject interface {
-	VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error
+type GetSpanDetailsForTraceResponseObject interface {
+	VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error
 }
 
-type QuerySpanDetailsForTrace200JSONResponse TraceSpanDetailsResponse
+type GetSpanDetailsForTrace200JSONResponse TraceSpanDetailsResponse
 
-func (response QuerySpanDetailsForTrace200JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response GetSpanDetailsForTrace200JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type QuerySpanDetailsForTrace400JSONResponse ErrorResponse
+type GetSpanDetailsForTrace400JSONResponse ErrorResponse
 
-func (response QuerySpanDetailsForTrace400JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response GetSpanDetailsForTrace400JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(400)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type QuerySpanDetailsForTrace401JSONResponse ErrorResponse
+type GetSpanDetailsForTrace401JSONResponse ErrorResponse
 
-func (response QuerySpanDetailsForTrace401JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response GetSpanDetailsForTrace401JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(401)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type QuerySpanDetailsForTrace403JSONResponse ErrorResponse
+type GetSpanDetailsForTrace403JSONResponse ErrorResponse
 
-func (response QuerySpanDetailsForTrace403JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response GetSpanDetailsForTrace403JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(403)
 
 	return json.NewEncoder(w).Encode(response)
 }
 
-type QuerySpanDetailsForTrace500JSONResponse ErrorResponse
+type GetSpanDetailsForTrace500JSONResponse ErrorResponse
 
-func (response QuerySpanDetailsForTrace500JSONResponse) VisitQuerySpanDetailsForTraceResponse(w http.ResponseWriter) error {
+func (response GetSpanDetailsForTrace500JSONResponse) VisitGetSpanDetailsForTraceResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(500)
 
@@ -1478,8 +1477,8 @@ type StrictServerInterface interface {
 	// (POST /api/v1alpha1/traces/{traceId}/spans/query)
 	QuerySpansForTrace(ctx context.Context, request QuerySpansForTraceRequestObject) (QuerySpansForTraceResponseObject, error)
 	// Get details of a span for a trace
-	// (POST /api/v1alpha1/traces/{traceId}/spans/{spanId})
-	QuerySpanDetailsForTrace(ctx context.Context, request QuerySpanDetailsForTraceRequestObject) (QuerySpanDetailsForTraceResponseObject, error)
+	// (GET /api/v1alpha1/traces/{traceId}/spans/{spanId})
+	GetSpanDetailsForTrace(ctx context.Context, request GetSpanDetailsForTraceRequestObject) (GetSpanDetailsForTraceResponseObject, error)
 	// Health check
 	// (GET /health)
 	Health(ctx context.Context, request HealthRequestObject) (HealthResponseObject, error)
@@ -1949,33 +1948,26 @@ func (sh *strictHandler) QuerySpansForTrace(w http.ResponseWriter, r *http.Reque
 	}
 }
 
-// QuerySpanDetailsForTrace operation middleware
-func (sh *strictHandler) QuerySpanDetailsForTrace(w http.ResponseWriter, r *http.Request, traceId string, spanId string) {
-	var request QuerySpanDetailsForTraceRequestObject
+// GetSpanDetailsForTrace operation middleware
+func (sh *strictHandler) GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request, traceId string, spanId string) {
+	var request GetSpanDetailsForTraceRequestObject
 
 	request.TraceId = traceId
 	request.SpanId = spanId
 
-	var body QuerySpanDetailsForTraceJSONRequestBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
-		return
-	}
-	request.Body = &body
-
 	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.QuerySpanDetailsForTrace(ctx, request.(QuerySpanDetailsForTraceRequestObject))
+		return sh.ssi.GetSpanDetailsForTrace(ctx, request.(GetSpanDetailsForTraceRequestObject))
 	}
 	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "QuerySpanDetailsForTrace")
+		handler = middleware(handler, "GetSpanDetailsForTrace")
 	}
 
 	response, err := handler(r.Context(), w, r, request)
 
 	if err != nil {
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(QuerySpanDetailsForTraceResponseObject); ok {
-		if err := validResponse.VisitQuerySpanDetailsForTraceResponse(w); err != nil {
+	} else if validResponse, ok := response.(GetSpanDetailsForTraceResponseObject); ok {
+		if err := validResponse.VisitGetSpanDetailsForTraceResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {
@@ -2079,45 +2071,44 @@ var swaggerSpec = []string{
 	"tjN/78BcjVYSMMvWvsW+DrWAqPyBev+Jaw86FR2aIQZT7a//PLIs6cqo4VHNR4qJJe6F0FlqgzZL0E2x",
 	"l71DdDZL56yeSu1s7B7cRcW3zZc5JJeBfKJTdVWJKWlkFfEckhiMaZbRO0tfKWRXKEPSbVioEUCDBTOa",
 	"oswXMUhRawqTatzhzDgAH/WBaRjRW33UUj0v5I+UgWFUEC5PXW58VTd9Nl0r1PNASCDQfuI9mqNMYr0/",
-	"holcauNYYFB1XhqAq0WOE5hlC+mOaB2q3Dy1HswrtAfdspKuGEyQ3Kb3SECc8eAN96PviFuM0nUnxII1",
-	"VUIwPCpMzh1MdQtUmH1yRvmchSuz9cAB4Ou3aRpIngfSGtJGg0kFEhNAIKFVNkMpcpiIf//Rm97QyyWU",
-	"s3R2BXMoDy2SmKEcYT1C4+7vt2vzCI4fQW0LYwXFeQuiLRjKR926YxjieSF0yzINQujr3fXaxyo1s038",
-	"HKXbLvKrUpQkbity+PWQcP7+TjR3orlSNDsJ1l9CNDeRI6xEcmv5dAr6mpl0SvF8v0Q6c9irS0kZThjD",
-	"jHeJJzTUUnlfUZ533XiCAuoPKOyK4/5cKb815g5Z1HXkWSjAWxNoDb6DRMeRHtruEJgxQY+gr8lW8LZv",
-	"s9U0nTXJFHLVrLClLg6SReluVOuYQg4gMd0UtcnwawdGqeMULFt889ja1OCA89BtssQtlOJQS5ktzYlL",
-	"Jo9S6Sug/SiuRoccD01bv+ehnnVzHBqL617L4xuxlC7vKwBYq9f09+j56qv9WFpQe4KCgPw2yI13Bv5F",
-	"EeLYHp1dlYlLCobF4lLaMY3dTwgyxI4LMZW/jdRvP1ty/P3L1ZLd+vuXKyCoVMfq4x2FmCIiTJf3ATgz",
-	"7oBiHDXKiMixaYGqtdgUQWn0IAcvNAJAXUMk6hV9I/FCagBlcJUOUKOqXVE5fA8Pyn0ZU/MNGAH1raa+",
-	"dnXvFK8QnC3VGDf7DX60iQnHn85Azugcp4iXl4cqFq/tjymg4PGQWDMBSZmno2Pg5U7o9yonoryl40vX",
-	"dBIg5OAOZZkkjSoAUcAsH/DBkJwJ9bGZCYPSzVL5Qjb+3vjw14ymRYa0w4VEomsqYSIKmKnMDjDHcEjk",
-	"YhOYZfqiR45IYS4o45YEKRhpi2vg6Vh+hhNkbLkh93EOkykCrwfSShYsM7vEjw4O7u7uBlA9HlA2OTDv",
-	"8oMPZyen55en+68Hh4OpmGVOt90osDFRHM0R43oDXw0OB4fmYzoE5jg6it4MDgdvInmAFFPF4DYfUXc+",
-	"Oyi/PJJ7UwSUo+J20TT92Mp7DU8/Y/2BHkyVVdIQdG+6qMya+4mmC8ukJrUD5nlmxObgX6YTpfYvOzWd",
-	"q58XHuqKwFTJWedb0eH14eF2MDBOnUKhEcpuabD3EEc/dsKobOZcaz0dRU4Aeb02z4bPnFbND3HX9dda",
-	"ZHtWfkbmMMOpvZPTq321odVa4JSBmVm40pvOomotpze3rM8NsD8evtnQmi4L3a1Wm4Fviz/MtbT0DAkF",
-	"OWJqqVQdAuYY3VnBpGNQ5b+MKY2BzWIZQRaDKmVqBP+QtujUyYpI9UWD7QRgaFf1594c4X52Yb59DN+b",
-	"lumn+4evagR0FuBrH75J1jbJQBo8KOG/3RiDO3pDJakQKgCuWp9be+R8aU6ZSmW4tJNgKNFomb45IpxT",
-	"AWqQ3VtiY0SQtQECTrh0zoxRuJaDrVWSiHezSZU30N0MfaCTbRmhpUr3JzZBy6XEnm36ECwZ3pmfnfl5",
-	"lPlR4vgXNT4f9l+/e1bGx6N9M636rO5VmrCmeWv1SauUb+1o113/2vqF7ahgXwX+E2thb7W2Z9/MuEfq",
-	"4u+tHb+rGvt+yuDJZXdWio0VXytIrgSblGn9jbxuYmy+0tdTio/tV/i2IcSeD5Q/sQz7vmnt2T49bCfB",
-	"OwnuIMHVhyuNABsZCsuvKUw6uNc/XC1y9HDAisx0mYAMzpBAjKv01+CnjZe/96s+S/4yo5PYqBWVt6i/",
-	"8runvrUVHalgYWTLdaIKg6gph64j0/sDwtdxQDmdMAQFApDUPqVOuqko/fJx+XH0LaopCb+Xknq12fkx",
-	"mUgULhckWampNBETRZznqK3ePd38Dj1gxhBMFwB9w1zwZ6lArDDUPqv+eC1ycC//U70xtABmSHhzj+Xf",
-	"1xRF/XJdFLdptPvLg172c5SHH7+LPBAqwFh9gPE5ioJlxlZRiCPTc6RRZIrEmlz8CxJPx8LapHTaKyYt",
-	"LJrvuPf/CfcqDlzBun8Kvy5elUFTo4IHMWuZWtHyeZOFR/A/5+n6zqR++Xk6k9/deBaKOM9P/Tw7ybcs",
-	"uJYLd4dGU0pvw6GcXyFJVVpL2eW+GdaBZn9t94klNtcgFCpfzHRb5HQzxfdk9hKFVYxuqA+mikI7Xg/x",
-	"ukmki45+v3Y5fy3eXC0aZRvybmHOqh16z0jnmdPufBvi4P/2zhMLROBzLd79t3TcRT13Uc/VUc/a1wKM",
-	"UFci1SrX99XXah46BTyXv14DBDUuit/LdL6Hs1k/s0Sgn5d5Vn2uYpu6xvmk53dSNO6XL1u0zLP1L/+i",
-	"SuZJT/UlEzzvM70RevfDPF30XKitVdiRuVAlfFxXauC56VlrW+CU7XRUCULZMUw1I5vgOSJuVv3RkMCy",
-	"Dkv1hwEv3XR80wmJx1XPvDLnf0/lbVWvq541Q/Ky7L9j4hO2i5JpNe22peZ7MUAwmepU/eW2nkPy0jZn",
-	"TWhBRGzKoMwvpmGr0y+W71WdU5ab9w5JvXuv39FrNHbZkgoOdEZ7YjUcatjkEYGLZrumnd+38/tW+33N",
-	"Ll+OWmwKmkc56hKibic7U/Ta81h3ZYtPtyHknur1JxZwX4mxZz/1sJ1I70S6g0iX9dpWkI0MheX33tTi",
-	"Phyo0uBu8qyriLUXo8t1e4q26lfzM2VXpki3x7nR1vV6joq2rLjnOfFPrF48fYE8/KVG7TTMTsN00DBL",
-	"ov8YZXOvGxA9hPXNL0iAVLeMkwoA6i4M9ekD+sV0mnsWWiZun830JvJd/uquEc9Fo3laC34vtdZsJBjQ",
-	"ayX37NTbTr2tyvtYpWm8im6KYKbbUHgzmk6mKLnVnwlQAxv9UZv+0mD51lfDf6RMNXoBlv3NypKpSKO3",
-	"6NJCxCNqGnuAObBw1Ca/eQSSuhdrDUeaI9NR/ggklBCUqL4cY4gzlLY3cquAFGRTS60gtd6u6n1PJCM4",
-	"TGT29fqh8W69ucnv11Khm3fulwtFbX6ZG/6rzIeqH1u2Ps1GEe1ATAHwMhh3Yb4XzQofrh/+LwAA//9a",
-	"y6cElb8AAA==",
+	"holcauNYYFB1XhqAq0WOE5hlC+mOaB2q3Dy1HswrtAfdspKuGEyQ3Kb3SECc8ZbSJSEYHhUmtQ2mutMo",
+	"zD45o3w2+cpQGDgAfG0tTZ/G80D2QNro46hAYgIIJLRKGig5GxPx7z96swh6eV5yls4eVw7l2UASM5SK",
+	"q0do3P1tbe11/fEjqG1hrKA4b0G0BUP5qFsTCkM8L4RuyZxBCH2dqF77WGVAtpkfR7e1S9aqTCCJ24pU",
+	"eT0knCa/E82daK4UzU6C9ZcQzU2k4iqR3FramoK+ZsKaUjzfL1/NnKnqUlKe2scw412O7Q21VF4LlMdK",
+	"99iugPrP7bsatD9XZm2NuUMWdR15Fgrw1gRag+8g0XGkh7Y7BGZM0CPoa7IVvO3bbDVNZ00yhVz1BGwp",
+	"P4NkUbob1TqmkANITNNCbTL82oFR6jgFyxbfPLY2NTjgPHRpK3ELZRLUMlNLc+KSyaNU+gpoP4qr0SHH",
+	"Q9PW73moZ90ch8biupfM+EYsZaX78uzXaun8PVqr+koslhbUngcgIL8NcuOdgX9RhDi2RwNVZeKSgmGx",
+	"uJR2TGP3E4IMseNCTOVvI/Xbz5Ycf/9ytWS3/v7lCggq1bH6RkYhpogI00x9AM6MO6AYR40yInJsOo1q",
+	"LTZFUBo9yMELjQBQ0f5EvaID/y+kBlAGV+kANaraFZUq9/Cg3JcxNZ9aEVBfHurbTffq7grB2VIpb7Ot",
+	"30d7/3/86QzkjM5xinh5R6dC3tr+mDoFHg+JNROQlOkwOtRc7oR+r3IiysswvnQbJgFCDu5QlknSqDoL",
+	"BczyAR8MyZlQ33SZMCjdLJWWY8Pcje9rzWhaZEg7XEgkunQRJqKAmUqgAHMMh0QuNoFZpu9T5IgU5oIy",
+	"bkmQgpG2uAaeDplnOEHGlhtyH+cwmSLweiCtZMEys0v86ODg7u5uANXjAWWTA/MuP/hwdnJ6fnm6/3pw",
+	"OJiKWeY0tY0CGxPF0Rwxrjfw1eBwcGi+WUNgjqOj6M3gcPAmkgdIMVUMbtP+dIOxg/IDH7n3Jl45Km6z",
+	"StP2rLw+8LQN1t/BwVRZJQ1Bt4CLyuS0n2i6sExqMihgnmdGbA7+ZRo+av+yU2+3+nnhoa4ITDGadb4V",
+	"HV4fHm4HA+PUKRQaEeOWPnYPcfRjJ4zKnsm1Ds9R5MRp1+umbPjM6Yj8EHddf60TtWflZ2QOM5zaqy+9",
+	"2lcbWq0FThmYmYUrveksqtbZeXPL+twA++Phmw2t6bLQTWG1Gfi2+MPc/krPkFCQI6aWStUhYI7RnRVM",
+	"OgZVmsmY0hjYZJERZDGoMpNG8A9pi06d5INUx/Ntwb2hXdUGe3OE+9mF+fYxfG86k5/uH76qEdBZgK9L",
+	"9yZZ2+TcaPCghP92Ywzu6A2VC0KoALjqMG7tkfNBN2UqleHSToKhRKMz+eaIcE4FqEF2L2ONEUHWBgg4",
+	"4dI5M0bhWg62Vkki3s0mVd5AdzP0gU62ZYSWCsqf2AQtV+x6tulDsDJ3Z3525udR5keJ41/U+HzYf/3u",
+	"WRkfj/bNtOqzuldpwprmrZUBrVK+taNdd/1rywS2o4J9he5PrIW9RdGefTPjHqmLv7d2/K5q7PspgyeX",
+	"3VkpNlZ8rSC5Emwyk/Wn6LqJsfkYXk8pPrYfu9uGEHu+A/7EMuz7dLRn+/SwnQTvJLiDBFffhzQCbGQo",
+	"LL+m/ufgXv9wtcjRwwErMtPMATI4QwIxrrJMg18QXv6srvr698uMTmKjVlR6oP6Y7p76pFV0pIKFka2K",
+	"iSoMoqYcuo5M7+/0XscB5XTCEBQIQFL7YjnppqL0y8flN8i3qKYk/F5K6tVm58dkIlG4XJBkpabSREwU",
+	"cZ6jtnr3dPM79IAZQzBdAPQNc8GfpQKxwlD7evnjtcjBvfxPtaDQApgh4U3xlX9fUxT1y3VR3KbR7i8P",
+	"etnPUR5+/C7yQKgAY/Wdw+coCpYZW0Uhjkxrj0YtJxJrcvEvSDwdC2uT0mmvmLSwaL7j3v8n3Ks4cAXr",
+	"/in8unhVBk2NCh7ErGVqRcvnTRYewf+cp+s7k/rl5+lMfnfjWSjiPD/18+wk37LgWi7cHRpNKb0Nh3J+",
+	"hSRVaS1lM/lmWAea/bVNHpbYXINQqHwx022R080U35PZSxRWMbqhPpgqCu14PcTrJpEuOvr92uX8tXhz",
+	"tWiU3b67hTmrruM9I51nTlfxbYiD/xM3TywQga+iePff0nEX9dxFPVdHPWtN+Y1QVyLVKtf31UdhHjoF",
+	"PJc/EgMENS6K38t0PjuzWT+zRKCfl3lWfRVim7rG+XLmd1I07gcmW7TMs/Uv/6JK5klP9SUTPO8zvRF6",
+	"9/s3XfRcqHtU2JG5UCV8XFdq4LlpDWs7zZRda1QJQtmYS/X8muA5Im5W/dGQwLIOS7VhAS/ddHzTcIjH",
+	"VWu6Mud/T+VtVa+r1jBD8rJsc2PiE7ZZkeno7HZ/5nsxQDCZ6lT95e6ZQ/LS9kBNaEFEbMqgzC+mL6rT",
+	"lpXvVQ1KlnvkDkm9Sa7f0Wv0T9mSCg40IHtiNRzqi+QRgYtmV6Sd37fz+1b7fc1mWo5abAqaRznqEqJu",
+	"JztT9NrzWHdli0+3IeSe6vUnFnBfibFnP/WwnUjvRLqDSJf12laQjQyF5ffe1OI+HKjS4G7yrKuItRej",
+	"y3V7irbqV/MzZVemSLfHudHW9XqOirasuOc58U+sXjx9gTz8pUbtNMxOw3TQMEui/xhlc68bEKnQUTAd",
+	"INUd46T8Q92EYT3F8wsSTgO6Z6F84vbZTMsi352wbibRW9FtW9c0u/sFlE25pzuds9M5q5IxWuU/pH2m",
+	"CGa6N4RXr5xMUXKrW+SrgY3eoE1dMli+itXwHylTjQZ9ZdOxso4p0ugtuvT18Iiaxh5gDiwctclvHoGk",
+	"7kNaw5HmyHRTPwIJJQQlqlnGGOIMpe3d1SogBdnUUitIrVeeet8TyQgOE5l9vX5ovFvvOPL7tVSn5p37",
+	"5epNm/TlxuQq5a2KupZ1f7N7QzsQU5W7DMZdmO9Fs8KH64f/CwAA//+jbxN7kb4AAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/observer/api/handlers/scope_auth_test.go
+++ b/internal/observer/api/handlers/scope_auth_test.go
@@ -191,23 +191,23 @@ func TestQuerySpans_ScopeAuthFailed_Returns500WithCode(t *testing.T) {
 	assertScopeAuthFailedResponse(t, rr)
 }
 
-func TestQuerySpanDetails_ScopeAuthFailed_Returns500WithCode(t *testing.T) {
+func TestGetSpanDetails_ScopeAuthFailed_Returns500WithCode(t *testing.T) {
 	t.Parallel()
 
 	svc := servicemocks.NewMockTracesQuerier(t)
-	svc.On("QuerySpanDetails", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("%w: token expired after idle", service.ErrScopeAuthFailed))
+	svc.On("GetSpanDetails", mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("%w: token expired after idle", service.ErrScopeAuthFailed))
 
 	h := &Handler{
 		baseHandler:   baseHandler{logger: noopLogger()},
 		tracesService: svc,
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/trace-1/spans/span-1", spanDetailsBody("test-ns"))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/span-1", nil)
 	req.SetPathValue("traceId", "trace-1")
 	req.SetPathValue("spanId", "span-1")
 	rr := httptest.NewRecorder()
 
-	h.QuerySpanDetailsForTrace(rr, req)
+	h.GetSpanDetailsForTrace(rr, req)
 
 	assertScopeAuthFailedResponse(t, rr)
 }

--- a/internal/observer/api/handlers/traces.go
+++ b/internal/observer/api/handlers/traces.go
@@ -210,22 +210,14 @@ func (h *Handler) QuerySpansForTrace(w http.ResponseWriter, r *http.Request) {
 	h.writeJSON(w, http.StatusOK, genResp)
 }
 
-// QuerySpanDetailsForTrace handles POST /api/v1alpha1/traces/{traceId}/spans/{spanId}
-func (h *Handler) QuerySpanDetailsForTrace(w http.ResponseWriter, r *http.Request) {
+// GetSpanDetailsForTrace handles GET /api/v1alpha1/traces/{traceId}/spans/{spanId}
+func (h *Handler) GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request) {
 	traceID := r.PathValue("traceId")
 	spanID := r.PathValue("spanId")
 
-	h.logger.Debug("QuerySpanDetailsForTrace called", "traceId", traceID, "spanId", spanID)
+	h.logger.Debug("GetSpanDetailsForTrace called", "traceId", traceID, "spanId", spanID)
 
-	// 1. BIND REQUEST (from generated type)
-	var genReq gen.TraceSpanDetailsRequest
-	if err := httputil.BindJSON(r, &genReq); err != nil {
-		h.logger.Error("Failed to bind request", "error", err)
-		h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, "", "Invalid request format")
-		return
-	}
-
-	// 2. VALIDATE REQUEST
+	// 1. VALIDATE PATH PARAMETERS
 	if traceID == "" {
 		h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, types.ErrorCodeV1TracesInvalidRequest, "traceId is required")
 		return
@@ -234,23 +226,8 @@ func (h *Handler) QuerySpanDetailsForTrace(w http.ResponseWriter, r *http.Reques
 		h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, types.ErrorCodeV1TracesInvalidRequest, "spanId is required")
 		return
 	}
-	if genReq.SearchScope.Namespace == "" {
-		h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, types.ErrorCodeV1TracesInvalidRequest, "searchScope.namespace is required")
-		return
-	}
 
-	scope := types.ComponentSearchScope{
-		Namespace:   genReq.SearchScope.Namespace,
-		Project:     derefString(genReq.SearchScope.Project),
-		Component:   derefString(genReq.SearchScope.Component),
-		Environment: derefString(genReq.SearchScope.Environment),
-	}
-	if scope.Component != "" && scope.Project == "" {
-		h.writeErrorResponse(w, http.StatusBadRequest, gen.BadRequest, types.ErrorCodeV1TracesInvalidRequest, "searchScope.project is required when searchScope.component is provided")
-		return
-	}
-
-	// 3. CHECK SERVICE INITIALIZATION
+	// 2. CHECK SERVICE INITIALIZATION
 	if h.tracesService == nil {
 		h.logger.Error("Traces service is not initialized")
 		h.writeErrorResponse(
@@ -263,18 +240,10 @@ func (h *Handler) QuerySpanDetailsForTrace(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// 4. CALL SERVICE (authorization is enforced by the service layer)
+	// 3. CALL SERVICE
 	ctx := r.Context()
-	spanInfo, err := h.tracesService.QuerySpanDetails(ctx, traceID, spanID, scope)
+	spanInfo, err := h.tracesService.GetSpanDetails(ctx, traceID, spanID)
 	if err != nil {
-		if errors.Is(err, observerAuthz.ErrAuthzForbidden) {
-			h.writeErrorResponse(w, http.StatusForbidden, gen.Forbidden, "", "Access denied")
-			return
-		}
-		if errors.Is(err, observerAuthz.ErrAuthzUnauthorized) {
-			h.writeErrorResponse(w, http.StatusUnauthorized, gen.Unauthorized, "", "Unauthorized")
-			return
-		}
 		h.logger.Error("Failed to get span details", "error", err)
 		errorCode := types.ErrorCodeV1TracesInternalGeneric
 		switch {
@@ -307,7 +276,7 @@ func (h *Handler) QuerySpanDetailsForTrace(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	// 5. CONVERT TO GENERATED TYPE AND RETURN
+	// 4. CONVERT TO GENERATED TYPE AND RETURN
 	genResp := convertSpanDetailsToGen(spanInfo)
 	h.writeJSON(w, http.StatusOK, genResp)
 }

--- a/internal/observer/api/handlers/traces_handler_test.go
+++ b/internal/observer/api/handlers/traces_handler_test.go
@@ -4,7 +4,7 @@
 package handlers
 
 // traces_handler_test.go covers the HTTP handler paths for QueryTraces,
-// QuerySpansForTrace, and QuerySpanDetailsForTrace that are NOT already covered
+// QuerySpansForTrace, and GetSpanDetailsForTrace that are NOT already covered
 // by scope_auth_test.go (scope-auth error) or traces_test.go (conversion functions).
 
 import (
@@ -338,52 +338,148 @@ func TestQuerySpansForTrace_GenericError(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesInternalGeneric)
 }
 
-// QuerySpanDetailsForTrace tests -------------------------------------------------
+// GetSpanDetailsForTrace tests ---------------------------------------------------
 
-func spanDetailsBody(namespace string) *strings.Reader {
-	return strings.NewReader(`{"searchScope":{"namespace":"` + namespace + `"}}`)
-}
-
-func TestQuerySpanDetailsForTrace_Success(t *testing.T) {
+func TestGetSpanDetailsForTrace_Success(t *testing.T) {
 	t.Parallel()
 
 	svc := servicemocks.NewMockTracesQuerier(t)
-	svc.On("QuerySpanDetails", mock.Anything, "trace-1", "span-1", types.ComponentSearchScope{Namespace: "test-ns"}).
-		Return(&types.SpanInfo{SpanID: "span-1"}, nil)
+	svc.On("GetSpanDetails", mock.Anything, mock.Anything, mock.Anything).Return(&types.SpanInfo{SpanID: "span-1"}, nil)
 
 	h := &Handler{
 		baseHandler:   baseHandler{logger: noopLogger()},
 		tracesService: svc,
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/trace-1/spans/span-1", spanDetailsBody("test-ns"))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/span-1", nil)
 	req.SetPathValue("traceId", "trace-1")
 	req.SetPathValue("spanId", "span-1")
 	rr := httptest.NewRecorder()
 
-	h.QuerySpanDetailsForTrace(rr, req)
+	h.GetSpanDetailsForTrace(rr, req)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
-func TestQuerySpanDetailsForTrace_AuthzForbidden(t *testing.T) {
+func TestGetSpanDetailsForTrace_EmptyTraceID(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: servicemocks.NewMockTracesQuerier(t),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces//spans/span-1", nil)
+	req.SetPathValue("traceId", "")
+	req.SetPathValue("spanId", "span-1")
+	rr := httptest.NewRecorder()
+
+	h.GetSpanDetailsForTrace(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "traceId is required")
+}
+
+func TestGetSpanDetailsForTrace_EmptySpanID(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: servicemocks.NewMockTracesQuerier(t),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/", nil)
+	req.SetPathValue("traceId", "trace-1")
+	req.SetPathValue("spanId", "")
+	rr := httptest.NewRecorder()
+
+	h.GetSpanDetailsForTrace(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "spanId is required")
+}
+
+func TestGetSpanDetailsForTrace_ServiceNotInitialized(t *testing.T) {
+	t.Parallel()
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: nil,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/span-1", nil)
+	req.SetPathValue("traceId", "trace-1")
+	req.SetPathValue("spanId", "span-1")
+	rr := httptest.NewRecorder()
+
+	h.GetSpanDetailsForTrace(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesServiceNotReady)
+}
+
+func TestGetSpanDetailsForTrace_SpanNotFound(t *testing.T) {
 	t.Parallel()
 
 	svc := servicemocks.NewMockTracesQuerier(t)
-	svc.On("QuerySpanDetails", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return(nil, observerAuthz.ErrAuthzForbidden)
+	svc.On("GetSpanDetails", mock.Anything, mock.Anything, mock.Anything).Return(nil, service.ErrSpanNotFound)
 
 	h := &Handler{
 		baseHandler:   baseHandler{logger: noopLogger()},
 		tracesService: svc,
 	}
 
-	req := httptest.NewRequest(http.MethodPost, "/api/v1alpha1/traces/trace-1/spans/span-1", spanDetailsBody("test-ns"))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/span-99", nil)
+	req.SetPathValue("traceId", "trace-1")
+	req.SetPathValue("spanId", "span-99")
+	rr := httptest.NewRecorder()
+
+	h.GetSpanDetailsForTrace(rr, req)
+
+	require.Equal(t, http.StatusNotFound, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesSpanNotFound)
+}
+
+func TestGetSpanDetailsForTrace_RetrievalError(t *testing.T) {
+	t.Parallel()
+
+	svc := servicemocks.NewMockTracesQuerier(t)
+	svc.On("GetSpanDetails", mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("%w: backend", service.ErrTracesRetrieval))
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: svc,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/span-1", nil)
 	req.SetPathValue("traceId", "trace-1")
 	req.SetPathValue("spanId", "span-1")
 	rr := httptest.NewRecorder()
 
-	h.QuerySpanDetailsForTrace(rr, req)
+	h.GetSpanDetailsForTrace(rr, req)
 
-	assert.Equal(t, http.StatusForbidden, rr.Code)
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesRetrievalFailed)
+}
+
+func TestGetSpanDetailsForTrace_GenericError(t *testing.T) {
+	t.Parallel()
+
+	svc := servicemocks.NewMockTracesQuerier(t)
+	svc.On("GetSpanDetails", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("unexpected"))
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: svc,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/span-1", nil)
+	req.SetPathValue("traceId", "trace-1")
+	req.SetPathValue("spanId", "span-1")
+	rr := httptest.NewRecorder()
+
+	h.GetSpanDetailsForTrace(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesInternalGeneric)
 }

--- a/internal/observer/mcp/handlers.go
+++ b/internal/observer/mcp/handlers.go
@@ -231,15 +231,8 @@ func (h *MCPHandler) QueryTraceSpans(ctx context.Context, traceID, namespace, pr
 	return h.tracesService.QuerySpans(ctx, traceID, req)
 }
 
-func (h *MCPHandler) GetSpanDetails(ctx context.Context, traceID, spanID,
-	namespace, project, component, environment string) (any, error) {
-	scope := types.ComponentSearchScope{
-		Namespace:   namespace,
-		Project:     project,
-		Component:   component,
-		Environment: environment,
-	}
-	return h.tracesService.QuerySpanDetails(ctx, traceID, spanID, scope)
+func (h *MCPHandler) GetSpanDetails(ctx context.Context, traceID, spanID string) (any, error) {
+	return h.tracesService.GetSpanDetails(ctx, traceID, spanID)
 }
 
 func (h *MCPHandler) QueryAlerts(ctx context.Context, namespace, project, component, environment,

--- a/internal/observer/mcp/server.go
+++ b/internal/observer/mcp/server.go
@@ -324,28 +324,14 @@ func registerTools(s *mcpsdk.Server, handler *MCPHandler) {
 		Name:        "get_span_details",
 		Description: "Get full details for a specific span within a trace in OpenChoreo. Returns complete span information including attributes, resource attributes, parent span ID, and timing details. Use trace_id and span_id from query_trace_spans results.",
 		InputSchema: createSchema(map[string]any{
-			"trace_id":    stringProperty("Trace ID containing the span (required)"),
-			"span_id":     stringProperty("Span ID to retrieve details for (required)"),
-			"namespace":   stringProperty("Organization namespace (required)"),
-			"project":     stringProperty("Project name"),
-			"component":   stringProperty("Component name"),
-			"environment": stringProperty("Environment name"),
-		}, []string{"trace_id", "span_id", "namespace"}),
+			"trace_id": stringProperty("Trace ID containing the span (required)"),
+			"span_id":  stringProperty("Span ID to retrieve details for (required)"),
+		}, []string{"trace_id", "span_id"}),
 	}, func(ctx context.Context, req *mcpsdk.CallToolRequest, args struct {
-		TraceID     string `json:"trace_id"`
-		SpanID      string `json:"span_id"`
-		Namespace   string `json:"namespace"`
-		Project     string `json:"project"`
-		Component   string `json:"component"`
-		Environment string `json:"environment"`
+		TraceID string `json:"trace_id"`
+		SpanID  string `json:"span_id"`
 	}) (*mcpsdk.CallToolResult, any, error) {
-		if err := validateComponentScope(args.Namespace, args.Project, args.Component); err != nil {
-			return nil, nil, err
-		}
-		result, err := handler.GetSpanDetails(ctx,
-			args.TraceID, args.SpanID,
-			args.Namespace, args.Project, args.Component, args.Environment,
-		)
+		result, err := handler.GetSpanDetails(ctx, args.TraceID, args.SpanID)
 		return handleToolResult(result, err)
 	})
 

--- a/internal/observer/mcp/server_test.go
+++ b/internal/observer/mcp/server_test.go
@@ -145,7 +145,6 @@ type MockTracesQuerier struct {
 	spansRequests       []*types.TracesQueryRequest
 	spanDetailsTraceIDs []string
 	spanDetailsSpanIDs  []string
-	spanDetailsScopes   []types.ComponentSearchScope
 	tracesResponse      *types.TracesQueryResponse
 	spansResponse       *types.SpansQueryResponse
 	spanInfo            *types.SpanInfo
@@ -196,12 +195,9 @@ func (m *MockTracesQuerier) QuerySpans(_ context.Context, traceID string, req *t
 	return m.spansResponse, nil
 }
 
-func (m *MockTracesQuerier) QuerySpanDetails(_ context.Context, traceID string, spanID string,
-	scope types.ComponentSearchScope,
-) (*types.SpanInfo, error) {
+func (m *MockTracesQuerier) GetSpanDetails(_ context.Context, traceID string, spanID string) (*types.SpanInfo, error) {
 	m.spanDetailsTraceIDs = append(m.spanDetailsTraceIDs, traceID)
 	m.spanDetailsSpanIDs = append(m.spanDetailsSpanIDs, spanID)
-	m.spanDetailsScopes = append(m.spanDetailsScopes, scope)
 	if m.spanDetailsErr != nil {
 		return nil, m.spanDetailsErr
 	}
@@ -227,7 +223,6 @@ func (m *MockTracesQuerier) reset() {
 	m.spansRequests = nil
 	m.spanDetailsTraceIDs = nil
 	m.spanDetailsSpanIDs = nil
-	m.spanDetailsScopes = nil
 }
 
 type MockAlertIncidentService struct {
@@ -626,29 +621,19 @@ var allToolSpecs = []toolTestSpec{
 		name:                "get_span_details",
 		descriptionKeywords: []string{"span"},
 		descriptionMinLen:   20,
-		requiredParams:      []string{"trace_id", "span_id", "namespace"},
-		optionalParams:      []string{"project", "component", "environment"},
+		requiredParams:      []string{"trace_id", "span_id"},
+		optionalParams:      []string{},
 		testArgs: map[string]any{
-			"trace_id":    testTraceID,
-			"span_id":     testSpanID,
-			"namespace":   testNamespace,
-			"project":     testProject,
-			"component":   testComponent,
-			"environment": testEnvironment,
+			"trace_id": testTraceID,
+			"span_id":  testSpanID,
 		},
 		validateCall: func(t *testing.T, svcs *testServices) {
 			t.Helper()
-			require.NotEmpty(t, svcs.traces.spanDetailsTraceIDs, "Expected QuerySpanDetails to be called")
-			require.NotEmpty(t, svcs.traces.spanDetailsSpanIDs, "Expected QuerySpanDetails to be called")
-			require.NotEmpty(t, svcs.traces.spanDetailsScopes, "Expected QuerySpanDetails scope to be recorded")
+			require.NotEmpty(t, svcs.traces.spanDetailsTraceIDs, "Expected GetSpanDetails to be called")
+			require.NotEmpty(t, svcs.traces.spanDetailsSpanIDs, "Expected GetSpanDetails to be called")
 			lastIdx := len(svcs.traces.spanDetailsSpanIDs) - 1
 			assert.Equal(t, testTraceID, svcs.traces.spanDetailsTraceIDs[lastIdx])
 			assert.Equal(t, testSpanID, svcs.traces.spanDetailsSpanIDs[lastIdx])
-			scope := svcs.traces.spanDetailsScopes[lastIdx]
-			assert.Equal(t, testNamespace, scope.Namespace)
-			assert.Equal(t, testProject, scope.Project)
-			assert.Equal(t, testComponent, scope.Component)
-			assert.Equal(t, testEnvironment, scope.Environment)
 		},
 	},
 	{
@@ -1038,9 +1023,8 @@ func TestMinimalParameterSets(t *testing.T) {
 			name:     "get_span_details_minimal",
 			toolName: "get_span_details",
 			args: map[string]any{
-				"trace_id":  testTraceID,
-				"span_id":   testSpanID,
-				"namespace": testNamespace,
+				"trace_id": testTraceID,
+				"span_id":  testSpanID,
 			},
 		},
 		{
@@ -1187,9 +1171,8 @@ func TestHandlerErrorPropagation(t *testing.T) {
 			name:     "span_details_service_error",
 			toolName: "get_span_details",
 			args: map[string]any{
-				"trace_id":  testTraceID,
-				"span_id":   testSpanID,
-				"namespace": testNamespace,
+				"trace_id": testTraceID,
+				"span_id":  testSpanID,
 			},
 			setupErr: func(s *testServices) { s.traces.spanDetailsErr = errors.New("span not found") },
 		},
@@ -1538,12 +1521,8 @@ func TestSchemaPropertyTypes(t *testing.T) {
 			"sort_order":  "string",
 		},
 		"get_span_details": {
-			"trace_id":    "string",
-			"span_id":     "string",
-			"namespace":   "string",
-			"project":     "string",
-			"component":   "string",
-			"environment": "string",
+			"trace_id": "string",
+			"span_id":  "string",
 		},
 	}
 

--- a/internal/observer/service/authz_test.go
+++ b/internal/observer/service/authz_test.go
@@ -294,41 +294,18 @@ func TestTracesAuthz_QuerySpans_Denied(t *testing.T) {
 	assert.ErrorIs(t, err, observerAuthz.ErrAuthzForbidden)
 }
 
-func TestTracesAuthz_QuerySpanDetails_Allowed(t *testing.T) {
-	scope := types.ComponentSearchScope{Namespace: "ns", Project: "proj", Component: "comp", Environment: "env"}
-
+func TestTracesAuthz_GetSpanDetails_PassThrough(t *testing.T) {
 	inner := mocks.NewMockTracesQuerier(t)
 	expected := &types.SpanInfo{SpanID: "span-1"}
-	inner.EXPECT().QuerySpanDetails(mock.Anything, "trace-1", "span-1", scope).Return(expected, nil)
+	inner.EXPECT().GetSpanDetails(mock.Anything, "trace-1", "span-1").Return(expected, nil)
 
-	var gotReq *authzcore.EvaluateRequest
+	// PDP with no Evaluate expectation — testify will fail if Evaluate is called
 	pdp := coremocks.NewMockPDP(t)
-	pdp.EXPECT().Evaluate(mock.Anything, mock.Anything).
-		Run(func(_ context.Context, req *authzcore.EvaluateRequest) { gotReq = req }).
-		Return(&authzcore.Decision{Decision: true}, nil).Once()
-
 	svc := NewTracesServiceWithAuthz(inner, pdp, testLogger())
 
-	resp, err := svc.QuerySpanDetails(authedCtx(), "trace-1", "span-1", scope)
+	resp, err := svc.GetSpanDetails(context.Background(), "trace-1", "span-1")
 	require.NoError(t, err)
 	assert.Equal(t, expected, resp)
-
-	require.NotNil(t, gotReq)
-	assert.Equal(t, string(observerAuthz.ActionViewTraces), gotReq.Action)
-	assert.Equal(t, string(observerAuthz.ResourceTypeComponent), gotReq.Resource.Type)
-	assert.Equal(t, "comp", gotReq.Resource.ID)
-	assert.Equal(t, authzcore.ResourceHierarchy{Namespace: "ns", Project: "proj", Component: "comp"}, gotReq.Resource.Hierarchy)
-	assert.Equal(t, "ns/env", gotReq.Context.Resource.Environment)
-}
-
-func TestTracesAuthz_QuerySpanDetails_Denied(t *testing.T) {
-	inner := mocks.NewMockTracesQuerier(t)
-
-	svc := NewTracesServiceWithAuthz(inner, mockPDPDeny(t), testLogger())
-
-	_, err := svc.QuerySpanDetails(authedCtx(), "trace-1", "span-1",
-		types.ComponentSearchScope{Namespace: "ns", Project: "proj"})
-	assert.ErrorIs(t, err, observerAuthz.ErrAuthzForbidden)
 }
 
 // --- MetricsQuerier QueryRuntimeTopology Authz Tests ---

--- a/internal/observer/service/interfaces.go
+++ b/internal/observer/service/interfaces.go
@@ -35,7 +35,7 @@ type MetricsQuerier interface {
 type TracesQuerier interface {
 	QueryTraces(ctx context.Context, req *types.TracesQueryRequest) (*types.TracesQueryResponse, error)
 	QuerySpans(ctx context.Context, traceID string, req *types.TracesQueryRequest) (*types.SpansQueryResponse, error)
-	QuerySpanDetails(ctx context.Context, traceID string, spanID string, scope types.ComponentSearchScope) (*types.SpanInfo, error)
+	GetSpanDetails(ctx context.Context, traceID string, spanID string) (*types.SpanInfo, error)
 }
 
 // AlertsQuerier is the interface for querying alerts.

--- a/internal/observer/service/mocks/tracesquerier.go
+++ b/internal/observer/service/mocks/tracesquerier.go
@@ -23,29 +23,29 @@ func (_m *MockTracesQuerier) EXPECT() *MockTracesQuerier_Expecter {
 	return &MockTracesQuerier_Expecter{mock: &_m.Mock}
 }
 
-// QuerySpanDetails provides a mock function with given fields: ctx, traceID, spanID, scope
-func (_m *MockTracesQuerier) QuerySpanDetails(ctx context.Context, traceID string, spanID string, scope types.ComponentSearchScope) (*types.SpanInfo, error) {
-	ret := _m.Called(ctx, traceID, spanID, scope)
+// GetSpanDetails provides a mock function with given fields: ctx, traceID, spanID
+func (_m *MockTracesQuerier) GetSpanDetails(ctx context.Context, traceID string, spanID string) (*types.SpanInfo, error) {
+	ret := _m.Called(ctx, traceID, spanID)
 
 	if len(ret) == 0 {
-		panic("no return value specified for QuerySpanDetails")
+		panic("no return value specified for GetSpanDetails")
 	}
 
 	var r0 *types.SpanInfo
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, types.ComponentSearchScope) (*types.SpanInfo, error)); ok {
-		return rf(ctx, traceID, spanID, scope)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*types.SpanInfo, error)); ok {
+		return rf(ctx, traceID, spanID)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, types.ComponentSearchScope) *types.SpanInfo); ok {
-		r0 = rf(ctx, traceID, spanID, scope)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *types.SpanInfo); ok {
+		r0 = rf(ctx, traceID, spanID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*types.SpanInfo)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, types.ComponentSearchScope) error); ok {
-		r1 = rf(ctx, traceID, spanID, scope)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, traceID, spanID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -53,33 +53,32 @@ func (_m *MockTracesQuerier) QuerySpanDetails(ctx context.Context, traceID strin
 	return r0, r1
 }
 
-// MockTracesQuerier_QuerySpanDetails_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'QuerySpanDetails'
-type MockTracesQuerier_QuerySpanDetails_Call struct {
+// MockTracesQuerier_GetSpanDetails_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSpanDetails'
+type MockTracesQuerier_GetSpanDetails_Call struct {
 	*mock.Call
 }
 
-// QuerySpanDetails is a helper method to define mock.On call
+// GetSpanDetails is a helper method to define mock.On call
 //   - ctx context.Context
 //   - traceID string
 //   - spanID string
-//   - scope types.ComponentSearchScope
-func (_e *MockTracesQuerier_Expecter) QuerySpanDetails(ctx interface{}, traceID interface{}, spanID interface{}, scope interface{}) *MockTracesQuerier_QuerySpanDetails_Call {
-	return &MockTracesQuerier_QuerySpanDetails_Call{Call: _e.mock.On("QuerySpanDetails", ctx, traceID, spanID, scope)}
+func (_e *MockTracesQuerier_Expecter) GetSpanDetails(ctx interface{}, traceID interface{}, spanID interface{}) *MockTracesQuerier_GetSpanDetails_Call {
+	return &MockTracesQuerier_GetSpanDetails_Call{Call: _e.mock.On("GetSpanDetails", ctx, traceID, spanID)}
 }
 
-func (_c *MockTracesQuerier_QuerySpanDetails_Call) Run(run func(ctx context.Context, traceID string, spanID string, scope types.ComponentSearchScope)) *MockTracesQuerier_QuerySpanDetails_Call {
+func (_c *MockTracesQuerier_GetSpanDetails_Call) Run(run func(ctx context.Context, traceID string, spanID string)) *MockTracesQuerier_GetSpanDetails_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(types.ComponentSearchScope))
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
 	})
 	return _c
 }
 
-func (_c *MockTracesQuerier_QuerySpanDetails_Call) Return(_a0 *types.SpanInfo, _a1 error) *MockTracesQuerier_QuerySpanDetails_Call {
+func (_c *MockTracesQuerier_GetSpanDetails_Call) Return(_a0 *types.SpanInfo, _a1 error) *MockTracesQuerier_GetSpanDetails_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockTracesQuerier_QuerySpanDetails_Call) RunAndReturn(run func(context.Context, string, string, types.ComponentSearchScope) (*types.SpanInfo, error)) *MockTracesQuerier_QuerySpanDetails_Call {
+func (_c *MockTracesQuerier_GetSpanDetails_Call) RunAndReturn(run func(context.Context, string, string) (*types.SpanInfo, error)) *MockTracesQuerier_GetSpanDetails_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/observer/service/traces.go
+++ b/internal/observer/service/traces.go
@@ -158,8 +158,8 @@ func (s *TracesService) QuerySpans(ctx context.Context, traceID string, req *typ
 	return s.convertAdapterSpansToResponse(spansResult), nil
 }
 
-// QuerySpanDetails retrieves detailed information about a specific span within a scope.
-func (s *TracesService) QuerySpanDetails(ctx context.Context, traceID string, spanID string, scope types.ComponentSearchScope) (*types.SpanInfo, error) {
+// GetSpanDetails retrieves detailed information about a specific span.
+func (s *TracesService) GetSpanDetails(ctx context.Context, traceID string, spanID string) (*types.SpanInfo, error) {
 	if traceID == "" {
 		return nil, fmt.Errorf("%w: traceId is required", ErrTracesInvalidRequest)
 	}
@@ -167,24 +167,11 @@ func (s *TracesService) QuerySpanDetails(ctx context.Context, traceID string, sp
 		return nil, fmt.Errorf("%w: spanId is required", ErrTracesInvalidRequest)
 	}
 
-	s.logger.Debug("QuerySpanDetails called",
+	s.logger.Info("GetSpanDetails called",
 		"traceId", traceID,
 		"spanId", spanID)
 
-	projectUID, componentUID, environmentUID, err := s.resolveSearchScope(ctx, &scope)
-	if err != nil {
-		s.logger.Error("Failed to resolve search scope", "error", err)
-		return nil, fmt.Errorf("%w: %w", ErrTracesResolveSearchScope, err)
-	}
-
-	params := observability.TracesQueryParams{
-		Namespace:     scope.Namespace,
-		ProjectID:     projectUID,
-		ComponentID:   componentUID,
-		EnvironmentID: environmentUID,
-	}
-
-	detail, err := s.tracingAdapter.QuerySpanDetails(ctx, traceID, spanID, params)
+	detail, err := s.tracingAdapter.GetSpanDetails(ctx, traceID, spanID)
 	if err != nil {
 		s.logger.Error("Failed to retrieve span details", "error", err)
 		if errors.Is(err, ErrSpanNotFound) {
@@ -192,10 +179,6 @@ func (s *TracesService) QuerySpanDetails(ctx context.Context, traceID string, sp
 		}
 		return nil, fmt.Errorf("%w: %w", ErrTracesRetrieval, err)
 	}
-	return spanDetailToInfo(detail), nil
-}
-
-func spanDetailToInfo(detail *observability.SpanDetail) *types.SpanInfo {
 	return &types.SpanInfo{
 		SpanID:             detail.SpanID,
 		SpanName:           detail.SpanName,
@@ -207,7 +190,7 @@ func spanDetailToInfo(detail *observability.SpanDetail) *types.SpanInfo {
 		Status:             detail.Status,
 		Attributes:         detail.Attributes,
 		ResourceAttributes: detail.ResourceAttributes,
-	}
+	}, nil
 }
 
 func (s *TracesService) convertToResponse(result *observability.TracesQueryResult) *types.TracesQueryResponse {

--- a/internal/observer/service/traces_adapter_test.go
+++ b/internal/observer/service/traces_adapter_test.go
@@ -31,12 +31,12 @@ type fakeTracingAdapter struct {
 	spanDetailResult *observability.SpanDetail
 	spanDetailErr    error
 
-	tracesCalled           bool
-	spansCalled            bool
-	querySpanDetailsCalled bool
-	lastTraceID            string
-	lastSpanID             string
-	lastParams             observability.TracesQueryParams
+	tracesCalled      bool
+	spansCalled       bool
+	spanDetailsCalled bool
+	lastTraceID       string
+	lastSpanID        string
+	lastParams        observability.TracesQueryParams
 }
 
 func (f *fakeTracingAdapter) GetTraces(_ context.Context,
@@ -56,13 +56,11 @@ func (f *fakeTracingAdapter) GetSpans(_ context.Context, traceID string,
 	return f.spansResult, f.spansErr
 }
 
-func (f *fakeTracingAdapter) QuerySpanDetails(_ context.Context, traceID, spanID string,
-	params observability.TracesQueryParams,
+func (f *fakeTracingAdapter) GetSpanDetails(_ context.Context, traceID, spanID string,
 ) (*observability.SpanDetail, error) {
-	f.querySpanDetailsCalled = true
+	f.spanDetailsCalled = true
 	f.lastTraceID = traceID
 	f.lastSpanID = spanID
-	f.lastParams = params
 	return f.spanDetailResult, f.spanDetailErr
 }
 
@@ -338,61 +336,74 @@ func TestTracesService_QuerySpans_AdapterError(t *testing.T) {
 	require.ErrorIs(t, err, ErrTracesRetrieval)
 }
 
-func TestTracesService_QuerySpanDetails_NamespaceOnly_Success(t *testing.T) {
+func TestTracesService_GetSpanDetails_EmptyTraceID(t *testing.T) {
 	t.Parallel()
+	svc := newTracesServiceForTest(t, &fakeTracingAdapter{})
+	_, err := svc.GetSpanDetails(context.Background(), "", "span-1")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrTracesInvalidRequest)
+}
+
+func TestTracesService_GetSpanDetails_EmptySpanID(t *testing.T) {
+	t.Parallel()
+	svc := newTracesServiceForTest(t, &fakeTracingAdapter{})
+	_, err := svc.GetSpanDetails(context.Background(), "trace-1", "")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrTracesInvalidRequest)
+}
+
+func TestTracesService_GetSpanDetails_Success(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 3, 7, 10, 0, 0, 0, time.UTC)
 	adapter := &fakeTracingAdapter{
-		spanDetailResult: &observability.SpanDetail{SpanID: "span-1", SpanName: "http.request"},
+		spanDetailResult: &observability.SpanDetail{
+			SpanID:       "span-1",
+			SpanName:     "http.request",
+			SpanKind:     "SERVER",
+			ParentSpanID: "",
+			StartTime:    now,
+			EndTime:      now.Add(time.Second),
+			DurationNs:   1000000000,
+			Status:       &observability.SpanStatus{Code: "error", Message: "failed to initialize connection to database"},
+			Attributes:   map[string]interface{}{"http.method": "GET"},
+		},
 	}
 	svc := newTracesServiceForTest(t, adapter)
 
-	resp, err := svc.QuerySpanDetails(context.Background(), "trace-1", "span-1",
-		types.ComponentSearchScope{Namespace: "ns"})
+	resp, err := svc.GetSpanDetails(context.Background(), "trace-1", "span-1")
 	require.NoError(t, err)
 	require.NotNil(t, resp)
-	assert.True(t, adapter.querySpanDetailsCalled)
-	assert.Equal(t, "ns", adapter.lastParams.Namespace)
-	assert.Empty(t, adapter.lastParams.ProjectID)
+	assert.True(t, adapter.spanDetailsCalled)
+	assert.Equal(t, "trace-1", adapter.lastTraceID)
+	assert.Equal(t, "span-1", adapter.lastSpanID)
 	assert.Equal(t, "span-1", resp.SpanID)
+	assert.Equal(t, "http.request", resp.SpanName)
+	assert.Equal(t, "SERVER", resp.SpanKind)
+	assert.Equal(t, int64(1000000000), resp.DurationNs)
+	assert.Equal(t, "GET", resp.Attributes["http.method"])
+	require.NotNil(t, resp.Status)
+	assert.Equal(t, "error", resp.Status.Code)
+	assert.Equal(t, "failed to initialize connection to database", resp.Status.Message)
 }
 
-func TestTracesService_QuerySpanDetails_WithResolver_ForwardsScopeUIDs(t *testing.T) {
+func TestTracesService_GetSpanDetails_NotFoundPassthrough(t *testing.T) {
 	t.Parallel()
+	adapter := &fakeTracingAdapter{spanDetailErr: ErrSpanNotFound}
+	svc := newTracesServiceForTest(t, adapter)
 
-	tokenSrv := newAlwaysOKTokenServer(t)
-	defer tokenSrv.Close()
+	_, err := svc.GetSpanDetails(context.Background(), "trace-1", "missing")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSpanNotFound)
+}
 
-	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		switch {
-		case strings.Contains(r.URL.Path, "/projects/"):
-			_, _ = w.Write([]byte(uidResponse(sampleProjectUID)))
-		case strings.Contains(r.URL.Path, "/components/"):
-			_, _ = w.Write([]byte(uidResponse(sampleComponentUID)))
-		case strings.Contains(r.URL.Path, "/environments/"):
-			_, _ = w.Write([]byte(uidResponse(sampleEnvironmentUID)))
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	}))
-	defer apiSrv.Close()
+func TestTracesService_GetSpanDetails_OtherError(t *testing.T) {
+	t.Parallel()
+	adapter := &fakeTracingAdapter{spanDetailErr: errors.New("upstream boom")}
+	svc := newTracesServiceForTest(t, adapter)
 
-	resolver := newTestResolver(t, apiSrv, tokenSrv, &config.UIDResolverConfig{MaxAuthRetry: 1})
-
-	adapter := &fakeTracingAdapter{
-		spanDetailResult: &observability.SpanDetail{SpanID: "span-1"},
-	}
-	svc, err := NewTracesService(adapter, resolver, &config.Config{},
-		slog.New(slog.NewTextHandler(io.Discard, nil)))
-	require.NoError(t, err)
-
-	resp, err := svc.QuerySpanDetails(context.Background(), "trace-1", "span-1",
-		types.ComponentSearchScope{Namespace: "ns", Project: "proj", Component: "comp", Environment: "env"})
-	require.NoError(t, err)
-	require.NotNil(t, resp)
-	assert.Equal(t, "ns", adapter.lastParams.Namespace)
-	assert.Equal(t, sampleProjectUID, adapter.lastParams.ProjectID)
-	assert.Equal(t, sampleComponentUID, adapter.lastParams.ComponentID)
-	assert.Equal(t, sampleEnvironmentUID, adapter.lastParams.EnvironmentID)
+	_, err := svc.GetSpanDetails(context.Background(), "trace-1", "span-1")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrTracesRetrieval)
 }
 
 func TestTracesService_ConvertAdapterSpansToResponse(t *testing.T) {

--- a/internal/observer/service/traces_authz.go
+++ b/internal/observer/service/traces_authz.go
@@ -64,18 +64,8 @@ func (s *tracesServiceWithAuthz) QuerySpans(ctx context.Context, traceID string,
 	return s.internal.QuerySpans(ctx, traceID, req)
 }
 
-func (s *tracesServiceWithAuthz) QuerySpanDetails(ctx context.Context, traceID string, spanID string, scope types.ComponentSearchScope) (*types.SpanInfo, error) {
-	resourceType, resourceName, hierarchy := observerAuthz.ComponentScopeAuthz(scope.Namespace, scope.Project, scope.Component)
-
-	if err := observerAuthz.CheckAuthorization(
-		ctx, s.logger, s.pdp,
-		observerAuthz.ActionViewTraces,
-		resourceType, resourceName, hierarchy,
-		authzcore.Context{Resource: authzcore.ResourceAttribute{
-			Environment: observerAuthz.FormatDualScopedResourceName(scope.Namespace, scope.Environment, false),
-		}},
-	); err != nil {
-		return nil, err
-	}
-	return s.internal.QuerySpanDetails(ctx, traceID, spanID, scope)
+// GetSpanDetails passes through without an authz check — traceID+spanID alone do not
+// carry enough scope context (namespace/project/component) to evaluate authorization.
+func (s *tracesServiceWithAuthz) GetSpanDetails(ctx context.Context, traceID string, spanID string) (*types.SpanInfo, error) {
+	return s.internal.GetSpanDetails(ctx, traceID, spanID)
 }

--- a/internal/observer/service/tracing_adapter.go
+++ b/internal/observer/service/tracing_adapter.go
@@ -128,24 +128,9 @@ func (t *TracingAdapter) GetSpans(ctx context.Context, traceID string, params ob
 	return convertSpansAdapterResponse(resp.JSON200), nil
 }
 
-// QuerySpanDetails implements observability.TracingAdapter interface
-func (t *TracingAdapter) QuerySpanDetails(ctx context.Context, traceID string, spanID string, params observability.TracesQueryParams) (*observability.SpanDetail, error) {
-	reqBody := gen.QuerySpanDetailsForTraceJSONRequestBody{
-		SearchScope: gen.ComponentSearchScope{
-			Namespace: params.Namespace,
-		},
-	}
-	if params.ProjectID != "" {
-		reqBody.SearchScope.Project = &params.ProjectID
-	}
-	if params.ComponentID != "" {
-		reqBody.SearchScope.Component = &params.ComponentID
-	}
-	if params.EnvironmentID != "" {
-		reqBody.SearchScope.Environment = &params.EnvironmentID
-	}
-
-	resp, err := t.client.QuerySpanDetailsForTraceWithResponse(ctx, traceID, spanID, reqBody)
+// GetSpanDetails implements observability.TracingAdapter interface
+func (t *TracingAdapter) GetSpanDetails(ctx context.Context, traceID string, spanID string) (*observability.SpanDetail, error) {
+	resp, err := t.client.GetSpanDetailsForTraceWithResponse(ctx, traceID, spanID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute request: %w", err)
 	}

--- a/internal/observer/service/tracing_adapter_test.go
+++ b/internal/observer/service/tracing_adapter_test.go
@@ -4,15 +4,11 @@
 package service
 
 import (
-	"context"
 	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/openchoreo/openchoreo/internal/observer/api/gen"
-	"github.com/openchoreo/openchoreo/pkg/observability"
 )
 
 func TestNewTracingAdapter_DefaultTimeout(t *testing.T) {
@@ -84,55 +80,6 @@ func TestNewTracingAdapter_ClientInitialized(t *testing.T) {
 	}
 	if adapter.client == nil {
 		t.Fatal("Expected non-nil client")
-	}
-}
-
-func TestTracingAdapter_QuerySpanDetails_ForwardsScopeAndConverts(t *testing.T) {
-	var gotPath, gotMethod string
-	var gotBody map[string]interface{}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPath = r.URL.Path
-		gotMethod = r.Method
-		_ = json.NewDecoder(r.Body).Decode(&gotBody)
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"spanId":"span-1","spanName":"http.request"}`))
-	}))
-	defer srv.Close()
-
-	adapter, err := NewTracingAdapter(TracingAdapterConfig{BaseURL: srv.URL, Timeout: 5 * time.Second})
-	if err != nil {
-		t.Fatalf("failed to create adapter: %v", err)
-	}
-
-	detail, err := adapter.QuerySpanDetails(context.Background(), "trace-1", "span-1",
-		observability.TracesQueryParams{Namespace: "ns", ProjectID: "proj-uid", ComponentID: "comp-uid", EnvironmentID: "env-uid"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if gotMethod != http.MethodPost {
-		t.Errorf("expected POST, got %s", gotMethod)
-	}
-	if gotPath != "/api/v1alpha1/traces/trace-1/spans/span-1" {
-		t.Errorf("unexpected path: %s", gotPath)
-	}
-	scope, _ := gotBody["searchScope"].(map[string]interface{})
-	if scope == nil {
-		t.Fatalf("expected searchScope in body, got %v", gotBody)
-	}
-	if scope["namespace"] != "ns" {
-		t.Errorf("expected namespace=ns, got %v", scope["namespace"])
-	}
-	if scope["project"] != "proj-uid" {
-		t.Errorf("expected project=proj-uid, got %v", scope["project"])
-	}
-	if scope["component"] != "comp-uid" {
-		t.Errorf("expected component=comp-uid, got %v", scope["component"])
-	}
-	if scope["environment"] != "env-uid" {
-		t.Errorf("expected environment=env-uid, got %v", scope["environment"])
-	}
-	if detail.SpanID != "span-1" {
-		t.Errorf("expected spanId=span-1, got %s", detail.SpanID)
 	}
 }
 

--- a/openapi/observability-tracing-adapter-api.yaml
+++ b/openapi/observability-tracing-adapter-api.yaml
@@ -152,12 +152,12 @@ paths:
 
 
   /api/v1alpha1/traces/{traceId}/spans/{spanId}:
-    post:
+    get:
       tags:
         - Traces
       summary: Get details of a span for a trace
       description: Get details of a span for a trace
-      operationId: querySpanDetailsForTrace
+      operationId: getSpanDetailsForTrace
       parameters:
         - name: traceId
           in: path
@@ -169,12 +169,6 @@ paths:
           required: true
           schema:
             type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/TraceSpanDetailsRequest"
       responses:
         "200":
           description: Span details queried successfully
@@ -278,14 +272,6 @@ components:
           description: Whether to include span attributes in the response. Defaults to false.
           default: false
       required: [startTime, endTime, searchScope]
-
-
-    TraceSpanDetailsRequest:
-      type: object
-      properties:
-        searchScope:
-          $ref: "#/components/schemas/ComponentSearchScope"
-      required: [searchScope]
 
 
     TracesQueryResponse:

--- a/openapi/observer-api.yaml
+++ b/openapi/observer-api.yaml
@@ -392,12 +392,12 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
 
   /api/v1alpha1/traces/{traceId}/spans/{spanId}:
-    post:
+    get:
       tags:
         - Traces
       summary: Get details of a span for a trace
-      description: Get details of a span for a trace
-      operationId: querySpanDetailsForTrace
+      description: Get details of a span for a trace from the observer service
+      operationId: getSpanDetailsForTrace
       parameters:
         - name: traceId
           in: path
@@ -411,12 +411,6 @@ paths:
           description: The ID of the span
           schema:
             type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/TraceSpanDetailsRequest"
       responses:
         "200":
           description: Span details queried successfully
@@ -1377,13 +1371,6 @@ components:
           description: Whether to include span attributes in the response. Defaults to false.
           default: false
       required: [startTime, endTime, searchScope]
-
-    TraceSpanDetailsRequest:
-      type: object
-      properties:
-        searchScope:
-          $ref: "#/components/schemas/ComponentSearchScope"
-      required: [searchScope]
 
     # Response schemas for traces
     TracesQueryResponse:

--- a/pkg/observability/traces.go
+++ b/pkg/observability/traces.go
@@ -14,8 +14,8 @@ type TracingAdapter interface {
 	GetTraces(ctx context.Context, params TracesQueryParams) (*TracesQueryResult, error)
 	// GetSpans retrieves spans for a specific trace
 	GetSpans(ctx context.Context, traceID string, params TracesQueryParams) (*SpansResult, error)
-	// QuerySpanDetails retrieves detailed information about a specific span within a scope
-	QuerySpanDetails(ctx context.Context, traceID string, spanID string, params TracesQueryParams) (*SpanDetail, error)
+	// GetSpanDetails retrieves detailed information about a specific span
+	GetSpanDetails(ctx context.Context, traceID string, spanID string) (*SpanDetail, error)
 }
 
 // SpanStatus represents the execution status of a span, following the


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Revert https://github.com/openchoreo/openchoreo/pull/4617

## Approach
reverted commit 88340034e0d44f929f4dd4b4f77bb7ad44b56565.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [ ] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
