### PR TITLE
fix: extract entity details from spanAttributes and authorise (#4642)

### DIFF
--- a/internal/observer/api/handlers/traces.go
+++ b/internal/observer/api/handlers/traces.go
@@ -244,6 +244,14 @@ func (h *Handler) GetSpanDetailsForTrace(w http.ResponseWriter, r *http.Request)
 	ctx := r.Context()
 	spanInfo, err := h.tracesService.GetSpanDetails(ctx, traceID, spanID)
 	if err != nil {
+		if errors.Is(err, observerAuthz.ErrAuthzForbidden) {
+			h.writeErrorResponse(w, http.StatusForbidden, gen.Forbidden, "", "Access denied")
+			return
+		}
+		if errors.Is(err, observerAuthz.ErrAuthzUnauthorized) {
+			h.writeErrorResponse(w, http.StatusUnauthorized, gen.Unauthorized, "", "Unauthorized")
+			return
+		}
 		h.logger.Error("Failed to get span details", "error", err)
 		errorCode := types.ErrorCodeV1TracesInternalGeneric
 		switch {

--- a/internal/observer/api/handlers/traces_handler_test.go
+++ b/internal/observer/api/handlers/traces_handler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/openchoreo/openchoreo/internal/observer/api/gen"
 	observerAuthz "github.com/openchoreo/openchoreo/internal/observer/authz"
 	"github.com/openchoreo/openchoreo/internal/observer/service"
 	servicemocks "github.com/openchoreo/openchoreo/internal/observer/service/mocks"
@@ -399,6 +400,52 @@ func TestGetSpanDetailsForTrace_EmptySpanID(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "spanId is required")
 }
 
+func TestGetSpanDetailsForTrace_AuthzForbidden(t *testing.T) {
+	t.Parallel()
+
+	svc := servicemocks.NewMockTracesQuerier(t)
+	svc.On("GetSpanDetails", mock.Anything, mock.Anything, mock.Anything).Return(nil, observerAuthz.ErrAuthzForbidden)
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: svc,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/span-1", nil)
+	req.SetPathValue("traceId", "trace-1")
+	req.SetPathValue("spanId", "span-1")
+	rr := httptest.NewRecorder()
+
+	h.GetSpanDetailsForTrace(rr, req)
+
+	require.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Contains(t, rr.Body.String(), string(gen.Forbidden))
+	assert.Contains(t, rr.Body.String(), "Access denied")
+}
+
+func TestGetSpanDetailsForTrace_AuthzUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	svc := servicemocks.NewMockTracesQuerier(t)
+	svc.On("GetSpanDetails", mock.Anything, mock.Anything, mock.Anything).Return(nil, observerAuthz.ErrAuthzUnauthorized)
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: svc,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/span-1", nil)
+	req.SetPathValue("traceId", "trace-1")
+	req.SetPathValue("spanId", "span-1")
+	rr := httptest.NewRecorder()
+
+	h.GetSpanDetailsForTrace(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+	assert.Contains(t, rr.Body.String(), string(gen.Unauthorized))
+	assert.Contains(t, rr.Body.String(), "Unauthorized")
+}
+
 func TestGetSpanDetailsForTrace_ServiceNotInitialized(t *testing.T) {
 	t.Parallel()
 
@@ -460,6 +507,28 @@ func TestGetSpanDetailsForTrace_RetrievalError(t *testing.T) {
 
 	require.Equal(t, http.StatusInternalServerError, rr.Code)
 	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesRetrievalFailed)
+}
+
+func TestGetSpanDetailsForTrace_InvalidRequest(t *testing.T) {
+	t.Parallel()
+
+	svc := servicemocks.NewMockTracesQuerier(t)
+	svc.On("GetSpanDetails", mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("%w: bad", service.ErrTracesInvalidRequest))
+
+	h := &Handler{
+		baseHandler:   baseHandler{logger: noopLogger()},
+		tracesService: svc,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/traces/trace-1/spans/span-1", nil)
+	req.SetPathValue("traceId", "trace-1")
+	req.SetPathValue("spanId", "span-1")
+	rr := httptest.NewRecorder()
+
+	h.GetSpanDetailsForTrace(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1TracesInvalidRequest)
 }
 
 func TestGetSpanDetailsForTrace_GenericError(t *testing.T) {

--- a/internal/observer/service/authz_test.go
+++ b/internal/observer/service/authz_test.go
@@ -5,6 +5,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +16,7 @@ import (
 	coremocks "github.com/openchoreo/openchoreo/internal/authz/core/mocks"
 	"github.com/openchoreo/openchoreo/internal/observer/api/gen"
 	observerAuthz "github.com/openchoreo/openchoreo/internal/observer/authz"
+	"github.com/openchoreo/openchoreo/internal/observer/labels"
 	"github.com/openchoreo/openchoreo/internal/observer/service/mocks"
 	"github.com/openchoreo/openchoreo/internal/observer/types"
 	"github.com/openchoreo/openchoreo/internal/server/middleware/auth"
@@ -294,18 +296,106 @@ func TestTracesAuthz_QuerySpans_Denied(t *testing.T) {
 	assert.ErrorIs(t, err, observerAuthz.ErrAuthzForbidden)
 }
 
-func TestTracesAuthz_GetSpanDetails_PassThrough(t *testing.T) {
+func spanWithScope() *types.SpanInfo {
+	return &types.SpanInfo{
+		SpanID: "span-1",
+		ResourceAttributes: map[string]interface{}{
+			labels.NamespaceName:   "ns",
+			labels.ProjectName:     "proj",
+			labels.ComponentName:   "comp",
+			labels.EnvironmentName: "dev",
+		},
+	}
+}
+
+func TestTracesAuthz_GetSpanDetails_NilPDP(t *testing.T) {
 	inner := mocks.NewMockTracesQuerier(t)
-	expected := &types.SpanInfo{SpanID: "span-1"}
+	expected := spanWithScope()
 	inner.EXPECT().GetSpanDetails(mock.Anything, "trace-1", "span-1").Return(expected, nil)
 
-	// PDP with no Evaluate expectation — testify will fail if Evaluate is called
-	pdp := coremocks.NewMockPDP(t)
-	svc := NewTracesServiceWithAuthz(inner, pdp, testLogger())
+	svc := NewTracesServiceWithAuthz(inner, nil, testLogger())
 
 	resp, err := svc.GetSpanDetails(context.Background(), "trace-1", "span-1")
 	require.NoError(t, err)
 	assert.Equal(t, expected, resp)
+}
+
+// spanScopeEvaluateReq matches the EvaluateRequest that GetSpanDetails derives
+// from spanWithScope's resource attributes: a component-scoped traces:view check.
+func spanScopeEvaluateReq(req *authzcore.EvaluateRequest) bool {
+	return req.Action == string(observerAuthz.ActionViewTraces) &&
+		req.Resource.Type == string(observerAuthz.ResourceTypeComponent) &&
+		req.Resource.ID == "comp" &&
+		req.Resource.Hierarchy == authzcore.ResourceHierarchy{Namespace: "ns", Project: "proj", Component: "comp"} &&
+		req.Context.Resource.Environment == "ns/dev"
+}
+
+func TestTracesAuthz_GetSpanDetails_Allowed(t *testing.T) {
+	inner := mocks.NewMockTracesQuerier(t)
+	expected := spanWithScope()
+	inner.EXPECT().GetSpanDetails(mock.Anything, "trace-1", "span-1").Return(expected, nil)
+
+	pdp := coremocks.NewMockPDP(t)
+	pdp.EXPECT().Evaluate(mock.Anything, mock.MatchedBy(spanScopeEvaluateReq)).
+		Return(&authzcore.Decision{Decision: true}, nil).Once()
+	svc := NewTracesServiceWithAuthz(inner, pdp, testLogger())
+
+	resp, err := svc.GetSpanDetails(authedCtx(), "trace-1", "span-1")
+	require.NoError(t, err)
+	assert.Equal(t, expected, resp)
+}
+
+func TestTracesAuthz_GetSpanDetails_Denied(t *testing.T) {
+	inner := mocks.NewMockTracesQuerier(t)
+	inner.EXPECT().GetSpanDetails(mock.Anything, "trace-1", "span-1").Return(spanWithScope(), nil)
+
+	pdp := coremocks.NewMockPDP(t)
+	pdp.EXPECT().Evaluate(mock.Anything, mock.MatchedBy(spanScopeEvaluateReq)).
+		Return(&authzcore.Decision{Decision: false}, nil).Once()
+	svc := NewTracesServiceWithAuthz(inner, pdp, testLogger())
+
+	resp, err := svc.GetSpanDetails(authedCtx(), "trace-1", "span-1")
+	assert.ErrorIs(t, err, observerAuthz.ErrAuthzForbidden)
+	assert.Nil(t, resp)
+}
+
+// The span fetch failing short-circuits before any authorization is attempted.
+func TestTracesAuthz_GetSpanDetails_FetchError(t *testing.T) {
+	inner := mocks.NewMockTracesQuerier(t)
+	wantErr := errors.New("adapter unavailable")
+	inner.EXPECT().GetSpanDetails(mock.Anything, "trace-1", "span-1").Return(nil, wantErr)
+
+	// A non-nil PDP with no Evaluate expectation: the mock fails if authz is consulted.
+	pdp := coremocks.NewMockPDP(t)
+	svc := NewTracesServiceWithAuthz(inner, pdp, testLogger())
+
+	resp, err := svc.GetSpanDetails(authedCtx(), "trace-1", "span-1")
+	assert.ErrorIs(t, err, wantErr)
+	assert.Nil(t, resp)
+}
+
+// A span lacking openchoreo.dev/* attributes yields an empty (unknown) scope; the
+// PDP is still consulted and its decision is honored.
+func TestTracesAuthz_GetSpanDetails_MissingScopeAttributes(t *testing.T) {
+	inner := mocks.NewMockTracesQuerier(t)
+	span := &types.SpanInfo{
+		SpanID:             "span-1",
+		ResourceAttributes: map[string]interface{}{"service.name": "frontend"},
+	}
+	inner.EXPECT().GetSpanDetails(mock.Anything, "trace-1", "span-1").Return(span, nil)
+
+	pdp := coremocks.NewMockPDP(t)
+	pdp.EXPECT().Evaluate(mock.Anything, mock.MatchedBy(func(req *authzcore.EvaluateRequest) bool {
+		return req.Resource.Type == string(observerAuthz.ResourceTypeUnknown) &&
+			req.Resource.ID == "" &&
+			req.Resource.Hierarchy == authzcore.ResourceHierarchy{} &&
+			req.Context.Resource.Environment == ""
+	})).Return(&authzcore.Decision{Decision: true}, nil).Once()
+	svc := NewTracesServiceWithAuthz(inner, pdp, testLogger())
+
+	resp, err := svc.GetSpanDetails(authedCtx(), "trace-1", "span-1")
+	require.NoError(t, err)
+	assert.Equal(t, span, resp)
 }
 
 // --- MetricsQuerier QueryRuntimeTopology Authz Tests ---

--- a/internal/observer/service/traces_authz.go
+++ b/internal/observer/service/traces_authz.go
@@ -9,6 +9,7 @@ import (
 
 	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
 	observerAuthz "github.com/openchoreo/openchoreo/internal/observer/authz"
+	"github.com/openchoreo/openchoreo/internal/observer/labels"
 	"github.com/openchoreo/openchoreo/internal/observer/types"
 )
 
@@ -64,8 +65,40 @@ func (s *tracesServiceWithAuthz) QuerySpans(ctx context.Context, traceID string,
 	return s.internal.QuerySpans(ctx, traceID, req)
 }
 
-// GetSpanDetails passes through without an authz check — traceID+spanID alone do not
-// carry enough scope context (namespace/project/component) to evaluate authorization.
+// GetSpanDetails authorizes on the return path: the request carries only traceID+spanID,
+// so the scope is derived from the fetched span's resource attributes and the span is
+// discarded if the caller is not authorized for it.
 func (s *tracesServiceWithAuthz) GetSpanDetails(ctx context.Context, traceID string, spanID string) (*types.SpanInfo, error) {
-	return s.internal.GetSpanDetails(ctx, traceID, spanID)
+	span, err := s.internal.GetSpanDetails(ctx, traceID, spanID)
+	if err != nil {
+		return nil, err
+	}
+
+	namespace := resourceAttrString(span.ResourceAttributes, labels.NamespaceName)
+	project := resourceAttrString(span.ResourceAttributes, labels.ProjectName)
+	component := resourceAttrString(span.ResourceAttributes, labels.ComponentName)
+	environment := resourceAttrString(span.ResourceAttributes, labels.EnvironmentName)
+
+	resourceType, resourceName, hierarchy := observerAuthz.ComponentScopeAuthz(namespace, project, component)
+	// TODO: currently the obs API is not equipped to provide cluster level environments,
+	// once that is done update false to proper isClusterScoped value.
+	if err := observerAuthz.CheckAuthorization(
+		ctx, s.logger, s.pdp,
+		observerAuthz.ActionViewTraces,
+		resourceType, resourceName, hierarchy,
+		authzcore.Context{Resource: authzcore.ResourceAttribute{
+			Environment: observerAuthz.FormatDualScopedResourceName(namespace, environment, false),
+		}},
+	); err != nil {
+		return nil, err
+	}
+	return span, nil
+}
+
+// resourceAttrString returns the string value for key, or "" if absent or not a string.
+func resourceAttrString(attrs map[string]interface{}, key string) string {
+	if v, ok := attrs[key].(string); ok {
+		return v
+	}
+	return ""
 }


### PR DESCRIPTION

<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Backport https://github.com/openchoreo/openchoreo/pull/4642 to OpenChoreo v1.2

## Approach
cherry picked from commit 1bb9672dc598e224e2579f7bcce1917c6b434f85 and adapted it to v1.2 branch


## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [ ] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
