### PR TITLE
fix(helm): raise argo-workflow-controller CPU/memory to stop CrashLoop

### DIFF
--- a/install/helm/openchoreo-workflow-plane/values.schema.json
+++ b/install/helm/openchoreo-workflow-plane/values.schema.json
@@ -19,13 +19,13 @@
                   "description": "Maximum resources the controller can consume",
                   "properties": {
                     "cpu": {
-                      "default": "50m",
+                      "default": "500m",
                       "description": "CPU limit for the controller",
                       "title": "cpu",
                       "type": "string"
                     },
                     "memory": {
-                      "default": "64Mi",
+                      "default": "256Mi",
                       "description": "Memory limit for the controller",
                       "title": "memory",
                       "type": "string"
@@ -40,13 +40,13 @@
                   "description": "Minimum resources guaranteed for the controller",
                   "properties": {
                     "cpu": {
-                      "default": "25m",
+                      "default": "100m",
                       "description": "CPU request for the controller",
                       "title": "cpu",
                       "type": "string"
                     },
                     "memory": {
-                      "default": "32Mi",
+                      "default": "128Mi",
                       "description": "Memory request for the controller",
                       "title": "memory",
                       "type": "string"

--- a/install/helm/openchoreo-workflow-plane/values.schema.json
+++ b/install/helm/openchoreo-workflow-plane/values.schema.json
@@ -19,7 +19,7 @@
                   "description": "Maximum resources the controller can consume",
                   "properties": {
                     "cpu": {
-                      "default": "500m",
+                      "default": "200m",
                       "description": "CPU limit for the controller",
                       "title": "cpu",
                       "type": "string"

--- a/install/helm/openchoreo-workflow-plane/values.yaml
+++ b/install/helm/openchoreo-workflow-plane/values.yaml
@@ -65,15 +65,15 @@ argo-workflows:
         # @schema
         # type: string
         # description: Memory limit for the controller
-        # default: 64Mi
+        # default: 256Mi
         # @schema
-        memory: 64Mi
+        memory: 256Mi
         # @schema
         # type: string
         # description: CPU limit for the controller
-        # default: 50m
+        # default: 500m
         # @schema
-        cpu: 50m
+        cpu: 500m
       # @schema
       # type: object
       # additionalProperties: true
@@ -83,15 +83,15 @@ argo-workflows:
         # @schema
         # type: string
         # description: Memory request for the controller
-        # default: 32Mi
+        # default: 128Mi
         # @schema
-        memory: 32Mi
+        memory: 128Mi
         # @schema
         # type: string
         # description: CPU request for the controller
-        # default: 25m
+        # default: 100m
         # @schema
-        cpu: 25m
+        cpu: 100m
 
   # @schema
   # type: object

--- a/install/helm/openchoreo-workflow-plane/values.yaml
+++ b/install/helm/openchoreo-workflow-plane/values.yaml
@@ -71,9 +71,9 @@ argo-workflows:
         # @schema
         # type: string
         # description: CPU limit for the controller
-        # default: 500m
+        # default: 200m
         # @schema
-        cpu: 500m
+        cpu: 200m
       # @schema
       # type: object
       # additionalProperties: true


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
The `argo-workflow-controller` deployed by the `openchoreo-workflow-plane` Helm
chart is CPU-starved by its default resource limits (`limits: {cpu: 50m, memory:
64Mi}`, `requests: {cpu: 25m, memory: 32Mi}`), set in
`install/helm/openchoreo-workflow-plane/values.yaml`. 50m is 5% of a CPU core.
Under normal build load the controller cannot drain its workqueue or even
service its own `/healthz` handler within the 30s liveness probe timeout,
so kubelet kills it, forcing a cold informer resync on the same 5%-of-a-core
budget, which repeats the failure. This produces a self-sustaining
CrashLoopBackOff, alternating `/healthz` 500s ("workflow exceeds max age and no
progress") and probe timeouts ("context deadline exceeded"), starving workflow
reconciliation entirely. The issue includes a detailed root-cause trace ruling
out an RBAC explanation and confirming this is pure CPU/scheduling starvation.

## Approach
Raise the controller's CPU/memory budget to the values suggested in the issue:

- `requests`: `cpu: 25m -> 100m`, `memory: 32Mi -> 128Mi`
- `limits`: `cpu: 50m -> 500m`, `memory: 64Mi -> 256Mi`

Updated the accompanying `# @schema ... default:` annotation comments in
`values.yaml` to match, and regenerated `values.schema.json` via this repo's
`make helm-package.openchoreo-workflow-plane` target (which runs `helm-schema`,
`helm dependency update`, and `helm lint`) so the generated schema stays in
sync with the new defaults. This is a values-only change; no Go code or
controller logic is touched.

## Related Issues
Related: https://github.com/openchoreo/openchoreo/issues/4648

## Checklist
- [x] Tests added or updated (unit, integration, etc.) — not applicable; this
      is a Helm values/schema change with no code path to unit-test. Validated
      via `helm lint`, `helm template` (confirmed the rendered
      `argo-workflow-controller` Deployment carries the new
      requests/limits), and schema regeneration, all run locally through this
      repo's own `make helm-package.openchoreo-workflow-plane` target.
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
Validation performed locally (no live cluster available in this environment):
- `make helm-package.openchoreo-workflow-plane` — runs `helm dependency
  update`, regenerates `values.schema.json` via `helm-schema`, `helm lint`
  (passed, 0 failures), and `helm package` (succeeded).
- `helm template` on the chart to confirm the rendered
  `argo-workflow-controller` Deployment manifest carries the new
  `limits: {cpu: 500m, memory: 256Mi}` / `requests: {cpu: 100m, memory:
  128Mi}`.

The exact numbers are the issue's own suggested values; the issue notes they
should be "validated against target node sizing and expected
concurrent-workflow count" in a real deployment, which is outside what can be
confirmed from this environment.

Fixes #4648