### PR TITLE
fix: add .exe extension to occ Windows release archives

### DIFF
--- a/make/golang.mk
+++ b/make/golang.mk
@@ -64,7 +64,9 @@ define package_binary
 	$(call log_info, Packaging binary '$(BINARY_NAME)' for $(OS)/$(ARCH))
 	if [ -f $(BIN_PATH) ]; then \
 		if [ $(OS) = "windows" ]; then \
-			zip -rj $(OUTPUT_PATH)/$(PACKAGE_FILE_NAME).zip $(BIN_PATH); \
+			cp $(BIN_PATH) $(OUTPUT_PATH)/$(BINARY_NAME).exe; \
+			zip -rj $(OUTPUT_PATH)/$(PACKAGE_FILE_NAME).zip $(OUTPUT_PATH)/$(BINARY_NAME).exe; \
+			rm -f $(OUTPUT_PATH)/$(BINARY_NAME).exe; \
 		else \
 			 tar -zcvf $(OUTPUT_PATH)/$(PACKAGE_FILE_NAME).tar.gz -C $(OUTPUT_PATH) $(BINARY_NAME); \
 		fi; \

--- a/make/golang.mk
+++ b/make/golang.mk
@@ -64,9 +64,9 @@ define package_binary
 	$(call log_info, Packaging binary '$(BINARY_NAME)' for $(OS)/$(ARCH))
 	if [ -f $(BIN_PATH) ]; then \
 		if [ $(OS) = "windows" ]; then \
+			trap 'rm -f $(OUTPUT_PATH)/$(BINARY_NAME).exe' EXIT; \
 			cp $(BIN_PATH) $(OUTPUT_PATH)/$(BINARY_NAME).exe; \
 			zip -rj $(OUTPUT_PATH)/$(PACKAGE_FILE_NAME).zip $(OUTPUT_PATH)/$(BINARY_NAME).exe; \
-			rm -f $(OUTPUT_PATH)/$(BINARY_NAME).exe; \
 		else \
 			 tar -zcvf $(OUTPUT_PATH)/$(PACKAGE_FILE_NAME).tar.gz -C $(OUTPUT_PATH) $(BINARY_NAME); \
 		fi; \

--- a/make/golang.mk
+++ b/make/golang.mk
@@ -64,9 +64,10 @@ define package_binary
 	$(call log_info, Packaging binary '$(BINARY_NAME)' for $(OS)/$(ARCH))
 	if [ -f $(BIN_PATH) ]; then \
 		if [ $(OS) = "windows" ]; then \
-			trap 'rm -f $(OUTPUT_PATH)/$(BINARY_NAME).exe' EXIT; \
-			cp $(BIN_PATH) $(OUTPUT_PATH)/$(BINARY_NAME).exe; \
-			zip -rj $(OUTPUT_PATH)/$(PACKAGE_FILE_NAME).zip $(OUTPUT_PATH)/$(BINARY_NAME).exe; \
+			( trap 'rm -f $(OUTPUT_PATH)/$(BINARY_NAME).exe' EXIT; \
+			  cp $(BIN_PATH) $(OUTPUT_PATH)/$(BINARY_NAME).exe; \
+			  zip -rj $(OUTPUT_PATH)/$(PACKAGE_FILE_NAME).zip $(OUTPUT_PATH)/$(BINARY_NAME).exe; \
+			); \
 		else \
 			 tar -zcvf $(OUTPUT_PATH)/$(PACKAGE_FILE_NAME).tar.gz -C $(OUTPUT_PATH) $(BINARY_NAME); \
 		fi; \


### PR DESCRIPTION
## Purpose
> The published Windows CLI archives (`occ_<version>_windows_<arch>.zip`) contain the binary as a bare file named `occ`, with no `.exe` extension. Windows resolves executables by extension, so the file extracted from the archive is not recognized as runnable from `cmd.exe` or PowerShell until manually renamed. Every other platform's archive already ships a name that works as-is.
>
> Fixes https://github.com/openchoreo/openchoreo/issues/4652

## Approach
> In the `package_binary` macro in `make/golang.mk`, for the Windows branch only, copy the raw build output to a `.exe`-suffixed name before zipping, zip that copy, then remove the temporary copy. The raw build output path (`bin/dist/<os>/<arch>/occ`) is unchanged, so the `bin/dist/**/occ` artifact glob in `.github/workflows/build-and-test.yml` keeps matching.
>
> This is the narrow fix (packaging step only). It does not change the nightly CI artifact, which is uploaded directly from the raw build output before packaging and still lacks the `.exe` suffix — that would require the broader alternative (appending `.exe` at the `go build` step itself), which changes the build output path and touches `build-and-test.yml` and the `go.install.%` target. Happy to follow up with that if maintainers prefer it.

## Related Issues
> https://github.com/openchoreo/openchoreo/issues/4652

## Checklist
- [x] Tests added or updated (unit, integration, etc.) — validated by building and packaging locally for both `windows/amd64` and `darwin/arm64` and inspecting archive contents (see commit message for exact commands/output); no existing automated test covers archive packaging.
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
> Note: `Build and Test` is currently green on `main`; the only failing workflow there (`E2E Gate`, scheduled) is unrelated to this change.
>
> The narrow scope here (packaging step only, not the nightly artifact) was intentional and matches the alternative explicitly declined in the linked issue.

Fixes #4652