### PR TITLE
refactor: use native mcp tools in sre agent

### DIFF
--- a/agents/sre-agent/src/agent/agent.py
+++ b/agents/sre-agent/src/agent/agent.py
@@ -5,7 +5,7 @@ import asyncio
 import json
 import logging
 import uuid
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator
 from typing import Any
 
 import httpx
@@ -25,13 +25,10 @@ from src.agent.middleware import (
 )
 from src.agent.stream_parser import ChatResponseParser
 from src.agent.tool_registry import (
-    ALL_TOOL_FACTORIES,
     OBSERVABILITY_TOOLS,
     OPENCHOREO_TOOLS,
     TOOL_ACTIVE_FORMS,
     TOOLS,
-    create_get_resource_release_binding_tool,
-    create_list_resource_release_bindings_tool,
 )
 from src.auth import get_oauth2_auth
 from src.clients import MCPClient, get_model, get_report_backend
@@ -56,7 +53,6 @@ class Agent:
         response_format: type[BaseModel],
         recursion_limit: int,
         use_summarization: bool = False,
-        tool_factories: list[Callable[..., BaseTool]] | None = None,
     ):
         self.template = template
         self.tools = tools
@@ -65,7 +61,6 @@ class Agent:
         self.model = get_model()
         self._middleware_classes = middleware
         self._use_summarization = use_summarization
-        self._tool_factories = tool_factories or []
 
     async def create(
         self,
@@ -80,9 +75,6 @@ class Agent:
             all_tools = await mcp_client.get_tools()
             tools = [t for t in all_tools if t.name in self.tools]
             logger.debug("Filtered to %d MCP tools: %s", len(tools), [t.name for t in tools])
-
-        for factory in self._tool_factories:
-            tools.append(factory(auth))
 
         logger.debug("Total tools: %d — %s", len(tools), [t.name for t in tools])
 
@@ -124,16 +116,12 @@ RCA_AGENT = Agent(
         TOOLS.QUERY_TRACES,
         TOOLS.QUERY_TRACE_SPANS,
         TOOLS.LIST_COMPONENTS,
+        TOOLS.LIST_RELEASE_BINDINGS,
+        TOOLS.GET_RELEASE_BINDING,
         TOOLS.GET_COMPONENT_RELEASE,
+        TOOLS.LIST_RESOURCE_RELEASE_BINDINGS,
+        TOOLS.GET_RESOURCE_RELEASE_BINDING,
     },
-    # Resource-dependency inspection: a Component may depend on a Resource
-    # (e.g. Postgres) whose pods aren't observable as a component, so telemetry
-    # alone can't explain its failures. These let the agent read the Resource's
-    # ResourceReleaseBinding config to spot misconfiguration (e.g. starved memory).
-    tool_factories=[
-        create_list_resource_release_bindings_tool,
-        create_get_resource_release_binding_tool,
-    ],
     middleware=[
         LoggingMiddleware,
         ToolErrorHandlerMiddleware,
@@ -147,8 +135,18 @@ RCA_AGENT = Agent(
 
 REMED_AGENT = Agent(
     template="prompts/remed_agent_prompt.j2",
-    tools=set(),
-    tool_factories=ALL_TOOL_FACTORIES,
+    tools={
+        TOOLS.LIST_COMPONENTS,
+        TOOLS.GET_COMPONENT,
+        TOOLS.LIST_WORKLOADS,
+        TOOLS.GET_WORKLOAD,
+        TOOLS.LIST_RELEASE_BINDINGS,
+        TOOLS.GET_RELEASE_BINDING,
+        TOOLS.GET_COMPONENT_RELEASE,
+        TOOLS.GET_COMPONENT_RELEASE_SCHEMA,
+        TOOLS.LIST_RESOURCE_RELEASE_BINDINGS,
+        TOOLS.GET_RESOURCE_RELEASE_BINDING,
+    },
     middleware=[
         LoggingMiddleware,
         ToolErrorHandlerMiddleware,

--- a/agents/sre-agent/src/agent/tool_registry.py
+++ b/agents/sre-agent/src/agent/tool_registry.py
@@ -1,16 +1,6 @@
 # Copyright 2026 The OpenChoreo Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import json
-from collections.abc import Callable
-
-import httpx
-from langchain_core.tools import BaseTool, StructuredTool
-from pydantic import BaseModel, Field
-
-from src.clients.openchoreo_api import get
-
-
 class Tool(str):
     active_form: str | None
     server: str
@@ -60,6 +50,9 @@ class TOOLS:
     LIST_COMPONENTS = Tool(
         "list_components", server=OPENCHOREO, active_form="Loading components..."
     )
+    GET_COMPONENT = Tool(
+        "get_component", server=OPENCHOREO, active_form="Fetching component..."
+    )
     PATCH_RELEASEBINDING = Tool(
         "patch_releasebinding", server=OPENCHOREO, active_form="Patching release binding..."
     )
@@ -75,15 +68,21 @@ class TOOLS:
         active_form="Fetching release schema...",
     )
     CREATE_WORKLOAD = Tool("create_workload", server=OPENCHOREO, active_form="Creating workload...")
-    GET_COMPONENT_WORKLOADS = Tool(
-        "get_component_workloads",
-        server=OPENCHOREO,
-        active_form="Fetching component workloads...",
+    LIST_WORKLOADS = Tool(
+        "list_workloads", server=OPENCHOREO, active_form="Loading workloads..."
+    )
+    GET_WORKLOAD = Tool(
+        "get_workload", server=OPENCHOREO, active_form="Fetching workload..."
     )
     LIST_RELEASE_BINDINGS = Tool(
         "list_release_bindings",
         server=OPENCHOREO,
         active_form="Loading release bindings...",
+    )
+    GET_RELEASE_BINDING = Tool(
+        "get_release_binding",
+        server=OPENCHOREO,
+        active_form="Fetching release binding...",
     )
     LIST_RESOURCE_RELEASE_BINDINGS = Tool(
         "list_resource_release_bindings",
@@ -94,11 +93,6 @@ class TOOLS:
         "get_resource_release_binding",
         server=OPENCHOREO,
         active_form="Fetching resource release binding...",
-    )
-    LIST_COMPONENT_TRAITS = Tool(
-        "list_component_traits",
-        server=OPENCHOREO,
-        active_form="Loading component traits...",
     )
     GET_TRAIT_SCHEMA = Tool(
         "get_trait_schema",
@@ -119,191 +113,3 @@ TOOL_ACTIVE_FORMS: dict[str, str] = {
     for v in vars(TOOLS).values()
     if isinstance(v, Tool) and v.active_form is not None
 }
-
-
-class _ListReleaseBindingsInput(BaseModel):
-    namespace: str = Field(..., description="Namespace name")
-    component: str = Field(..., description="Component name to filter by")
-
-
-class _GetComponentWorkloadsInput(BaseModel):
-    namespace: str = Field(..., description="Namespace name")
-    project: str = Field(..., description="Project name")
-    component: str = Field(..., description="Component name")
-
-
-class _GetComponentReleaseSchemaInput(BaseModel):
-    namespace: str = Field(..., description="Namespace name")
-    component: str = Field(..., description="Component name")
-
-
-class _ListComponentTraitsInput(BaseModel):
-    namespace: str = Field(..., description="Namespace name")
-    component: str = Field(..., description="Component name")
-
-
-class _ListComponentsInput(BaseModel):
-    namespace: str = Field(..., description="Namespace name")
-    project: str = Field(..., description="Project name")
-
-
-class _ListResourceReleaseBindingsInput(BaseModel):
-    namespace: str = Field(..., description="Namespace name")
-    resource: str | None = Field(
-        default=None, description="Optional Resource name to filter bindings by"
-    )
-
-
-class _GetResourceReleaseBindingInput(BaseModel):
-    namespace: str = Field(..., description="Namespace name")
-    name: str = Field(..., description="ResourceReleaseBinding name")
-
-
-def create_list_release_bindings_tool(auth: httpx.Auth) -> StructuredTool:
-    async def _run(namespace: str, component: str) -> str:
-        result = await get(
-            f"/namespaces/{namespace}/releasebindings",
-            auth,
-            params={"component": component},
-        )
-        return json.dumps(result)
-
-    return StructuredTool.from_function(
-        coroutine=_run,
-        name="list_release_bindings",
-        description=(
-            "List release bindings for a component. Returns the full binding spec "
-            "including current workloadOverrides, traitEnvironmentConfigs, and "
-            "componentTypeEnvironmentConfigs."
-        ),
-        args_schema=_ListReleaseBindingsInput,
-    )
-
-
-def create_get_component_workloads_tool(auth: httpx.Auth) -> StructuredTool:
-    async def _run(namespace: str, project: str, component: str) -> str:
-        result = await get(
-            f"/namespaces/{namespace}/workloads",
-            auth,
-            params={"project": project, "component": component},
-        )
-        return json.dumps(result)
-
-    return StructuredTool.from_function(
-        coroutine=_run,
-        name="get_component_workloads",
-        description="Get workloads for a component including container specs, env vars, and endpoints.",
-        args_schema=_GetComponentWorkloadsInput,
-    )
-
-
-def create_get_component_release_schema_tool(auth: httpx.Auth) -> StructuredTool:
-    async def _run(namespace: str, component: str) -> str:
-        result = await get(
-            f"/namespaces/{namespace}/components/{component}/schema",
-            auth,
-        )
-        return json.dumps(result)
-
-    return StructuredTool.from_function(
-        coroutine=_run,
-        name="get_component_release_schema",
-        description=(
-            "Get the JSON Schema for a component's trait and componentType overrides. "
-            "Source of truth for valid override fields."
-        ),
-        args_schema=_GetComponentReleaseSchemaInput,
-    )
-
-
-def create_list_component_traits_tool(auth: httpx.Auth) -> StructuredTool:
-    async def _run(namespace: str, component: str) -> str:
-        result = await get(
-            f"/namespaces/{namespace}/components/{component}",
-            auth,
-        )
-        traits = result.get("spec", {}).get("traits", [])
-        return json.dumps(traits)
-
-    return StructuredTool.from_function(
-        coroutine=_run,
-        name="list_component_traits",
-        description="List traits attached to a component with their base parameter values.",
-        args_schema=_ListComponentTraitsInput,
-    )
-
-
-def create_list_components_tool(auth: httpx.Auth) -> StructuredTool:
-    async def _run(namespace: str, project: str) -> str:
-        result = await get(
-            f"/namespaces/{namespace}/components",
-            auth,
-            params={"project": project},
-        )
-        return json.dumps(result)
-
-    return StructuredTool.from_function(
-        coroutine=_run,
-        name="list_components",
-        description="List components in a project.",
-        args_schema=_ListComponentsInput,
-    )
-
-
-def create_list_resource_release_bindings_tool(auth: httpx.Auth) -> StructuredTool:
-    async def _run(namespace: str, resource: str | None = None) -> str:
-        params = {"resource": resource} if resource else None
-        result = await get(
-            f"/namespaces/{namespace}/resourcereleasebindings",
-            auth,
-            params=params,
-        )
-        return json.dumps(result)
-
-    return StructuredTool.from_function(
-        coroutine=_run,
-        name="list_resource_release_bindings",
-        description=(
-            "List ResourceReleaseBindings in a namespace. A Resource (e.g. a managed "
-            "Postgres from a ClusterResourceType) is bound to an environment via a "
-            "ResourceReleaseBinding, whose spec.resourceTypeEnvironmentConfigs holds the "
-            "per-environment overrides. PREFER omitting `resource` to list all bindings in "
-            "the namespace, then match the one whose spec.owner.resourceName equals the "
-            "Resource ref you are looking for — the optional `resource` filter must be the "
-            "exact Resource name (NOT the binding name, which is usually <resource>-<env>) "
-            "or it returns nothing."
-        ),
-        args_schema=_ListResourceReleaseBindingsInput,
-    )
-
-
-def create_get_resource_release_binding_tool(auth: httpx.Auth) -> StructuredTool:
-    async def _run(namespace: str, name: str) -> str:
-        result = await get(
-            f"/namespaces/{namespace}/resourcereleasebindings/{name}",
-            auth,
-        )
-        return json.dumps(result)
-
-    return StructuredTool.from_function(
-        coroutine=_run,
-        name="get_resource_release_binding",
-        description=(
-            "Get a ResourceReleaseBinding by name, including its current "
-            "spec.resourceTypeEnvironmentConfigs (the overridable fields defined by the "
-            "backing ClusterResourceType/ResourceType). Source of truth for what is "
-            "currently configured on a Resource in an environment."
-        ),
-        args_schema=_GetResourceReleaseBindingInput,
-    )
-
-
-ALL_TOOL_FACTORIES: list[Callable[..., BaseTool]] = [
-    create_list_release_bindings_tool,
-    create_get_component_workloads_tool,
-    create_get_component_release_schema_tool,
-    create_list_component_traits_tool,
-    create_list_components_tool,
-    create_list_resource_release_bindings_tool,
-    create_get_resource_release_binding_tool,
-]

--- a/agents/sre-agent/src/templates/prompts/rca_agent_prompt.j2
+++ b/agents/sre-agent/src/templates/prompts/rca_agent_prompt.j2
@@ -24,16 +24,22 @@ You are an expert Site Reliability Engineer (SRE) agent for OpenChoreo. You are 
 ### Openchoreo Tools: `{{ openchoreo_tools|map(attribute='name')|join('`, `') }}`
 {% set oc_tool_names = openchoreo_tools|map(attribute='name')|list -%}
 {% if 'list_components' in oc_tool_names -%}
-- `list_components` lists components in a project. Use it to discover sibling components when investigating cross-component issues and release names of a component for `get_component_release`
+- `list_components` lists components in a project. Use it to discover sibling components when investigating cross-component issues. Its `latestRelease` is informational and may not be the release deployed in the scoped environment.
+{% endif -%}
+{% if 'list_release_bindings' in oc_tool_names -%}
+- `list_release_bindings` takes `namespace_name` and `component_name` and returns binding summaries. Select the summary whose `environment` is `{{ scope.environment }}`; its `releaseName` identifies the release deployed in the alert scope.
+{% endif -%}
+{% if 'get_release_binding' in oc_tool_names -%}
+- `get_release_binding` takes `namespace_name` and the `binding_name` from `list_release_bindings` and returns its full detail.
 {% endif -%}
 {% if 'get_component_release' in oc_tool_names -%}
-- `get_component_release` returns the component release detail including its declared dependencies and endpoints. Use it to discover what other components **and Resources** a component depends on (`dependencies.resources` lists Resource refs like a managed Postgres). Use 'list_components' to get the release names of a component
+- `get_component_release` takes `namespace_name` and the deployed `release_name` from `list_release_bindings`. It returns declared dependencies and endpoints; `dependencies.resources` lists Resource refs such as a managed Postgres.
 {% endif -%}
 {% if 'list_resource_release_bindings' in oc_tool_names -%}
-- `list_resource_release_bindings` lists ResourceReleaseBindings in the scope namespace. Call it with ONLY the namespace (omit the `resource` filter) to enumerate all Resource bindings, then pick the one whose `spec.owner.resourceName` matches the Resource `ref` from the component's `dependencies.resources` AND whose `spec.environment` matches the alert scope's environment (`{{ scope.environment }}`) — a Resource can have multiple bindings across environments, so both must match. Do NOT pass the binding name (usually `<resource>-<env>`) as the `resource` filter — that returns nothing. A Resource (e.g. Postgres) is NOT a component — its pods carry no component labels, so its logs/metrics/events are NOT queryable via the observability tools; inspecting its binding config is the only way to reason about it.
+- `list_resource_release_bindings` takes `namespace_name` and the exact `resource_name` from `dependencies.resources`. Select the summary whose `environment` is `{{ scope.environment }}`; a Resource can have bindings in multiple environments. A Resource is not a component, so its telemetry is not queryable with the component observability tools.
 {% endif -%}
 {% if 'get_resource_release_binding' in oc_tool_names -%}
-- `get_resource_release_binding` returns a ResourceReleaseBinding's current `spec.resourceTypeEnvironmentConfigs` (the per-environment overrides, e.g. `memory`, `persistenceEnabled`). Use it to check whether a depended-on Resource is misconfigured — e.g. a `memory` value far too low for the workload, which causes OOM-kills and crash-loops and makes the Resource unavailable to its dependents.
+- `get_resource_release_binding` takes `namespace_name` and the binding `name` from the selected summary. Its `resourceTypeEnvironmentConfigs` contains the current per-environment overrides, such as `memory` and `persistenceEnabled`.
 {% endif -%}
 {% endif -%}
 
@@ -59,7 +65,7 @@ You are an expert Site Reliability Engineer (SRE) agent for OpenChoreo. You are 
 
 ## INVESTIGATION STRATEGY
 1. Start by examining the alerting component's logs, metrics, and traces
-2. Use `get_component_release` to check the alerting component's declared dependencies. If it depends on other components in the same project, investigate their telemetry as part of the analysis around the alert timeframe. You may continue following the dependency chain as long as you stay within the same project and environment.
+2. Use `list_release_bindings` to identify the release deployed in the alert environment, then use `get_component_release` to check its declared dependencies. If it depends on other components in the same project, investigate their telemetry around the alert timeframe. You may continue following the dependency chain as long as you stay within the same project and environment.
 3. Checking project-level logs around the alert timeframe is also a good idea if dependencies weren't configured — related components in the same project may be failing around the same time, even if the alerting component's telemetry doesn't explicitly reference them
 4. When evidence points to another service **within the same project**, follow it — an RCA that says "component A failed because component B returned errors" without investigating component B is incomplete
 5. If a component's telemetry shows it cannot reach a **Resource** dependency (e.g. DB connection refused/errors), remember the Resource's own pods are NOT observable via the telemetry tools. Use `get_component_release` to find the Resource `ref` under `dependencies.resources`, then `list_resource_release_bindings` + `get_resource_release_binding` to inspect its config. A misconfigured value (e.g. a `memory` limit far too low for the workload) is a valid, well-evidenced root cause even without pod telemetry — do NOT fall back to guessing at hostnames or DNS when the binding config explains the failure
@@ -76,7 +82,7 @@ If instead the alerting component's own metrics show it is OOMKilled or crash-lo
 ## BEFORE PRODUCING YOUR FINAL REPORT
 You MUST NOT produce your report until all of the following are true:
 - You examined logs, metrics, or traces for the alerting component
-- You called `get_component_release` to check the alerting component's declared dependencies and investigated any in-scope dependencies. If no dependencies were configured, you checked for related failures by examining sibling components or project-level logs around the alert timeframe
+- You identified the alert environment's deployed release with `list_release_bindings`, called `get_component_release` to check its declared dependencies, and investigated any in-scope dependencies. If no dependencies were configured, you checked for related failures by examining sibling components or project-level logs around the alert timeframe
 - If the failing dependency is a **Resource** (not a component), you inspected its ResourceReleaseBinding config via `list_resource_release_bindings` / `get_resource_release_binding` before concluding — never attribute a Resource failure to a hostname/DNS/config cause you have not confirmed against the actual binding
 - Your root causes identify the origin of the failure — whether that is the alerting component itself or an upstream dependency
 If any condition is not met, continue investigating.

--- a/agents/sre-agent/src/templates/prompts/remed_agent_prompt.j2
+++ b/agents/sre-agent/src/templates/prompts/remed_agent_prompt.j2
@@ -8,7 +8,7 @@ A **Namespace** contains **Projects** and **Environments**. A Project is an isol
 
 Inside a Project, you define **Components**. Each Component references a **ComponentType** that determines its workload shape, declares parameters (port, resources, etc.), and optionally attaches **Traits**. If building from an image, you also define a **Workload** that specifies the runtime contract (container image, env vars, files, endpoints, dependencies). If building from source, the Workload is generated automatically.
 
-All of this is snapshotted into a **ComponentRelease**. A **ReleaseBinding** then binds that ComponentRelease to a specific Environment with environment-specific overrides and renders it into concrete Kubernetes manifests. The ReleaseBinding `spec` contains override sections per environment — call `list_release_bindings` to see the current structure.
+All of this is snapshotted into a **ComponentRelease**. A **ReleaseBinding** then binds that ComponentRelease to a specific Environment with environment-specific overrides and renders it into concrete Kubernetes manifests. Use `list_release_bindings` to find the scoped binding, then `get_release_binding` to inspect its current overrides.
 
 Namespace > Project > Component > ComponentRelease > ReleaseBinding (per Environment)
 
@@ -57,7 +57,7 @@ You are NOT required to map RCA actions 1:1. Think holistically:
   - `target_kind`: `"ReleaseBinding"` (a Component, default) or `"ResourceReleaseBinding"` (a Resource such as Postgres). Only `fields` under `/spec/resourceTypeEnvironmentConfigs` are valid for a ResourceReleaseBinding — never `env` or `files`.
   - `release_binding`: the binding name — a Component binding (e.g. "api-service-development") for `ReleaseBinding`, or a Resource binding (e.g. "snip-postgres-development") for `ResourceReleaseBinding`
   - `env`: a list of `{key, value}` pairs for environment variable changes. Reference env vars **by key name**, not by array index. If the key already exists in the binding's env array it will be updated; otherwise it will be appended.
-  - `files`: a list of `{key, mount_path, value}` entries for updating the content of **existing** file mounts only. `key` + `mount_path` together identify the file mount — both must match an existing mount from `list_release_bindings`. Only the `value` (file content) is changed; you cannot add new mounts or change the mount path.
+  - `files`: a list of `{key, mount_path, value}` entries for updating the content of **existing** file mounts only. `key` + `mount_path` together identify the file mount — both must match an existing mount in the Workload or ReleaseBinding detail. Only the `value` (file content) is changed; you cannot add new mounts or change the mount path.
   - `fields`: a list of `{json_pointer, value}` pairs for non-array changes (trait overrides, componentType overrides, etc.). Use RFC 6901 JSON Pointers starting with `/spec/`. For `target_kind: "ReleaseBinding"`, **only use field paths that exist in the schema returned by `get_component_release_schema`** — the available fields are dynamic and vary per ComponentType and Trait. For `target_kind: "ResourceReleaseBinding"`, there is no schema tool — confirm the field path exists by inspecting the current `spec.resourceTypeEnvironmentConfigs` via `get_resource_release_binding` instead.
 
   **Each revised action targets exactly one ReleaseBinding.** If you need to change multiple bindings, create separate actions for each.
@@ -108,10 +108,13 @@ You are NOT required to map RCA actions 1:1. Think holistically:
 
 ## TOOL GUIDELINES
 
-- `list_release_bindings`: Returns the current binding spec including `workloadOverrides.container.env`, `workloadOverrides.container.files`, `componentTypeEnvironmentConfigs`, and `traitEnvironmentConfigs`.
-- `get_component_workloads`: Returns the base workload spec — single `container` (image, env vars, files), `endpoints` (map keyed by name), and `dependencies.endpoints` (connections with envBindings).
-- `get_component_release_schema`: Returns the JSON Schema for overridable fields on a **ReleaseBinding**. **Call this before producing any `revised` action with `fields` targeting a ReleaseBinding** — the schema is dynamic and varies per ComponentType and Trait. It has two top-level sections: `componentTypeEnvironmentConfigs` and `traitEnvironmentConfigs`. It does not apply to ResourceReleaseBindings — use `get_resource_release_binding` for those.
-- `list_component_traits`: Returns traits from the Component's inline `spec.traits` array with their base parameter values.
-- `list_components`: Lists components in a project.
-- `list_resource_release_bindings`: Lists ResourceReleaseBindings in the namespace. Call it with ONLY the namespace (omit the `resource` filter) and match the binding whose `spec.owner.resourceName` is the Resource the RCA report implicates AND whose `spec.environment` matches the scoped environment (`{{ scope.environment }}`) — a Resource can have multiple bindings across environments, so both must match. Do NOT pass the binding name as the `resource` filter, it returns nothing.
-- `get_resource_release_binding`: Returns a ResourceReleaseBinding's current `spec.resourceTypeEnvironmentConfigs`. **Call this before producing a `revised` action targeting a ResourceReleaseBinding** to confirm the field exists and see its current value.
+- `list_components`: Discover components in the scoped project. `latestRelease` is informational and may not be the release deployed in the scoped environment.
+- `get_component`: Inspect a component's parameters and inline traits.
+- `list_release_bindings`: Call with `namespace_name` and `component_name`. Select the summary whose `environment` is `{{ scope.environment }}`; it provides the binding `name` and deployed `releaseName`.
+- `get_release_binding`: Call with `namespace_name` and the selected `binding_name`. It returns the current `workloadOverrides`, `componentTypeEnvironmentConfigs`, and `traitEnvironmentConfigs`.
+- `list_workloads`: Call with `namespace_name` and `component_name` to discover the component's Workload.
+- `get_workload`: Call with `namespace_name` and the selected `workload_name` to inspect its full base spec, including env vars, files, endpoints, and dependencies.
+- `get_component_release`: Call with `namespace_name` and the deployed `release_name` from `list_release_bindings` to inspect the exact release's dependencies, including Resource refs.
+- `get_component_release_schema`: Call with `namespace_name`, `component_name`, and the deployed `release_name`. It returns the JSON Schema for overridable fields on a **ReleaseBinding**. **Call this before producing any `revised` action with `fields` targeting a ReleaseBinding**. It does not apply to ResourceReleaseBindings.
+- `list_resource_release_bindings`: Call with `namespace_name` and the exact `resource_name` from the ComponentRelease dependency. Select the summary whose `environment` is `{{ scope.environment }}`.
+- `get_resource_release_binding`: Call with `namespace_name` and the selected binding `name`. Its `resourceTypeEnvironmentConfigs` contains the current overrides. **Call this before producing a `revised` action targeting a ResourceReleaseBinding** to confirm the field exists and see its current value.

--- a/agents/sre-agent/tests/test_agent.py
+++ b/agents/sre-agent/tests/test_agent.py
@@ -12,8 +12,9 @@ import httpx
 import pytest
 
 import src.agent.agent as agent_module
-from src.agent.agent import Agent, run_analysis, stream_chat
+from src.agent.agent import Agent, RCA_AGENT, REMED_AGENT, run_analysis, stream_chat
 from src.agent.middleware import LoggingMiddleware
+from src.agent.tool_registry import TOOLS
 from src.helpers import AlertScope
 from src.models import RCAReport
 from tests.factories import make_rca_report, make_remediation_result
@@ -50,7 +51,7 @@ def _make_agent(**overrides):
 
 
 @pytest.mark.asyncio
-async def test_create_filters_mcp_tools_and_appends_factories():
+async def test_create_filters_mcp_tools():
     captured = {}
     fake_agent = MagicMock()
     fake_agent.with_config.return_value = "CONFIGURED"
@@ -59,7 +60,7 @@ async def test_create_filters_mcp_tools_and_appends_factories():
         captured.update(kwargs)
         return fake_agent
 
-    agent_obj = _make_agent(tool_factories=[lambda auth: _tool("list_components")])
+    agent_obj = _make_agent(tools={"query_traces", "list_components"})
 
     with (
         patch("src.agent.agent.MCPClient") as mcp_cls,
@@ -67,18 +68,49 @@ async def test_create_filters_mcp_tools_and_appends_factories():
         patch("src.agent.agent.render", lambda *a, **k: "PROMPT"),
     ):
         mcp_cls.return_value.get_tools = AsyncMock(
-            return_value=[_tool("query_traces"), _tool("query_logs")]
+            return_value=[
+                _tool("query_traces"),
+                _tool("query_logs"),
+                _tool("list_components"),
+            ]
         )
         runnable, logging_mw = await agent_obj.create(auth=AUTH)
 
     names = [t.name for t in captured["tools"]]
     assert "query_traces" in names  # in the allowlist
     assert "query_logs" not in names  # filtered out
-    assert "list_components" in names  # factory appended
+    assert "list_components" in names  # in the allowlist
     assert captured["system_prompt"] == "PROMPT"
     assert runnable == "CONFIGURED"
     assert isinstance(logging_mw, LoggingMiddleware)
     fake_agent.with_config.assert_called_once_with({"recursion_limit": 42})
+
+
+def test_analysis_agents_use_native_binding_tools():
+    expected = {
+        TOOLS.LIST_RELEASE_BINDINGS,
+        TOOLS.GET_RELEASE_BINDING,
+        TOOLS.LIST_RESOURCE_RELEASE_BINDINGS,
+        TOOLS.GET_RESOURCE_RELEASE_BINDING,
+    }
+
+    assert expected <= RCA_AGENT.tools
+    assert expected <= REMED_AGENT.tools
+
+
+def test_remediation_agent_only_uses_read_tools():
+    assert REMED_AGENT.tools == {
+        TOOLS.LIST_COMPONENTS,
+        TOOLS.GET_COMPONENT,
+        TOOLS.LIST_WORKLOADS,
+        TOOLS.GET_WORKLOAD,
+        TOOLS.LIST_RELEASE_BINDINGS,
+        TOOLS.GET_RELEASE_BINDING,
+        TOOLS.GET_COMPONENT_RELEASE,
+        TOOLS.GET_COMPONENT_RELEASE_SCHEMA,
+        TOOLS.LIST_RESOURCE_RELEASE_BINDINGS,
+        TOOLS.GET_RESOURCE_RELEASE_BINDING,
+    }
 
 
 @pytest.mark.asyncio

--- a/agents/sre-agent/tests/test_template_manager.py
+++ b/agents/sre-agent/tests/test_template_manager.py
@@ -55,7 +55,7 @@ def _make_tool(name: str):
     return SimpleNamespace(name=name)
 
 
-def test_rca_prompt_requires_environment_match_for_resource_binding_selection():
+def test_rca_prompt_scopes_resource_binding_selection():
     rendered = tm.render(
         "prompts/rca_agent_prompt.j2",
         {
@@ -64,7 +64,7 @@ def test_rca_prompt_requires_environment_match_for_resource_binding_selection():
             "scope": _make_scope("staging"),
         },
     )
-    assert "spec.environment" in rendered
+    assert "`resource_name`" in rendered
     assert "staging" in rendered
 
 
@@ -84,12 +84,12 @@ def test_rca_prompt_reflects_different_scoped_environments():
     assert "development" not in prod
 
 
-def test_remed_prompt_requires_environment_match_for_resource_binding_selection():
+def test_remed_prompt_scopes_resource_binding_selection():
     rendered = tm.render(
         "prompts/remed_agent_prompt.j2",
         {"tools": [], "scope": _make_scope("staging")},
     )
-    assert "spec.environment" in rendered
+    assert "`resource_name`" in rendered
     assert "staging" in rendered
 
 

--- a/agents/sre-agent/tests/test_template_manager.py
+++ b/agents/sre-agent/tests/test_template_manager.py
@@ -89,8 +89,10 @@ def test_remed_prompt_scopes_resource_binding_selection():
         "prompts/remed_agent_prompt.j2",
         {"tools": [], "scope": _make_scope("staging")},
     )
-    assert "`resource_name`" in rendered
-    assert "staging" in rendered
+    assert (
+        "Call with `namespace_name` and the exact `resource_name` from the ComponentRelease dependency. "
+        "Select the summary whose `environment` is `staging`."
+    ) in rendered
 
 
 def test_remed_prompt_separates_schema_source_by_target_kind():

--- a/agents/sre-agent/tests/test_tool_registry.py
+++ b/agents/sre-agent/tests/test_tool_registry.py
@@ -1,29 +1,16 @@
 # Copyright 2026 The OpenChoreo Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the tool registry: tool metadata and OpenChoreo tool factories."""
-
-import json
-from unittest.mock import AsyncMock, patch
-
-import httpx
-import pytest
+"""Tests for the tool registry metadata."""
 
 from src.agent.tool_registry import (
-    ALL_TOOL_FACTORIES,
     OBSERVABILITY,
     OBSERVABILITY_TOOLS,
     OPENCHOREO,
     OPENCHOREO_TOOLS,
     TOOL_ACTIVE_FORMS,
     TOOLS,
-    create_get_resource_release_binding_tool,
-    create_list_components_tool,
-    create_list_release_bindings_tool,
-    create_list_resource_release_bindings_tool,
 )
-
-AUTH = httpx.BasicAuth("user", "pass")
 
 
 def test_tool_is_str_with_metadata():
@@ -44,75 +31,18 @@ def test_active_forms_only_include_tools_with_forms():
     assert all(v is not None for v in TOOL_ACTIVE_FORMS.values())
 
 
-def test_all_tool_factories_are_callables():
-    assert create_list_components_tool in ALL_TOOL_FACTORIES
-    assert create_list_resource_release_bindings_tool in ALL_TOOL_FACTORIES
-    assert create_get_resource_release_binding_tool in ALL_TOOL_FACTORIES
-    assert len(ALL_TOOL_FACTORIES) == 7
+def test_native_mcp_discovery_tools_are_grouped_as_openchoreo():
+    expected = {
+        TOOLS.LIST_COMPONENTS,
+        TOOLS.GET_COMPONENT,
+        TOOLS.LIST_WORKLOADS,
+        TOOLS.GET_WORKLOAD,
+        TOOLS.LIST_RELEASE_BINDINGS,
+        TOOLS.GET_RELEASE_BINDING,
+        TOOLS.GET_COMPONENT_RELEASE,
+        TOOLS.GET_COMPONENT_RELEASE_SCHEMA,
+        TOOLS.LIST_RESOURCE_RELEASE_BINDINGS,
+        TOOLS.GET_RESOURCE_RELEASE_BINDING,
+    }
 
-
-@pytest.mark.asyncio
-async def test_list_components_factory_builds_tool_and_calls_api():
-    tool = create_list_components_tool(AUTH)
-    assert tool.name == "list_components"
-
-    get_mock = AsyncMock(return_value={"items": ["a"]})
-    with patch("src.agent.tool_registry.get", get_mock):
-        out = await tool.coroutine(namespace="ns", project="p")
-
-    assert json.loads(out) == {"items": ["a"]}
-    assert get_mock.await_args.args[0] == "/namespaces/ns/components"
-    assert get_mock.await_args.kwargs["params"] == {"project": "p"}
-
-
-@pytest.mark.asyncio
-async def test_list_release_bindings_factory_filters_by_component():
-    tool = create_list_release_bindings_tool(AUTH)
-    assert tool.name == "list_release_bindings"
-
-    get_mock = AsyncMock(return_value={"items": []})
-    with patch("src.agent.tool_registry.get", get_mock):
-        await tool.coroutine(namespace="ns", component="c")
-
-    assert get_mock.await_args.args[0] == "/namespaces/ns/releasebindings"
-    assert get_mock.await_args.kwargs["params"] == {"component": "c"}
-
-
-@pytest.mark.asyncio
-async def test_list_resource_release_bindings_factory_filters_by_resource():
-    tool = create_list_resource_release_bindings_tool(AUTH)
-    assert tool.name == "list_resource_release_bindings"
-
-    get_mock = AsyncMock(return_value={"items": []})
-    with patch("src.agent.tool_registry.get", get_mock):
-        await tool.coroutine(namespace="ns", resource="snip-postgres")
-
-    assert get_mock.await_args.args[0] == "/namespaces/ns/resourcereleasebindings"
-    assert get_mock.await_args.kwargs["params"] == {"resource": "snip-postgres"}
-
-
-@pytest.mark.asyncio
-async def test_list_resource_release_bindings_factory_omits_empty_filter():
-    tool = create_list_resource_release_bindings_tool(AUTH)
-
-    get_mock = AsyncMock(return_value={"items": []})
-    with patch("src.agent.tool_registry.get", get_mock):
-        await tool.coroutine(namespace="ns")
-
-    assert get_mock.await_args.kwargs["params"] is None
-
-
-@pytest.mark.asyncio
-async def test_get_resource_release_binding_factory_builds_path():
-    tool = create_get_resource_release_binding_tool(AUTH)
-    assert tool.name == "get_resource_release_binding"
-
-    get_mock = AsyncMock(return_value={"metadata": {"name": "snip-postgres-development"}})
-    with patch("src.agent.tool_registry.get", get_mock):
-        out = await tool.coroutine(namespace="ns", name="snip-postgres-development")
-
-    assert json.loads(out) == {"metadata": {"name": "snip-postgres-development"}}
-    assert (
-        get_mock.await_args.args[0]
-        == "/namespaces/ns/resourcereleasebindings/snip-postgres-development"
-    )
+    assert expected <= OPENCHOREO_TOOLS


### PR DESCRIPTION
## Purpose
Use native OpenChoreo MCP tools in SRE RCA and remediation instead of local REST wrappers.

## Approach
- Remove the wrapper factories and whitelist read-only MCP tools.
- Update prompts and tests for native list/get contracts.

## Related Issues
None.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported
- [x] This PR includes AI-generated code or content

## Remarks
`make lint` passes. Tests were not run.