### PR TITLE
fix(helm): restrict observability service ingress

### DIFF
--- a/agents/sre-agent/src/mcp_server.py
+++ b/agents/sre-agent/src/mcp_server.py
@@ -92,31 +92,9 @@ mcp_server = FastMCP(
     # from the path before forwarding — so the inner app must serve at
     # the root "/" or the request 404s.
     streamable_http_path="/",
-    # FastMCP's default DNS-rebinding protection rejects any Host header
-    # not on a tiny allowlist (localhost). In-cluster traffic from the
-    # assistant-agent uses the Service DNS host (e.g.
-    # sre-agent.openchoreo-observability-plane.svc.cluster.local),
-    # which would 421. We disable the protection because (a) ingress is
-    # already gated by JWT auth and (b) the protection guards browsers,
-    # not service-to-service callers.
-    #
-    # Required deployment invariants (the security argument depends on
-    # ALL of these — verify when changing the chart or networking):
-    #   1. ``mcp>=1.23.0`` is pinned in pyproject.toml. Pre-1.23 the SDK
-    #      had a different default for this flag and a different set of
-    #      transport-layer mitigations.
-    #   2. The ``/mcp`` endpoint is NOT exposed via the cluster's
-    #      external HTTPRoute. Only the in-cluster Service is reachable.
-    #      See install/helm/.../templates/rca-agent/httproute.yaml — it
-    #      must NOT include a /mcp path match for the public gateway.
-    #   3. NetworkPolicy (or equivalent) restricts ingress to ``/mcp`` to
-    #      the assistant-agent ServiceAccount / Pod selector.
-    # If any of (1)–(3) cannot be guaranteed in a target environment,
-    # flip this to True and supply ``allowed_hosts`` for the in-cluster
-    # Service DNS instead of disabling protection wholesale.
-    # TODO: revisit once FastMCP exposes a clean ``allowed_hosts`` API
-    # that can be combined with ``enable_dns_rebinding_protection=True``
-    # for a defense-in-depth setup.
+    # Requests arrive through service and gateway hostnames that cannot be
+    # statically enumerated here. JWT authentication and per-tool authorization
+    # are enforced by _MCPAuthMiddleware below.
     transport_security=TransportSecuritySettings(
         enable_dns_rebinding_protection=False,
     ),

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -4605,7 +4605,7 @@
               "type": "integer"
             },
             "observerApiUrl": {
-              "default": "http://observer.openchoreo-observability-plane.svc.cluster.local:8080",
+              "default": "http://observer.openchoreo.localhost:11080",
               "title": "observerApiUrl",
               "type": "string"
             },

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -4269,7 +4269,7 @@ portalAssistant:
 
   config:
     openchoreoApiUrl: "http://openchoreo-api.openchoreo-control-plane.svc.cluster.local:8080"
-    observerApiUrl: "http://observer.openchoreo-observability-plane.svc.cluster.local:8080"
+    observerApiUrl: "http://observer.openchoreo.localhost:11080"
     rcaAgentApiUrl: ""
     maxConcurrentChats: 20
     authzTimeoutSeconds: 30

--- a/install/helm/openchoreo-observability-plane/templates/networkpolicy.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/networkpolicy.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: observability-plane-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "openchoreo-observability-plane.labels" . | nindent 4 }}
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector: {}
+    {{- with .Values.networkPolicy.additionalIngress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- with .Values.networkPolicy.unrestrictedIngressAppNames }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: observability-plane-unrestricted-ingress
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "openchoreo-observability-plane.labels" $ | nindent 4 }}
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+          {{- toYaml . | nindent 10 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - {}
+{{- end }}
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/sre-agent/http-route.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/sre-agent/http-route.yaml
@@ -31,4 +31,12 @@ spec:
     backendRefs:
     - name: {{ .Values.rca.name }}
       port: {{ .Values.rca.service.port }}
+  - name: mcp
+    matches:
+    - path:
+        type: PathPrefix
+        value: /mcp
+    backendRefs:
+    - name: {{ .Values.rca.name }}
+      port: {{ .Values.rca.service.port }}
 {{- end }}

--- a/install/helm/openchoreo-observability-plane/templates/sre-agent/traffic-policy.yaml
+++ b/install/helm/openchoreo-observability-plane/templates/sre-agent/traffic-policy.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.gateway.enabled .Values.rca.enabled .Values.rca.http.enabled (eq (.Values.gateway.gatewayClassName | default "kgateway") "kgateway") }}
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: TrafficPolicy
+metadata:
+  name: {{ .Values.rca.name }}-mcp-timeout
+  namespace: {{ .Release.Namespace }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ .Values.rca.name }}
+      sectionName: mcp
+  timeouts:
+    request: "0s"
+    streamIdle: "24h"
+{{- end }}

--- a/install/helm/openchoreo-observability-plane/values.schema.json
+++ b/install/helm/openchoreo-observability-plane/values.schema.json
@@ -1327,6 +1327,43 @@
       "title": "kubernetesClusterDomain",
       "type": "string"
     },
+    "networkPolicy": {
+      "additionalProperties": false,
+      "description": "Namespace ingress isolation for observability-plane workloads. Requires a NetworkPolicy-capable CNI.",
+      "properties": {
+        "additionalIngress": {
+          "default": [],
+          "description": "Additional ingress rules appended to the built-in rules",
+          "items": {
+            "required": [],
+            "type": "object"
+          },
+          "title": "additionalIngress",
+          "type": "array"
+        },
+        "enabled": {
+          "default": true,
+          "description": "Restrict ingress to the release namespace, except for explicitly exempted applications and rules",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "unrestrictedIngressAppNames": {
+          "default": [
+            "gateway-default",
+            "opentelemetry-collector"
+          ],
+          "description": "app.kubernetes.io/name values allowed unrestricted ingress",
+          "items": {
+            "type": "string"
+          },
+          "title": "unrestrictedIngressAppNames",
+          "type": "array"
+        }
+      },
+      "required": [],
+      "title": "networkPolicy",
+      "type": "object"
+    },
     "observer": {
       "additionalProperties": true,
       "description": "OpenChoreo Observer service configuration - REST API that abstracts observability backends for logging, metrics, and tracing via adapters",

--- a/install/helm/openchoreo-observability-plane/values.yaml
+++ b/install/helm/openchoreo-observability-plane/values.yaml
@@ -63,6 +63,38 @@ kubernetesClusterDomain: cluster.local
 
 # @schema
 # type: object
+# description: Namespace ingress isolation for observability-plane workloads. Requires a NetworkPolicy-capable CNI.
+# @schema
+networkPolicy:
+  # @schema
+  # type: boolean
+  # description: Restrict ingress to the release namespace, except for explicitly exempted applications and rules
+  # default: true
+  # @schema
+  enabled: true
+
+  # @schema
+  # type: array
+  # description: app.kubernetes.io/name values allowed unrestricted ingress
+  # items:
+  #   type: string
+  # default: [gateway-default, opentelemetry-collector]
+  # @schema
+  unrestrictedIngressAppNames:
+    - gateway-default
+    - opentelemetry-collector
+
+  # @schema
+  # type: array
+  # description: Additional ingress rules appended to the built-in rules
+  # items:
+  #   type: object
+  # default: []
+  # @schema
+  additionalIngress: []
+
+# @schema
+# type: object
 # description: Configuration for the observability plane controller manager that reconciles ObservabilityAlertRules and other CRDs
 # @schema
 controllerManager:

--- a/install/k3d/multi-cluster/values-cp.yaml
+++ b/install/k3d/multi-cluster/values-cp.yaml
@@ -25,6 +25,10 @@ backstage:
     hostnames:
     - openchoreo.localhost
 
+portalAssistant:
+  config:
+    observerApiUrl: "http://observer.openchoreo.localhost:11080"
+
 security:
   oidc:
     issuer: "http://thunder.openchoreo.localhost:8080"

--- a/install/k3d/single-cluster/values-cp.yaml
+++ b/install/k3d/single-cluster/values-cp.yaml
@@ -21,6 +21,10 @@ backstage:
     hostnames:
     - openchoreo.localhost
 
+portalAssistant:
+  config:
+    observerApiUrl: "http://observer.openchoreo.localhost:11080"
+
 security:
   oidc:
     issuer: "http://thunder.openchoreo.localhost:8080"

--- a/install/quick-start/.values-cp.yaml
+++ b/install/quick-start/.values-cp.yaml
@@ -126,6 +126,10 @@ backstage:
     hostnames:
     - openchoreo.localhost
 
+portalAssistant:
+  config:
+    observerApiUrl: "http://observer.openchoreo.localhost:11080"
+
 features:
   secretManagement:
     enabled: true

--- a/test/e2e/framework/observer.go
+++ b/test/e2e/framework/observer.go
@@ -10,12 +10,12 @@ import (
 	"time"
 )
 
-// Observer service coordinates inside the e2e cluster. Set by `_e2e.install-op`
-// in make/e2e.mk — keep these names in sync.
+// Observer gateway coordinates inside the e2e cluster. Set by `_e2e.install-op`
+// in make/e2e.mk — keep these values in sync.
 const (
 	ObserverNamespace = "openchoreo-observability-plane"
-	ObserverService   = "observer"
-	ObserverPort      = 8080
+	ObserverService   = "gateway-default"
+	observerURL       = "http://observer.e2e-op.local:21080"
 
 	// Thunder OAuth2 client_credentials path used to mint a bearer token for
 	// the observer's JWT-protected query routes. service_mcp_client carries
@@ -62,10 +62,8 @@ type ObserverQueryFrom struct {
 	// k3d cluster). Empty falls back to the default in-cluster URL.
 	ThunderTokenURL string
 
-	// ObserverURL overrides the in-cluster observer service base URL.
-	// Set this when the exec pod cannot reach
-	// observer.openchoreo-observability-plane.svc via cluster DNS (e.g.
-	// multi-cluster e2e where the observer is in a different k3d cluster).
+	// ObserverURL overrides the observer gateway base URL. Set this for
+	// multi-cluster e2e where the observer runs in a different k3d cluster.
 	// Must not include a trailing slash. Empty falls back to the default
 	// in-cluster URL.
 	ObserverURL string
@@ -220,8 +218,8 @@ func QueryTraces(q ObserverQueryFrom, token string, req TracesQueryRequest) (*Tr
 	return &resp, nil
 }
 
-// observerPost runs `kubectl exec <pod> -- curl ...` to POST to the observer's
-// in-cluster Service. Using kubectl-exec instead of `kubectl port-forward`
+// observerPost runs `kubectl exec <pod> -- curl ...` to POST through the
+// observability gateway. Using kubectl-exec instead of `kubectl port-forward`
 // avoids forwarder lifecycle management and mirrors the pattern used by
 // framework/gitea.go.
 func observerPost(q ObserverQueryFrom, token, path string, payload any) (string, error) {
@@ -229,8 +227,7 @@ func observerPost(q ObserverQueryFrom, token, path string, payload any) (string,
 	if err != nil {
 		return "", fmt.Errorf("marshal payload: %w", err)
 	}
-	baseURL := fmt.Sprintf("http://%s.%s.svc.cluster.local:%d",
-		ObserverService, ObserverNamespace, ObserverPort)
+	baseURL := observerURL
 	if q.ObserverURL != "" {
 		baseURL = q.ObserverURL
 	}

--- a/test/e2e/k3d/multi-cluster/values-cp.yaml
+++ b/test/e2e/k3d/multi-cluster/values-cp.yaml
@@ -17,6 +17,10 @@ backstage:
     hostnames:
       - openchoreo.e2e-mc-cp.local
 
+portalAssistant:
+  config:
+    observerApiUrl: "http://observer.e2e-mc-op.local:31080"
+
 security:
   oidc:
     issuer: "http://thunder.e2e-mc-cp.local:38080"

--- a/test/e2e/k3d/values-cp.yaml
+++ b/test/e2e/k3d/values-cp.yaml
@@ -17,6 +17,10 @@ backstage:
     hostnames:
       - openchoreo.e2e-cp.local
 
+portalAssistant:
+  config:
+    observerApiUrl: "http://observer.e2e-op.local:21080"
+
 security:
   oidc:
     issuer: "http://thunder.e2e-cp.local:28080"


### PR DESCRIPTION
## Purpose
Restrict observability-plane ingress while preserving required platform communication.

## Approach
- Restrict all observability-plane pods to same-namespace ingress.
- Add an additive allow-all policy for the configured gateway and collector applications.
- Route Observer and SRE MCP traffic through their hostname-based routes on the observability Gateway.
- Apply the standard MCP streaming timeout to the SRE route.
- Use the single-cluster Observer gateway hostname by default and configure local and e2e overrides explicitly.

## Related Issues
None.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks
None.