### PR TITLE
feat(api): record resource.environment in audit events

### DIFF
--- a/internal/observer/authz/helpers.go
+++ b/internal/observer/authz/helpers.go
@@ -108,11 +108,17 @@ func CheckAuthorization(
 	// and an authz-disabled deployment all produce an audit event carrying
 	// the hierarchy the decision was made on. Mirrors openchoreo-api's
 	// AuthzChecker.Check; a no-op when the request has no audit context.
+	//
+	// Environment is read from the ABAC attributes for the same reason as
+	// there. It records nothing today: every observer operation supplying one
+	// is a read, and reads are unaudited. Wired anyway so an audited
+	// operation that becomes environment-scoped needs no change here.
 	audit.SetHierarchy(ctx, audit.Hierarchy{
-		Namespace: hierarchy.Namespace,
-		Project:   hierarchy.Project,
-		Component: hierarchy.Component,
-		Resource:  hierarchy.Resource,
+		Namespace:   hierarchy.Namespace,
+		Environment: authzCtx.Resource.Environment,
+		Project:     hierarchy.Project,
+		Component:   hierarchy.Component,
+		Resource:    hierarchy.Resource,
 	})
 
 	if pdp == nil {

--- a/internal/observer/authz/helpers_test.go
+++ b/internal/observer/authz/helpers_test.go
@@ -17,6 +17,7 @@ import (
 	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
 	coremocks "github.com/openchoreo/openchoreo/internal/authz/core/mocks"
 	"github.com/openchoreo/openchoreo/internal/observer/types"
+	"github.com/openchoreo/openchoreo/internal/server/middleware/audit"
 	"github.com/openchoreo/openchoreo/internal/server/middleware/auth"
 )
 
@@ -423,6 +424,71 @@ func TestCheckAuthorization_DecisionDenied(t *testing.T) {
 		authzcore.Context{},
 	)
 	assert.ErrorIs(t, err, ErrAuthzForbidden)
+}
+
+// TestCheckAuthorization_RecordsEnvironmentRegardlessOfDecision guards that an
+// environment-scoped observer operation reaches the audit record with the same
+// dual-scoped value the decision used, whatever the decision was. No audited
+// observer operation supplies one yet, so this is what keeps the wiring honest
+// until one does.
+func TestCheckAuthorization_RecordsEnvironmentRegardlessOfDecision(t *testing.T) {
+	const env = "acme/production"
+
+	tests := []struct {
+		name     string
+		decision *authzcore.Decision
+		evalErr  error
+	}{
+		{name: "allow", decision: &authzcore.Decision{Decision: true}},
+		{name: "deny", decision: &authzcore.Decision{Decision: false}},
+		{name: "pdp error", evalErr: fmt.Errorf("pdp unavailable")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockPDP := coremocks.NewMockPDP(t)
+			mockPDP.EXPECT().Evaluate(mock.Anything, mock.Anything).
+				Return(tt.decision, tt.evalErr)
+
+			ctx, auditData := audit.NewAuditContext(ctxWithSubject(), &audit.Resource{})
+			_ = CheckAuthorization(
+				ctx,
+				noopLogger(),
+				mockPDP,
+				ActionViewLogs,
+				ResourceTypeComponent,
+				"api",
+				authzcore.ResourceHierarchy{Namespace: "acme", Component: "api"},
+				authzcore.Context{Resource: authzcore.ResourceAttribute{Environment: env}},
+			)
+
+			want := audit.Hierarchy{Namespace: "acme", Environment: env, Component: "api"}
+			assert.Equal(t, want, auditData.Hierarchy)
+		})
+	}
+}
+
+// TestCheckAuthorization_NoEnvironmentAttributeRecordsNone covers observer's
+// current operations, none of which pass an environment.
+func TestCheckAuthorization_NoEnvironmentAttributeRecordsNone(t *testing.T) {
+	mockPDP := coremocks.NewMockPDP(t)
+	mockPDP.EXPECT().Evaluate(mock.Anything, mock.Anything).
+		Return(&authzcore.Decision{Decision: true}, nil)
+
+	ctx, auditData := audit.NewAuditContext(ctxWithSubject(), &audit.Resource{})
+	err := CheckAuthorization(
+		ctx,
+		noopLogger(),
+		mockPDP,
+		ActionViewLogs,
+		ResourceTypeComponent,
+		"api",
+		authzcore.ResourceHierarchy{Namespace: "acme"},
+		authzcore.Context{},
+	)
+
+	require.NoError(t, err)
+	assert.Empty(t, auditData.Hierarchy.Environment)
 }
 
 func TestCheckAuthorization_BuildsCorrectRequest(t *testing.T) {

--- a/internal/openchoreo-api/api/handlers/exec_wirelogs_audit_test.go
+++ b/internal/openchoreo-api/api/handlers/exec_wirelogs_audit_test.go
@@ -296,8 +296,13 @@ func TestWirelogsHandler_SetsResourceNamespaceFromParsedPath(t *testing.T) {
 	if resource["namespace"] != "ns-a" {
 		t.Errorf("resource.namespace = %v, want %q", resource["namespace"], "ns-a")
 	}
-	if resource["name"] != "dev-a" {
-		t.Errorf("resource.name = %v, want %q", resource["name"], "dev-a")
+	// The route's scope belongs in resource.environment, not resource.name,
+	// and carries the dual-scoped identifier authorization uses.
+	if resource["environment"] != "ns-a/dev-a" {
+		t.Errorf("resource.environment = %v, want %q", resource["environment"], "ns-a/dev-a")
+	}
+	if _, present := resource["name"]; present {
+		t.Errorf("resource.name = %v, want absent", resource["name"])
 	}
 }
 

--- a/internal/openchoreo-api/api/handlers/wirelogs.go
+++ b/internal/openchoreo-api/api/handlers/wirelogs.go
@@ -133,10 +133,21 @@ func (h *WirelogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	checkReq := wirelogsCheckRequest(namespace, environment, project, component)
+
 	// The middleware's pre-handler seed can't fill resource.namespace for
 	// this route (its path parameter isn't "namespaceName"), so set it here
 	// — after validation, so a malformed value never reaches the record.
-	audit.SetResource(r.Context(), &audit.Resource{Namespace: namespace, Name: environment})
+	//
+	// The environment is this route's scope rather than the target object's
+	// name, so it goes in the hierarchy. Taken from the check request so both
+	// carry one value, and written before the ownership 403 below, which is a
+	// denial that never reaches the check that would otherwise record it.
+	audit.SetResource(r.Context(), &audit.Resource{Namespace: namespace})
+	audit.SetHierarchy(r.Context(), audit.Hierarchy{
+		Namespace:   namespace,
+		Environment: checkReq.Context.Resource.Environment,
+	})
 
 	ctx := r.Context()
 	logger := h.logger.With(
@@ -169,7 +180,7 @@ func (h *WirelogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err := h.authzChecker.Check(ctx, wirelogsCheckRequest(namespace, environment, project, component)); err != nil {
+	if err := h.authzChecker.Check(ctx, checkReq); err != nil {
 		if errors.Is(err, svcpkg.ErrForbidden) {
 			http.Error(w, "you do not have permission to view wirelogs for this scope", http.StatusForbidden)
 			return

--- a/internal/openchoreo-api/services/authz.go
+++ b/internal/openchoreo-api/services/authz.go
@@ -45,11 +45,16 @@ func (c *AuthzChecker) Check(ctx context.Context, req CheckRequest) error {
 	// REST path parameter or a handler's SetResource call, so both REST
 	// handlers and MCP tools (pkg/mcp/mcpaudit) get the hierarchy for free
 	// instead of each caller having to capture it individually.
+	// Environment comes from the ABAC attributes, which have no hierarchy
+	// level, and keeps the dual-scoped form so the record quotes the
+	// identifier the decision was made on. Read from the check itself rather
+	// than a field of its own, so callers can't set one and forget the other.
 	audit.SetHierarchy(ctx, audit.Hierarchy{
-		Namespace: req.Hierarchy.Namespace,
-		Project:   req.Hierarchy.Project,
-		Component: req.Hierarchy.Component,
-		Resource:  req.Hierarchy.Resource,
+		Namespace:   req.Hierarchy.Namespace,
+		Environment: req.Context.Resource.Environment,
+		Project:     req.Hierarchy.Project,
+		Component:   req.Hierarchy.Component,
+		Resource:    req.Hierarchy.Resource,
 	})
 
 	authSubjectCtx, _ := auth.GetSubjectContextFromContext(ctx)

--- a/internal/openchoreo-api/services/authz_test.go
+++ b/internal/openchoreo-api/services/authz_test.go
@@ -142,6 +142,60 @@ func TestCheck_RecordsHierarchyRegardlessOfDecision(t *testing.T) {
 	}
 }
 
+// TestCheck_RecordsEnvironmentRegardlessOfDecision is why the environment is
+// recorded here rather than by a handler's SetResource call: a denial never
+// reaches the handler, and a refused attempt on a production environment is
+// exactly the record that needs to name it. It also pins the value to the
+// dual-scoped identifier the decision used, not a re-derived variant.
+func TestCheck_RecordsEnvironmentRegardlessOfDecision(t *testing.T) {
+	evalErr := errors.New("pdp unavailable")
+	tests := []struct {
+		name     string
+		decision *authz.Decision
+		evalErr  error
+	}{
+		{name: "allow", decision: &authz.Decision{Decision: true, Context: &authz.DecisionContext{}}},
+		{name: "deny", decision: &authz.Decision{Decision: false, Context: &authz.DecisionContext{}}},
+		{name: "pdp error", evalErr: evalErr},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pdp := authzmocks.NewMockPDP(t)
+			pdp.EXPECT().Evaluate(mock.Anything, mock.Anything).Return(tt.decision, tt.evalErr)
+			checker := newTestChecker(pdp)
+
+			req := testCheckRequest()
+			req.Context = authz.Context{
+				Resource: authz.ResourceAttribute{
+					Environment: FormatDualScopedResourceName("ns-1", "production", false),
+				},
+			}
+
+			ctx, auditData := audit.NewAuditContext(ctxWithSubject(testSubjectContext()), &audit.Resource{})
+			_ = checker.Check(ctx, req)
+
+			want := audit.Hierarchy{Namespace: "ns-1", Environment: "ns-1/production", Project: "my-project"}
+			require.Equal(t, want, auditData.Hierarchy)
+		})
+	}
+}
+
+// TestCheck_NoEnvironmentAttributeRecordsNone covers the environment-agnostic
+// majority of operations: no ABAC environment means an empty one, not
+// something derived from the namespace.
+func TestCheck_NoEnvironmentAttributeRecordsNone(t *testing.T) {
+	pdp := authzmocks.NewMockPDP(t)
+	pdp.EXPECT().Evaluate(mock.Anything, mock.Anything).
+		Return(&authz.Decision{Decision: true, Context: &authz.DecisionContext{}}, nil)
+	checker := newTestChecker(pdp)
+
+	ctx, auditData := audit.NewAuditContext(ctxWithSubject(testSubjectContext()), &audit.Resource{})
+	_ = checker.Check(ctx, testCheckRequest())
+
+	require.Empty(t, auditData.Hierarchy.Environment)
+}
+
 // TestBatchCheck_DoesNotRecordHierarchy guards that FilteredList's per-item
 // checks — routed through BatchCheck, not Check — stay out of the audit
 // record. BatchCheck is used for read-side filtering, not an audited

--- a/internal/server/middleware/audit/logger.go
+++ b/internal/server/middleware/audit/logger.go
@@ -131,6 +131,12 @@ func decodeObjectAttrs(dec *json.Decoder) ([]any, error) {
 				if err != nil {
 					return nil, err
 				}
+				if len(group) == 0 {
+					// slog.JSONHandler drops an empty group, which would lose
+					// the field the marshaled form still carries.
+					attrs = append(attrs, slog.Any(key, map[string]any{}))
+					continue
+				}
 				attrs = append(attrs, slog.Group(key, group...))
 			case '[':
 				arr, err := decodeArray(dec)

--- a/internal/server/middleware/audit/logger.go
+++ b/internal/server/middleware/audit/logger.go
@@ -4,7 +4,10 @@
 package audit
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"log/slog"
 )
 
@@ -53,92 +56,169 @@ func NewLogger(slogger *slog.Logger) *Logger {
 	return &Logger{slogger: slog.New(&forceLevelHandler{Handler: slogger.Handler()})}
 }
 
-// LogEvent emits an audit log event using slog
+// LogEvent emits an audit log event using slog. The attrs are derived from
+// Event.MarshalJSON's output rather than built by hand, so the log stream and
+// a sink that marshals the same *Event cannot publish different shapes.
 func (l *Logger) LogEvent(event *Event) {
-	attrs := []any{
-		slog.String("event_id", event.EventID),
-		slog.Time("timestamp", event.Timestamp),
+	payload, err := json.Marshal(event)
+	if err != nil {
+		l.logRenderFailure(event, err)
+		return
 	}
 
-	actorAttrs := []any{
-		slog.String("type", event.Actor.Type),
-		slog.String("id", event.Actor.ID),
-	}
-	if len(event.Actor.Entitlements) > 0 {
-		entitlementAttrs := make([]any, 0, len(event.Actor.Entitlements))
-		for k, v := range event.Actor.Entitlements {
-			entitlementAttrs = append(entitlementAttrs, slog.Any(k, v))
-		}
-		actorAttrs = append(actorAttrs, slog.Group("entitlements", entitlementAttrs...))
-	}
-	attrs = append(attrs, slog.Group("actor", actorAttrs...))
+	dec := json.NewDecoder(bytes.NewReader(payload))
+	// Numbers stay json.Number so a value round-trips to the same bytes it
+	// marshaled from, rather than through float64.
+	dec.UseNumber()
 
-	attrs = append(attrs,
-		slog.String("action", event.Action),
-		slog.String("category", string(event.Category)),
-		slog.String("result", string(event.Result)),
-		slog.String("request_id", event.RequestID),
-		slog.String("source_ip", event.SourceIP),
-		slog.String("service", event.Service),
-	)
-	if event.Origin != "" {
-		attrs = append(attrs, slog.String("origin", string(event.Origin)))
+	tok, err := dec.Token()
+	if err != nil {
+		l.logRenderFailure(event, err)
+		return
 	}
-	if event.OperationID != "" {
-		attrs = append(attrs, slog.String("operation_id", event.OperationID))
+	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
+		l.logRenderFailure(event, fmt.Errorf("expected a JSON object, got %v", tok))
+		return
 	}
 
-	if event.ResourceType != "" || event.Resource != nil || event.Hierarchy != (Hierarchy{}) {
-		var resourceAttrs []any
-		if event.ResourceType != "" {
-			resourceAttrs = append(resourceAttrs, slog.String("type", event.ResourceType))
-		}
-		// Same precedence as Event.MarshalJSON and buildEvent's
-		// withHierarchyNamespaceFallback: the hierarchy's namespace unless
-		// the Resource carries one of its own. Keeping the two render paths
-		// identical here is what TestEvent_MarshalJSONMatchesLogEventShape
-		// guards.
-		namespace := event.Hierarchy.Namespace
-		if event.Resource != nil && event.Resource.Namespace != "" {
-			namespace = event.Resource.Namespace
-		}
-		if namespace != "" {
-			resourceAttrs = append(resourceAttrs, slog.String("namespace", namespace))
-		}
-		if event.Hierarchy.Project != "" {
-			resourceAttrs = append(resourceAttrs, slog.String("project", event.Hierarchy.Project))
-		}
-		if event.Hierarchy.Component != "" {
-			resourceAttrs = append(resourceAttrs, slog.String("component", event.Hierarchy.Component))
-		}
-		if event.Hierarchy.Resource != "" {
-			resourceAttrs = append(resourceAttrs, slog.String("resource", event.Hierarchy.Resource))
-		}
-		if event.Resource != nil {
-			if event.Resource.ID != "" {
-				resourceAttrs = append(resourceAttrs, slog.String("id", event.Resource.ID))
-			}
-			if event.Resource.Name != "" {
-				resourceAttrs = append(resourceAttrs, slog.String("name", event.Resource.Name))
-			}
-			if len(event.Resource.Metadata) > 0 {
-				metadataAttrs := make([]any, 0, len(event.Resource.Metadata))
-				for k, v := range event.Resource.Metadata {
-					metadataAttrs = append(metadataAttrs, slog.Any(k, v))
-				}
-				resourceAttrs = append(resourceAttrs, slog.Group("metadata", metadataAttrs...))
-			}
-		}
-		attrs = append(attrs, slog.Group("resource", resourceAttrs...))
-	}
-
-	if len(event.Metadata) > 0 {
-		metadataAttrs := make([]any, 0, len(event.Metadata))
-		for k, v := range event.Metadata {
-			metadataAttrs = append(metadataAttrs, slog.Any(k, v))
-		}
-		attrs = append(attrs, slog.Group("metadata", metadataAttrs...))
+	attrs, err := decodeObjectAttrs(dec)
+	if err != nil {
+		l.logRenderFailure(event, err)
+		return
 	}
 
 	l.slogger.Info("AUDIT-LOG", attrs...)
+}
+
+// logRenderFailure publishes an audit event's identity when its body cannot be
+// rendered, rather than dropping the record silently. Reachable only through
+// the map[string]any metadata fields, which could hold a non-marshalable value.
+func (l *Logger) logRenderFailure(event *Event, err error) {
+	l.slogger.Error("AUDIT-LOG-RENDER-FAILED",
+		slog.String("event_id", event.EventID),
+		slog.String("action", event.Action),
+		slog.String("result", string(event.Result)),
+		slog.String("error", err.Error()),
+	)
+}
+
+// decodeObjectAttrs reads key/value pairs up to the object's closing brace as
+// slog attrs, nested objects becoming slog.Group. A decoder rather than a
+// map[string]any because map iteration would lose field order.
+func decodeObjectAttrs(dec *json.Decoder) ([]any, error) {
+	var attrs []any
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		if delim, ok := tok.(json.Delim); ok && delim == '}' {
+			return attrs, nil
+		}
+		key, ok := tok.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected an object key, got %v", tok)
+		}
+
+		valTok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		if delim, ok := valTok.(json.Delim); ok {
+			switch delim {
+			case '{':
+				group, err := decodeObjectAttrs(dec)
+				if err != nil {
+					return nil, err
+				}
+				attrs = append(attrs, slog.Group(key, group...))
+			case '[':
+				arr, err := decodeArray(dec)
+				if err != nil {
+					return nil, err
+				}
+				attrs = append(attrs, slog.Any(key, arr))
+			default:
+				return nil, fmt.Errorf("unexpected delimiter %v for key %q", delim, key)
+			}
+			continue
+		}
+		attrs = append(attrs, slog.Any(key, valTok))
+	}
+}
+
+// decodeArray reads array elements up to the closing bracket as plain Go
+// values; an array has no keys to group by.
+func decodeArray(dec *json.Decoder) ([]any, error) {
+	items := []any{}
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		if delim, ok := tok.(json.Delim); ok {
+			switch delim {
+			case ']':
+				return items, nil
+			case '{':
+				obj, err := decodeObjectMap(dec)
+				if err != nil {
+					return nil, err
+				}
+				items = append(items, obj)
+				continue
+			case '[':
+				nested, err := decodeArray(dec)
+				if err != nil {
+					return nil, err
+				}
+				items = append(items, nested)
+				continue
+			}
+		}
+		items = append(items, tok)
+	}
+}
+
+// decodeObjectMap reads an object nested inside an array into a map.
+func decodeObjectMap(dec *json.Decoder) (map[string]any, error) {
+	out := map[string]any{}
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		if delim, ok := tok.(json.Delim); ok && delim == '}' {
+			return out, nil
+		}
+		key, ok := tok.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected an object key, got %v", tok)
+		}
+
+		valTok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		if delim, ok := valTok.(json.Delim); ok {
+			switch delim {
+			case '{':
+				nested, err := decodeObjectMap(dec)
+				if err != nil {
+					return nil, err
+				}
+				out[key] = nested
+			case '[':
+				arr, err := decodeArray(dec)
+				if err != nil {
+					return nil, err
+				}
+				out[key] = arr
+			default:
+				return nil, fmt.Errorf("unexpected delimiter %v for key %q", delim, key)
+			}
+			continue
+		}
+		out[key] = valTok
+	}
 }

--- a/internal/server/middleware/audit/logger_test.go
+++ b/internal/server/middleware/audit/logger_test.go
@@ -176,63 +176,6 @@ func TestLogEvent_OmitsEmptyHierarchyFields(t *testing.T) {
 	}
 }
 
-// TestEvent_MarshalJSONMatchesLogEventShape guards against a future sink that
-// marshals *Event directly (e.g. a P5 webhook sink) publishing a different
-// wire shape than Logger.LogEvent — both must render resource.type nested
-// inside "resource", not as a sibling "resource_type" field.
-func TestEvent_MarshalJSONMatchesLogEventShape(t *testing.T) {
-	event := &Event{
-		Actor:        Actor{Type: "user", ID: "u1"},
-		Action:       "update_project",
-		Category:     CategoryManagement,
-		Result:       ResultSuccess,
-		ResourceType: "project",
-		Resource:     &Resource{ID: "uid-1", Name: "p1"},
-		Hierarchy:    Hierarchy{Project: "p1"},
-	}
-
-	var loggerRecord map[string]any
-	var buf bytes.Buffer
-	NewLogger(slog.New(slog.NewJSONHandler(&buf, nil))).LogEvent(event)
-	if err := json.Unmarshal(buf.Bytes(), &loggerRecord); err != nil {
-		t.Fatalf("failed to unmarshal LogEvent output: %v", err)
-	}
-
-	var marshalRecord map[string]any
-	marshaled, err := json.Marshal(event)
-	if err != nil {
-		t.Fatalf("json.Marshal(event) failed: %v", err)
-	}
-	if err := json.Unmarshal(marshaled, &marshalRecord); err != nil {
-		t.Fatalf("failed to unmarshal json.Marshal(event) output: %v", err)
-	}
-
-	loggerResource, ok := loggerRecord["resource"].(map[string]any)
-	if !ok {
-		t.Fatal("LogEvent output has no resource group")
-	}
-	marshalResource, ok := marshalRecord["resource"].(map[string]any)
-	if !ok {
-		t.Fatal("json.Marshal(event) output has no resource field")
-	}
-
-	if marshalResource["type"] != loggerResource["type"] {
-		t.Errorf("resource.type = %v, want %v (matching LogEvent)", marshalResource["type"], loggerResource["type"])
-	}
-	if marshalResource["id"] != loggerResource["id"] {
-		t.Errorf("resource.id = %v, want %v (matching LogEvent)", marshalResource["id"], loggerResource["id"])
-	}
-	if marshalResource["name"] != loggerResource["name"] {
-		t.Errorf("resource.name = %v, want %v (matching LogEvent)", marshalResource["name"], loggerResource["name"])
-	}
-	if marshalResource["project"] != loggerResource["project"] {
-		t.Errorf("resource.project = %v, want %v (matching LogEvent)", marshalResource["project"], loggerResource["project"])
-	}
-	if _, present := marshalRecord["resource_type"]; present {
-		t.Error(`json.Marshal(event) must not emit a sibling "resource_type" field`)
-	}
-}
-
 // testRenderNamespace is the namespace the two render-path tests below assert
 // on, named rather than repeated so the literal appears once per role.
 const testRenderNamespace = "ns-1"

--- a/internal/server/middleware/audit/record_shape_test.go
+++ b/internal/server/middleware/audit/record_shape_test.go
@@ -12,17 +12,17 @@ import (
 	"time"
 )
 
-// goldenTime is the fixed Timestamp most golden cases use, so the rendered
-// bytes don't depend on the clock.
-var goldenTime = time.Date(2026, 9, 7, 12, 30, 45, 0, time.UTC)
+// fixedTime is the Timestamp most cases use, so the rendered bytes don't
+// depend on the clock.
+var fixedTime = time.Date(2026, 9, 7, 12, 30, 45, 0, time.UTC)
 
 // logLinePrefix is what slog's JSONHandler puts before the event's own fields.
 const logLinePrefix = `{"level":"INFO","msg":"AUDIT-LOG",`
 
-// newGoldenLogger returns a Logger writing to buf with slog's handler-stamped
+// newRecordLogger returns a Logger writing to buf with slog's handler-stamped
 // "time" attr removed — it is the wall clock at emission, so it would defeat
 // any byte comparison. The event's own pinned "timestamp" is the one asserted.
-func newGoldenLogger(buf *bytes.Buffer) *Logger {
+func newRecordLogger(buf *bytes.Buffer) *Logger {
 	return NewLogger(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{
 		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 			if len(groups) == 0 && a.Key == slog.TimeKey {
@@ -33,22 +33,22 @@ func newGoldenLogger(buf *bytes.Buffer) *Logger {
 	})))
 }
 
-type goldenCase struct {
+type recordCase struct {
 	name  string
 	event *Event
 	want  string
 }
 
-// goldenCases covers the branches the render takes: every field populated, a
+// recordCases covers the branches the render takes: every field populated, a
 // nil Resource carrying only a hierarchy, a rejection that resolved no
 // operation, sub-second timestamps, and both metadata groups.
-func goldenCases() []goldenCase {
-	return []goldenCase{
+func recordCases() []recordCase {
+	return []recordCase{
 		{
 			name: "full event",
 			event: &Event{
 				EventID:   "01920000-0000-7000-8000-000000000001",
-				Timestamp: goldenTime,
+				Timestamp: fixedTime,
 				Actor: Actor{
 					Type:         "user",
 					ID:           "user@example.com",
@@ -65,7 +65,7 @@ func goldenCases() []goldenCase {
 				RequestID:    "11111111-1111-4111-8111-111111111111",
 				SourceIP:     "10.0.0.1",
 				Service:      "openchoreo-api",
-				Metadata:     map[string]any{"note": "golden"},
+				Metadata:     map[string]any{"note": "n1"},
 			},
 			want: logLinePrefix + `"event_id":"01920000-0000-7000-8000-000000000001",` +
 				`"timestamp":"2026-09-07T12:30:45Z",` +
@@ -75,13 +75,13 @@ func goldenCases() []goldenCase {
 				`"service":"openchoreo-api","origin":"api","operation_id":"UpdateReleaseBinding",` +
 				`"resource":{"type":"releasebindings","namespace":"ns-1","environment":"ns-1/production",` +
 				`"project":"p1","component":"c1","id":"uid-1","name":"rb-1"},` +
-				`"metadata":{"note":"golden"}}` + "\n",
+				`"metadata":{"note":"n1"}}` + "\n",
 		},
 		{
 			name: "nil resource with hierarchy",
 			event: &Event{
 				EventID:      "01920000-0000-7000-8000-000000000002",
-				Timestamp:    goldenTime,
+				Timestamp:    fixedTime,
 				Actor:        Actor{Type: "user", ID: "u1"},
 				Action:       "update_project",
 				Category:     CategoryManagement,
@@ -106,7 +106,7 @@ func goldenCases() []goldenCase {
 			name: "unauthenticated with no operation",
 			event: &Event{
 				EventID:   "01920000-0000-7000-8000-000000000003",
-				Timestamp: goldenTime,
+				Timestamp: fixedTime,
 				Actor:     Actor{Type: "anonymous", ID: "anonymous"},
 				Result:    ResultUnauthenticated,
 				RequestID: "33333333-3333-4333-8333-333333333333",
@@ -143,7 +143,7 @@ func goldenCases() []goldenCase {
 			name: "resource metadata group",
 			event: &Event{
 				EventID:      "01920000-0000-7000-8000-000000000004",
-				Timestamp:    goldenTime,
+				Timestamp:    fixedTime,
 				Actor:        Actor{Type: "service_account", ID: "sa-1"},
 				Action:       "create_secret",
 				Category:     CategoryAuthorization,
@@ -170,10 +170,32 @@ func goldenCases() []goldenCase {
 				`"metadata":{"kind":"opaque"}}}` + "\n",
 		},
 		{
+			name: "empty nested object survives",
+			event: &Event{
+				EventID:   "01920000-0000-7000-8000-000000000007",
+				Timestamp: fixedTime,
+				Actor:     Actor{Type: "user", ID: "u1"},
+				Action:    "create_project",
+				Category:  CategoryManagement,
+				Result:    ResultSuccess,
+				RequestID: "77777777-7777-4777-8777-777777777777",
+				SourceIP:  "10.0.0.7",
+				Service:   "openchoreo-api",
+				// slog.JSONHandler omits an empty group, so a nested {} has to
+				// be rendered as a value to stay in the record.
+				Metadata: map[string]any{"empty": map[string]any{}, "keep": "v"},
+			},
+			want: logLinePrefix + `"event_id":"01920000-0000-7000-8000-000000000007",` +
+				`"timestamp":"2026-09-07T12:30:45Z","actor":{"type":"user","id":"u1"},` +
+				`"action":"create_project","category":"management","result":"success",` +
+				`"request_id":"77777777-7777-4777-8777-777777777777","source_ip":"10.0.0.7",` +
+				`"service":"openchoreo-api","metadata":{"empty":{},"keep":"v"}}` + "\n",
+		},
+		{
 			name: "multi-key maps are ordered",
 			event: &Event{
 				EventID:   "01920000-0000-7000-8000-000000000006",
-				Timestamp: goldenTime,
+				Timestamp: fixedTime,
 				Actor: Actor{
 					Type: "user",
 					ID:   "u1",
@@ -199,15 +221,15 @@ func goldenCases() []goldenCase {
 	}
 }
 
-// TestRenderGolden pins the exact bytes Logger.LogEvent publishes. A diff here
-// is a change to the audit record downstream consumers read as a contract.
-// Compared as bytes, not as an unmarshalled map, because field order is part
-// of what this guards.
-func TestRenderGolden(t *testing.T) {
-	for _, tc := range goldenCases() {
+// TestPublishedRecordShape pins the exact bytes Logger.LogEvent publishes. A
+// diff here is a change to the audit record downstream consumers read as a
+// contract. Compared as bytes, not as an unmarshalled map, because field order
+// is part of what this guards.
+func TestPublishedRecordShape(t *testing.T) {
+	for _, tc := range recordCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			newGoldenLogger(&buf).LogEvent(tc.event)
+			newRecordLogger(&buf).LogEvent(tc.event)
 			if got := buf.String(); got != tc.want {
 				t.Errorf("published record changed:\n got: %s\nwant: %s", got, tc.want)
 			}
@@ -215,11 +237,11 @@ func TestRenderGolden(t *testing.T) {
 	}
 }
 
-// TestRenderGolden_MarshalJSONIsTheSameDefinition asserts json.Marshal(event)
+// TestPublishedRecordShape_MarshalJSONAgrees asserts json.Marshal(event)
 // publishes the same fields in the same order as the log stream, so a sink
 // that marshals an *Event and the log stream stay one wire shape.
-func TestRenderGolden_MarshalJSONIsTheSameDefinition(t *testing.T) {
-	for _, tc := range goldenCases() {
+func TestPublishedRecordShape_MarshalJSONAgrees(t *testing.T) {
+	for _, tc := range recordCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			marshaled, err := json.Marshal(tc.event)
 			if err != nil {
@@ -239,7 +261,7 @@ func TestRenderGolden_MarshalJSONIsTheSameDefinition(t *testing.T) {
 // be marshaled still produces a record rather than vanishing.
 func TestLogEvent_RenderFailureIsReported(t *testing.T) {
 	var buf bytes.Buffer
-	newGoldenLogger(&buf).LogEvent(&Event{
+	newRecordLogger(&buf).LogEvent(&Event{
 		EventID:  "01920000-0000-7000-8000-00000000000f",
 		Action:   "create_project",
 		Result:   ResultSuccess,

--- a/internal/server/middleware/audit/render_golden_test.go
+++ b/internal/server/middleware/audit/render_golden_test.go
@@ -1,0 +1,256 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package audit
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+)
+
+// goldenTime is the fixed Timestamp most golden cases use, so the rendered
+// bytes don't depend on the clock.
+var goldenTime = time.Date(2026, 9, 7, 12, 30, 45, 0, time.UTC)
+
+// logLinePrefix is what slog's JSONHandler puts before the event's own fields.
+const logLinePrefix = `{"level":"INFO","msg":"AUDIT-LOG",`
+
+// newGoldenLogger returns a Logger writing to buf with slog's handler-stamped
+// "time" attr removed — it is the wall clock at emission, so it would defeat
+// any byte comparison. The event's own pinned "timestamp" is the one asserted.
+func newGoldenLogger(buf *bytes.Buffer) *Logger {
+	return NewLogger(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if len(groups) == 0 && a.Key == slog.TimeKey {
+				return slog.Attr{}
+			}
+			return a
+		},
+	})))
+}
+
+type goldenCase struct {
+	name  string
+	event *Event
+	want  string
+}
+
+// goldenCases covers the branches the render takes: every field populated, a
+// nil Resource carrying only a hierarchy, a rejection that resolved no
+// operation, sub-second timestamps, and both metadata groups.
+func goldenCases() []goldenCase {
+	return []goldenCase{
+		{
+			name: "full event",
+			event: &Event{
+				EventID:   "01920000-0000-7000-8000-000000000001",
+				Timestamp: goldenTime,
+				Actor: Actor{
+					Type:         "user",
+					ID:           "user@example.com",
+					Entitlements: map[string][]string{"groups": {"dev", "ops"}},
+				},
+				Action:       "update_release_binding",
+				Category:     CategoryManagement,
+				Origin:       OriginAPI,
+				OperationID:  "UpdateReleaseBinding",
+				ResourceType: "releasebindings",
+				Resource:     &Resource{Namespace: "ns-1", ID: "uid-1", Name: "rb-1"},
+				Hierarchy:    Hierarchy{Namespace: "ns-1", Environment: "ns-1/production", Project: "p1", Component: "c1"},
+				Result:       ResultSuccess,
+				RequestID:    "11111111-1111-4111-8111-111111111111",
+				SourceIP:     "10.0.0.1",
+				Service:      "openchoreo-api",
+				Metadata:     map[string]any{"note": "golden"},
+			},
+			want: logLinePrefix + `"event_id":"01920000-0000-7000-8000-000000000001",` +
+				`"timestamp":"2026-09-07T12:30:45Z",` +
+				`"actor":{"type":"user","id":"user@example.com","entitlements":{"groups":["dev","ops"]}},` +
+				`"action":"update_release_binding","category":"management","result":"success",` +
+				`"request_id":"11111111-1111-4111-8111-111111111111","source_ip":"10.0.0.1",` +
+				`"service":"openchoreo-api","origin":"api","operation_id":"UpdateReleaseBinding",` +
+				`"resource":{"type":"releasebindings","namespace":"ns-1","environment":"ns-1/production",` +
+				`"project":"p1","component":"c1","id":"uid-1","name":"rb-1"},` +
+				`"metadata":{"note":"golden"}}` + "\n",
+		},
+		{
+			name: "nil resource with hierarchy",
+			event: &Event{
+				EventID:      "01920000-0000-7000-8000-000000000002",
+				Timestamp:    goldenTime,
+				Actor:        Actor{Type: "user", ID: "u1"},
+				Action:       "update_project",
+				Category:     CategoryManagement,
+				Origin:       OriginMCP,
+				OperationID:  "UpdateProject",
+				ResourceType: "projects",
+				Resource:     nil,
+				Hierarchy:    Hierarchy{Namespace: "ns-1", Project: "p1"},
+				Result:       ResultDenied,
+				RequestID:    "22222222-2222-4222-8222-222222222222",
+				SourceIP:     "10.0.0.2",
+				Service:      "openchoreo-api",
+			},
+			want: logLinePrefix + `"event_id":"01920000-0000-7000-8000-000000000002",` +
+				`"timestamp":"2026-09-07T12:30:45Z","actor":{"type":"user","id":"u1"},` +
+				`"action":"update_project","category":"management","result":"denied",` +
+				`"request_id":"22222222-2222-4222-8222-222222222222","source_ip":"10.0.0.2",` +
+				`"service":"openchoreo-api","origin":"mcp","operation_id":"UpdateProject",` +
+				`"resource":{"type":"projects","namespace":"ns-1","project":"p1"}}` + "\n",
+		},
+		{
+			name: "unauthenticated with no operation",
+			event: &Event{
+				EventID:   "01920000-0000-7000-8000-000000000003",
+				Timestamp: goldenTime,
+				Actor:     Actor{Type: "anonymous", ID: "anonymous"},
+				Result:    ResultUnauthenticated,
+				RequestID: "33333333-3333-4333-8333-333333333333",
+				SourceIP:  "10.0.0.3",
+				Service:   "openchoreo-api",
+			},
+			// No "resource" at all: nothing resource-shaped was resolved.
+			want: logLinePrefix + `"event_id":"01920000-0000-7000-8000-000000000003",` +
+				`"timestamp":"2026-09-07T12:30:45Z","actor":{"type":"anonymous","id":"anonymous"},` +
+				`"action":"","category":"","result":"unauthenticated",` +
+				`"request_id":"33333333-3333-4333-8333-333333333333","source_ip":"10.0.0.3",` +
+				`"service":"openchoreo-api"}` + "\n",
+		},
+		{
+			name: "sub-second timestamp",
+			event: &Event{
+				EventID:   "01920000-0000-7000-8000-000000000005",
+				Timestamp: time.Date(2026, 9, 7, 12, 30, 45, 123456789, time.UTC),
+				Actor:     Actor{Type: "user", ID: "u1"},
+				Action:    "delete_project",
+				Category:  CategoryManagement,
+				Result:    ResultSuccess,
+				RequestID: "55555555-5555-4555-8555-555555555555",
+				SourceIP:  "10.0.0.5",
+				Service:   "openchoreo-api",
+			},
+			want: logLinePrefix + `"event_id":"01920000-0000-7000-8000-000000000005",` +
+				`"timestamp":"2026-09-07T12:30:45.123456789Z","actor":{"type":"user","id":"u1"},` +
+				`"action":"delete_project","category":"management","result":"success",` +
+				`"request_id":"55555555-5555-4555-8555-555555555555","source_ip":"10.0.0.5",` +
+				`"service":"openchoreo-api"}` + "\n",
+		},
+		{
+			name: "resource metadata group",
+			event: &Event{
+				EventID:      "01920000-0000-7000-8000-000000000004",
+				Timestamp:    goldenTime,
+				Actor:        Actor{Type: "service_account", ID: "sa-1"},
+				Action:       "create_secret",
+				Category:     CategoryAuthorization,
+				Origin:       OriginAPI,
+				OperationID:  "CreateSecret",
+				ResourceType: "secrets",
+				Resource: &Resource{
+					Namespace: "ns-1",
+					Name:      "s1",
+					Metadata:  map[string]any{"kind": "opaque"},
+				},
+				Result:    ResultFailure,
+				RequestID: "44444444-4444-4444-8444-444444444444",
+				SourceIP:  "10.0.0.4",
+				Service:   "observer-api",
+			},
+			want: logLinePrefix + `"event_id":"01920000-0000-7000-8000-000000000004",` +
+				`"timestamp":"2026-09-07T12:30:45Z",` +
+				`"actor":{"type":"service_account","id":"sa-1"},` +
+				`"action":"create_secret","category":"authorization","result":"failure",` +
+				`"request_id":"44444444-4444-4444-8444-444444444444","source_ip":"10.0.0.4",` +
+				`"service":"observer-api","origin":"api","operation_id":"CreateSecret",` +
+				`"resource":{"type":"secrets","namespace":"ns-1","name":"s1",` +
+				`"metadata":{"kind":"opaque"}}}` + "\n",
+		},
+		{
+			name: "multi-key maps are ordered",
+			event: &Event{
+				EventID:   "01920000-0000-7000-8000-000000000006",
+				Timestamp: goldenTime,
+				Actor: Actor{
+					Type: "user",
+					ID:   "u1",
+					// json.Marshal sorts map keys, so a multi-key map has a
+					// stable published order.
+					Entitlements: map[string][]string{"roles": {"admin"}, "groups": {"dev"}},
+				},
+				Action:    "create_project",
+				Category:  CategoryManagement,
+				Result:    ResultSuccess,
+				RequestID: "66666666-6666-4666-8666-666666666666",
+				SourceIP:  "10.0.0.6",
+				Service:   "openchoreo-api",
+				Metadata:  map[string]any{"z": 1, "a": 2},
+			},
+			want: logLinePrefix + `"event_id":"01920000-0000-7000-8000-000000000006",` +
+				`"timestamp":"2026-09-07T12:30:45Z",` +
+				`"actor":{"type":"user","id":"u1","entitlements":{"groups":["dev"],"roles":["admin"]}},` +
+				`"action":"create_project","category":"management","result":"success",` +
+				`"request_id":"66666666-6666-4666-8666-666666666666","source_ip":"10.0.0.6",` +
+				`"service":"openchoreo-api","metadata":{"a":2,"z":1}}` + "\n",
+		},
+	}
+}
+
+// TestRenderGolden pins the exact bytes Logger.LogEvent publishes. A diff here
+// is a change to the audit record downstream consumers read as a contract.
+// Compared as bytes, not as an unmarshalled map, because field order is part
+// of what this guards.
+func TestRenderGolden(t *testing.T) {
+	for _, tc := range goldenCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			newGoldenLogger(&buf).LogEvent(tc.event)
+			if got := buf.String(); got != tc.want {
+				t.Errorf("published record changed:\n got: %s\nwant: %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRenderGolden_MarshalJSONIsTheSameDefinition asserts json.Marshal(event)
+// publishes the same fields in the same order as the log stream, so a sink
+// that marshals an *Event and the log stream stay one wire shape.
+func TestRenderGolden_MarshalJSONIsTheSameDefinition(t *testing.T) {
+	for _, tc := range goldenCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			marshaled, err := json.Marshal(tc.event)
+			if err != nil {
+				t.Fatalf("json.Marshal(event) failed: %v", err)
+			}
+			// The log line is the marshaled object with slog's level/msg
+			// spliced in after the opening brace.
+			want := strings.TrimSuffix(strings.TrimPrefix(tc.want, logLinePrefix), "\n")
+			if got := strings.TrimPrefix(string(marshaled), "{"); got != want {
+				t.Errorf("marshaled form differs from the log stream:\n got: %s\nwant: %s", got, want)
+			}
+		})
+	}
+}
+
+// TestLogEvent_RenderFailureIsReported guards that an event whose body cannot
+// be marshaled still produces a record rather than vanishing.
+func TestLogEvent_RenderFailureIsReported(t *testing.T) {
+	var buf bytes.Buffer
+	newGoldenLogger(&buf).LogEvent(&Event{
+		EventID:  "01920000-0000-7000-8000-00000000000f",
+		Action:   "create_project",
+		Result:   ResultSuccess,
+		Metadata: map[string]any{"bad": func() {}},
+	})
+
+	got := buf.String()
+	if !strings.Contains(got, "AUDIT-LOG-RENDER-FAILED") {
+		t.Errorf("expected a render-failure record, got: %s", got)
+	}
+	if !strings.Contains(got, "01920000-0000-7000-8000-00000000000f") {
+		t.Errorf("render-failure record must identify the event, got: %s", got)
+	}
+}

--- a/internal/server/middleware/audit/types.go
+++ b/internal/server/middleware/audit/types.go
@@ -38,11 +38,14 @@ type Resource struct {
 }
 
 // Hierarchy identifies where in OpenChoreo's resource tree an audited
-// operation was authorized — mirroring authz.ResourceHierarchy's json tags
-// (Namespace/Project/Component/Resource) so a record is directly comparable
-// to a policy scope. Declared locally rather than importing
-// internal/authz/core, keeping this package a leaf so internal/openchoreo-api
-// can depend on it without a cycle.
+// operation was authorized, so a record is directly comparable to a policy
+// scope. Declared locally rather than importing internal/authz/core, keeping
+// this package a leaf so internal/openchoreo-api can depend on it without a
+// cycle.
+//
+// Namespace/Project/Component/Resource mirror authz.ResourceHierarchy's json
+// tags; Environment has no level there and comes from authz.Context.Resource,
+// the ABAC attributes CEL conditions evaluate against.
 //
 // Recorded here rather than merged into Resource: SetResource replaces the
 // whole *Resource rather than merging fields (see SetResource's doc comment),
@@ -52,10 +55,11 @@ type Resource struct {
 // at render time (see Event.MarshalJSON and Logger.LogEvent), that ordering
 // can't erase it.
 type Hierarchy struct {
-	Namespace string `json:"namespace,omitempty"`
-	Project   string `json:"project,omitempty"`
-	Component string `json:"component,omitempty"`
-	Resource  string `json:"resource,omitempty"`
+	Namespace   string `json:"namespace,omitempty"`
+	Environment string `json:"environment,omitempty"`
+	Project     string `json:"project,omitempty"`
+	Component   string `json:"component,omitempty"`
+	Resource    string `json:"resource,omitempty"`
 }
 
 // Result represents the outcome of an action
@@ -101,84 +105,93 @@ type Event struct {
 	Metadata     map[string]any `json:"metadata,omitempty"` // Additional context (optional)
 }
 
-// eventJSON mirrors Event's field order but replaces Resource with
-// resourceJSON — see MarshalJSON.
+// eventJSON is the single definition of the published audit record. Field
+// order here is published order, for json.Marshal and for Logger.LogEvent
+// alike — reordering these fields changes the record consumers receive.
 type eventJSON struct {
 	EventID     string         `json:"event_id"`
 	Timestamp   time.Time      `json:"timestamp"`
 	Actor       Actor          `json:"actor"`
 	Action      string         `json:"action"`
 	Category    Category       `json:"category"`
-	Origin      Origin         `json:"origin,omitempty"`
-	OperationID string         `json:"operation_id,omitempty"`
-	Resource    *resourceJSON  `json:"resource"`
 	Result      Result         `json:"result"`
 	RequestID   string         `json:"request_id"`
 	SourceIP    string         `json:"source_ip"`
 	Service     string         `json:"service"`
+	Origin      Origin         `json:"origin,omitempty"`
+	OperationID string         `json:"operation_id,omitempty"`
+	Resource    *resourceJSON  `json:"resource,omitempty"`
 	Metadata    map[string]any `json:"metadata,omitempty"`
 }
 
 // resourceJSON is Resource with Type merged back in, plus Hierarchy's
-// project/component/resource folded in as flat siblings after namespace —
-// the shape Logger.LogEvent renders, and the shape MarshalJSON reproduces.
+// environment/project/component/resource folded in as flat siblings after
+// namespace. Field order here is published order — see eventJSON.
 type resourceJSON struct {
-	Type      string         `json:"type,omitempty"`
-	Namespace string         `json:"namespace,omitempty"`
-	Project   string         `json:"project,omitempty"`
-	Component string         `json:"component,omitempty"`
-	Resource  string         `json:"resource,omitempty"`
-	ID        string         `json:"id,omitempty"`
-	Name      string         `json:"name,omitempty"`
-	Metadata  map[string]any `json:"metadata,omitempty"`
+	Type        string         `json:"type,omitempty"`
+	Namespace   string         `json:"namespace,omitempty"`
+	Environment string         `json:"environment,omitempty"`
+	Project     string         `json:"project,omitempty"`
+	Component   string         `json:"component,omitempty"`
+	Resource    string         `json:"resource,omitempty"`
+	ID          string         `json:"id,omitempty"`
+	Name        string         `json:"name,omitempty"`
+	Metadata    map[string]any `json:"metadata,omitempty"`
 }
 
-// MarshalJSON nests ResourceType inside "resource", matching what
-// Logger.LogEvent renders (event.ResourceType != "" || event.Resource != nil
-// → a "resource" group with "type" first). Without this, a future sink that
-// calls json.Marshal(event) directly — rather than rendering attrs by hand
-// like Logger does — would publish "resource_type" as a sibling field
-// instead, a different wire shape for the same event.
+// MarshalJSON defines the published audit record. Logger.LogEvent renders its
+// output rather than building attrs of its own, so a sink that marshals an
+// *Event and the log stream cannot disagree.
+//
+// It nests ResourceType inside "resource" (as "type"); without that, a
+// marshaled Event would publish "resource_type" as a sibling field instead.
 func (e Event) MarshalJSON() ([]byte, error) {
-	out := eventJSON{
+	return json.Marshal(eventJSON{
 		EventID:     e.EventID,
 		Timestamp:   e.Timestamp,
 		Actor:       e.Actor,
 		Action:      e.Action,
 		Category:    e.Category,
-		Origin:      e.Origin,
-		OperationID: e.OperationID,
 		Result:      e.Result,
 		RequestID:   e.RequestID,
 		SourceIP:    e.SourceIP,
 		Service:     e.Service,
+		Origin:      e.Origin,
+		OperationID: e.OperationID,
+		Resource:    e.resolvedResource(),
 		Metadata:    e.Metadata,
+	})
+}
+
+// resolvedResource folds ResourceType and Hierarchy into the published
+// "resource" group, returning nil when the event has nothing resource-shaped
+// to report (a rejection that resolved no operation).
+//
+// Resource.Namespace wins over the hierarchy's when set. buildEvent already
+// applies that precedence via withHierarchyNamespaceFallback, so this repeats
+// it only for the hand-built Events that reach exported MarshalJSON without
+// passing through the emitter.
+func (e Event) resolvedResource() *resourceJSON {
+	if e.ResourceType == "" && e.Resource == nil && e.Hierarchy == (Hierarchy{}) {
+		return nil
 	}
-	if e.ResourceType != "" || e.Resource != nil || e.Hierarchy != (Hierarchy{}) {
-		// Namespace defaults to the hierarchy's and is overridden by a
-		// non-empty Resource.Namespace — the same precedence buildEvent's
-		// withHierarchyNamespaceFallback applies, repeated here so this
-		// render path is correct for any Event, not only one that came
-		// through the emitter. Without it, an Event carrying a hierarchy but
-		// no Resource at all would publish resource.project while silently
-		// dropping resource.namespace.
-		out.Resource = &resourceJSON{
-			Type:      e.ResourceType,
-			Namespace: e.Hierarchy.Namespace,
-			Project:   e.Hierarchy.Project,
-			Component: e.Hierarchy.Component,
-			Resource:  e.Hierarchy.Resource,
-		}
-		if e.Resource != nil {
-			if e.Resource.Namespace != "" {
-				out.Resource.Namespace = e.Resource.Namespace
-			}
-			out.Resource.ID = e.Resource.ID
-			out.Resource.Name = e.Resource.Name
-			out.Resource.Metadata = e.Resource.Metadata
-		}
+	out := &resourceJSON{
+		Type:        e.ResourceType,
+		Namespace:   e.Hierarchy.Namespace,
+		Environment: e.Hierarchy.Environment,
+		Project:     e.Hierarchy.Project,
+		Component:   e.Hierarchy.Component,
+		Resource:    e.Hierarchy.Resource,
 	}
-	return json.Marshal(out)
+	if e.Resource != nil {
+		if e.Resource.Namespace != "" {
+			out.Namespace = e.Resource.Namespace
+		}
+		out.ID = e.Resource.ID
+		out.Name = e.Resource.Name
+		out.Metadata = e.Resource.Metadata
+	}
+	return out
 }
 
 // AuditData is a mutable container for audit information set by handlers.


### PR DESCRIPTION
## Purpose

Audit records showed the namespace, project and component an operation touched, but not the environment. You could see that someone updated a release binding, but not which environment it targeted — and on a refusal, not which environment they were refused for.

Environment is one of the four tenancy fields audit is meant to record, and the only one nothing populated. `authz.ResourceHierarchy` has no environment level, and the audit hook copies that struct, so there was nowhere for the value to come from.

This goes in before the event schema gets versioned, so v1 doesn't ship with a tenancy field missing.

## Approach

`AuthzChecker.Check` already records the resource hierarchy for audit. It now also reads the environment from `req.Context.Resource.Environment`, which the check already carries. That covers REST and MCP at once, and since it runs before the PDP evaluates, denials carry the environment too.

The value is stored as-is, in the `{namespace}/{name}` form authorization uses, so the record matches what the policy matched. `Hierarchy` gains an `Environment` field, and it publishes as `resource.environment`.

Observer's `CheckAuthorization` is wired the same way. It records nothing yet, because all its environment-scoped operations are reads, but it won't need changing when an audited one becomes environment-scoped.

Adding a field to the event meant editing two render paths, so they were merged first: `Logger.LogEvent` now renders `Event.MarshalJSON`'s output instead of building slog attrs by hand.

## Behavioural changes

- `resource.environment` appears on the release-binding families, `/exec/` and wirelogs, as `default/production` rather than `production`.
- Wirelogs used to record the environment in `resource.name`. It now uses `resource.environment`, and `resource.name` is absent for that route.
- `json.Marshal` of an `Event` changes field order and no longer emits `"resource":null`. Nothing consumes that yet — `Logger` is the only sink.
- Multi-key `actor.entitlements` and `metadata` maps now have a stable key order.

The log line is otherwise byte-identical, including sub-second timestamps. The golden test was captured against the old implementation before the render changed, so that's verified rather than assumed.

## Related Issues

Part of #3343. Builds on #4571 and #4643.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks

`go build ./...` is clean, `golangci-lint` reports 0 issues, `make code.gen` shows no drift, and tests pass across `./internal/server/...`, `./internal/openchoreo-api/...`, `./internal/observer/...` and `./pkg/mcp/...`.

Coverage follows the authorization check, which leaves three gaps on purpose. Observability alert notification channels have a required `spec.environment` but don't pass it to authz, so they record none — giving them one changes what policies can express, so it belongs in its own change. The Environment CRUD operations don't set the field, since `resource.name` is already the environment name there. And `/exec/` needed no change, because it already passes its resolved environment to the check.

Wirelogs sets the environment in the handler as well as in its check request, because its ownership-mismatch 403 returns before the check runs. Both read it from the same check request.
