### PR TITLE
fix: enforce per-expression and per-reconcile CEL cost limits (Backport to release-v1.0)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 
 	// +kubebuilder:scaffold:imports
 	"k8s.io/apimachinery/pkg/runtime"
@@ -96,6 +97,7 @@ func setupControlPlaneControllers(
 	k8sClientMgr *kubernetesClient.KubeMultiClientManager,
 	clusterGatewayURL string,
 	gwTLS gatewayClient.TLSConfig,
+	celCostLimit uint64,
 ) error {
 	// Create gateway client for plane lifecycle notifications
 	var gwClient *gatewayClient.Client
@@ -224,9 +226,12 @@ func setupControlPlaneControllers(
 	}
 
 	if err := (&releasebinding.Reconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Pipeline: componentpipeline.NewPipeline(),
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+		Pipeline: componentpipeline.NewPipeline(
+			componentpipeline.WithCostLimit(celCostLimit),
+		),
+		CELCostLimit: celCostLimit,
 	}).SetupWithManager(mgr); err != nil {
 		return err
 	}
@@ -259,7 +264,10 @@ func setupControlPlaneControllers(
 		K8sClientMgr: k8sClientMgr,
 		Scheme:       mgr.GetScheme(),
 		GatewayURL:   clusterGatewayURL,
-		Pipeline:     workflowpipeline.NewPipeline(),
+		Pipeline: workflowpipeline.NewPipeline(
+			workflowpipeline.WithCostLimit(celCostLimit),
+		),
+		CELCostLimit: celCostLimit,
 	}).SetupWithManager(mgr); err != nil {
 		return err
 	}
@@ -337,6 +345,7 @@ func main() {
 	var clusterGatewayClientCert string
 	var clusterGatewayClientKey string
 	var deploymentPlane string
+	var celCostLimit uint64
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -364,8 +373,22 @@ func main() {
 	opts := zap.Options{
 		Development: true,
 	}
+	// The environment default is resolved before the flag is declared, so a malformed value
+	// is reported after flag.Parse rather than silently replaced by the built-in default:
+	// an operator who set a cost limit and got the default instead would be running with a
+	// bound they did not choose.
+	celCostLimitDefault, celCostLimitEnvErr := getEnvUint("CEL_COST_LIMIT", 0)
+	flag.Uint64Var(&celCostLimit, "cel-cost-limit", celCostLimitDefault,
+		"Maximum accumulated cost for a single CEL template expression. 0 uses the built-in safe default. "+
+			"Defaults to the CEL_COST_LIMIT environment variable when set.")
+
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	if celCostLimitEnvErr != nil {
+		setupLog.Error(celCostLimitEnvErr, "invalid CEL_COST_LIMIT")
+		os.Exit(1)
+	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
@@ -485,7 +508,7 @@ func main() {
 	switch deploymentPlane {
 	// Control plane controllers
 	case deploymentPlaneControlPlane:
-		err = setupControlPlaneControllers(mgr, k8sClientMgr, clusterGatewayURL, gwTLS)
+		err = setupControlPlaneControllers(mgr, k8sClientMgr, clusterGatewayURL, gwTLS, celCostLimit)
 		if err != nil {
 			setupLog.Error(err, "unable to setup control plane controllers")
 			os.Exit(1)
@@ -594,6 +617,22 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+}
+
+// getEnvUint retrieves an unsigned integer environment variable, returning a default if
+// unset. An unparseable value is an error rather than a silent fallback: an operator who
+// set a cost limit and got the default instead would be running with a bound they did not
+// choose.
+func getEnvUint(key string, defaultValue uint64) (uint64, error) {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue, nil
+	}
+	parsed, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s=%q: %w", key, value, err)
+	}
+	return parsed, nil
 }
 
 // getEnv retrieves an environment variable value, returning a default if not set

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"testing"
+)
+
+func TestGetEnvUint(t *testing.T) {
+	t.Run("unset uses default", func(t *testing.T) {
+		t.Setenv("TEST_CEL_COST_LIMIT", "")
+		got, err := getEnvUint("TEST_CEL_COST_LIMIT", 42)
+		if err != nil || got != 42 {
+			t.Fatalf("getEnvUint() = %d, %v; want 42, nil", got, err)
+		}
+	})
+
+	t.Run("valid value", func(t *testing.T) {
+		t.Setenv("TEST_CEL_COST_LIMIT", "2000000")
+		got, err := getEnvUint("TEST_CEL_COST_LIMIT", 0)
+		if err != nil || got != 2_000_000 {
+			t.Fatalf("getEnvUint() = %d, %v; want 2000000, nil", got, err)
+		}
+	})
+
+	// Silently falling back to the default here would leave an operator running with a cost
+	// limit they did not choose and no signal that their setting was discarded.
+	t.Run("malformed value is rejected", func(t *testing.T) {
+		t.Setenv("TEST_CEL_COST_LIMIT", "two million")
+		if _, err := getEnvUint("TEST_CEL_COST_LIMIT", 0); err == nil {
+			t.Fatal("getEnvUint() accepted a malformed value")
+		}
+	})
+}

--- a/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
+++ b/install/helm/openchoreo-control-plane/templates/controller-manager/deployment.yaml
@@ -56,6 +56,11 @@ spec:
         - --cluster-gateway-client-cert={{ .Values.controllerManager.clusterGateway.tls.clientCertPath }}
         - --cluster-gateway-client-key={{ .Values.controllerManager.clusterGateway.tls.clientKeyPath }}
         {{- end }}
+        {{- if .Values.controllerManager.manager.celCostLimit }}
+        {{- /* int64: Helm decodes values.yaml numbers as float64, so a bare render emits
+               2e+06, which the controller's uint64 flag parser rejects at startup. */}}
+        - --cel-cost-limit={{ int64 .Values.controllerManager.manager.celCostLimit }}
+        {{- end }}
         env:
         - name: ENABLE_WEBHOOKS
           value: {{ quote .Values.controllerManager.manager.env.enableWebhooks }}

--- a/install/helm/openchoreo-control-plane/values.schema.json
+++ b/install/helm/openchoreo-control-plane/values.schema.json
@@ -1755,6 +1755,13 @@
               "title": "args",
               "type": "array"
             },
+            "celCostLimit": {
+              "default": 2000000,
+              "description": "Maximum accumulated cost for a single CEL template expression. This is the controller's own built-in default, stated here so the bound is visible rather than implied; 0 also selects it. Raising it weakens the guard proportionally - the per-reconcile cost budget is derived from it - so treat it as an escape hatch for a legitimate template, not a tuning knob.",
+              "minimum": 0,
+              "title": "celCostLimit",
+              "type": "integer"
+            },
             "env": {
               "additionalProperties": false,
               "description": "Environment variables for the controller-manager",

--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -675,6 +675,13 @@ controllerManager:
       # default: "true"
       # @schema
       enableWebhooks: "true"
+    # @schema
+    # type: integer
+    # minimum: 0
+    # description: Maximum accumulated cost for a single CEL template expression. This is the controller's own built-in default, stated here so the bound is visible rather than implied; 0 also selects it. Raising it weakens the guard proportionally - the per-reconcile cost budget is derived from it - so treat it as an escape hatch for a legitimate template, not a tuning knob.
+    # default: 2000000
+    # @schema
+    celCostLimit: 2000000
 
   # @schema
   # type: object

--- a/internal/controller/conditions.go
+++ b/internal/controller/conditions.go
@@ -13,6 +13,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openchoreo/openchoreo/internal/template"
 )
 
 // This file contains the types and functions to manage the conditions in the Kubernetes objects.
@@ -39,14 +41,24 @@ type ConditionedObject interface {
 	SetConditions(conditions []metav1.Condition)
 }
 
+// maxConditionMessageLen bounds what any condition message may carry. Render errors reach
+// a condition verbatim and quote tenant-authored input, so each layer that builds one is
+// expected to bound the fragments it names; this is the backstop for the layer that
+// forgets. The API server caps a condition message at 32768 bytes and rejects invalid
+// UTF-8, and a rejected status write replaces the paced render requeue with a hot backoff -
+// so the bound sits well below the cap, leaving room for the rest of the status object
+// while staying far larger than any message worth reading.
+const maxConditionMessageLen = 8192
+
 // NewCondition creates a new condition with the last transition time set to the current time.
+// The message is bounded (see maxConditionMessageLen); a message that fits is untouched.
 func NewCondition(conditionType ConditionType, status metav1.ConditionStatus, reason ConditionReason,
 	message string, observedGeneration int64) metav1.Condition {
 	return metav1.Condition{
 		Type:               string(conditionType),
 		Status:             status,
 		Reason:             string(reason),
-		Message:            message,
+		Message:            template.TruncateTo(message, maxConditionMessageLen),
 		LastTransitionTime: metav1.Now(),
 		ObservedGeneration: observedGeneration,
 	}

--- a/internal/controller/conditions_test.go
+++ b/internal/controller/conditions_test.go
@@ -4,9 +4,14 @@
 package controller
 
 import (
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/template"
 )
 
 func TestNeedConditionUpdate(t *testing.T) {
@@ -256,5 +261,73 @@ func TestNeedConditionUpdate(t *testing.T) {
 				t.Errorf("NeedConditionUpdate() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// Every rendering reconciler copies a render error into a condition message, and each
+// layer that builds one is expected to bound the fragments it quotes. This is the backstop
+// for the layer that forgets: the API server caps a condition message at 32768 bytes and
+// rejects invalid UTF-8, and a rejected status write replaces the paced requeue with a hot
+// backoff. Bounding here means no single missed wrap can cause that.
+func TestNewConditionBoundsTheMessage(t *testing.T) {
+	huge := strings.Repeat("x", 100_000)
+
+	cond := NewCondition("Ready", metav1.ConditionFalse, "RenderingFailed", huge, 1)
+
+	if len(cond.Message) > maxConditionMessageLen {
+		t.Fatalf("message is %d bytes, want at most %d", len(cond.Message), maxConditionMessageLen)
+	}
+	if !strings.HasSuffix(cond.Message, template.TruncationMarker) {
+		t.Fatalf("a cut message should be marked truncated, got: %.40s...", cond.Message)
+	}
+	if !strings.HasPrefix(cond.Message, "xxxx") {
+		t.Fatalf("the surviving prefix should still be the original message, got: %.40s", cond.Message)
+	}
+}
+
+// A message that fits is the common case and must be untouched, byte for byte: the paced
+// requeue depends on the same inputs producing the same condition on every reconcile.
+func TestNewConditionKeepsMessagesThatFit(t *testing.T) {
+	msg := "failed to render resources: no such field: spec.nope"
+
+	cond := NewCondition("Ready", metav1.ConditionFalse, "RenderingFailed", msg, 1)
+
+	if cond.Message != msg {
+		t.Fatalf("message was altered: got %q, want %q", cond.Message, msg)
+	}
+}
+
+// Cutting mid-rune produces invalid UTF-8, which the API server rejects just as firmly as
+// an oversized message - so the bound has to land on a rune boundary regardless of where
+// the multi-byte characters fall.
+func TestNewConditionBoundKeepsValidUTF8(t *testing.T) {
+	for pad := 0; pad < 4; pad++ {
+		msg := strings.Repeat("a", pad) + strings.Repeat("日", maxConditionMessageLen)
+
+		cond := NewCondition("Ready", metav1.ConditionFalse, "RenderingFailed", msg, 1)
+
+		if !utf8.ValidString(cond.Message) {
+			t.Fatalf("pad %d produced invalid UTF-8", pad)
+		}
+		if len(cond.Message) > maxConditionMessageLen {
+			t.Fatalf("pad %d: message is %d bytes, want at most %d",
+				pad, len(cond.Message), maxConditionMessageLen)
+		}
+	}
+}
+
+// The bound applies through the Mark* helpers too, which is how reconcilers actually
+// record a render failure.
+func TestMarkFalseConditionBoundsTheMessage(t *testing.T) {
+	rb := &openchoreov1alpha1.ReleaseBinding{}
+
+	MarkFalseCondition(rb, "ReleaseSynced", "RenderingFailed", strings.Repeat("y", 100_000))
+
+	conditions := rb.GetConditions()
+	if len(conditions) != 1 {
+		t.Fatalf("expected one condition, got %d", len(conditions))
+	}
+	if len(conditions[0].Message) > maxConditionMessageLen {
+		t.Fatalf("message is %d bytes, want at most %d", len(conditions[0].Message), maxConditionMessageLen)
 	}
 }

--- a/internal/controller/controller_common.go
+++ b/internal/controller/controller_common.go
@@ -42,14 +42,10 @@ func UpdateCondition(
 ) error {
 	logger := log.FromContext(ctx)
 
-	condition := metav1.Condition{
-		Type:               conditionType,
-		Status:             status,
-		Reason:             reason,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-		ObservedGeneration: resource.GetGeneration(),
-	}
+	// Built through NewCondition so the message bound applies here too - this helper is
+	// the other way a condition reaches a status write.
+	condition := NewCondition(ConditionType(conditionType), status, ConditionReason(reason),
+		message, resource.GetGeneration())
 
 	changed := meta.SetStatusCondition(conditions, condition)
 	if changed {

--- a/internal/controller/releasebinding/controller.go
+++ b/internal/controller/releasebinding/controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openchoreo/openchoreo/internal/networkpolicy"
 	componentpipeline "github.com/openchoreo/openchoreo/internal/pipeline/component"
 	pipelinecontext "github.com/openchoreo/openchoreo/internal/pipeline/component/context"
+	"github.com/openchoreo/openchoreo/internal/template"
 )
 
 const (
@@ -48,6 +49,10 @@ type Reconciler struct {
 	// Pipeline is the component rendering pipeline, shared across all reconciliations.
 	// This enables CEL environment caching across different component types and reconciliations.
 	Pipeline *componentpipeline.Pipeline
+
+	// CELCostLimit bounds the accumulated cost of a single CEL expression.
+	// Zero selects the template engine's built-in default.
+	CELCostLimit uint64
 }
 
 // +kubebuilder:rbac:groups=openchoreo.dev,resources=releasebindings,verbs=get;list;watch;create;update;patch;delete
@@ -455,7 +460,11 @@ func (r *Reconciler) reconcileRelease(ctx context.Context, releaseBinding *openc
 	}
 
 	// Render resources using the shared pipeline instance
-	renderOutput, err := r.Pipeline.Render(renderInput)
+	// Seed one cost budget for this reconcile's rendering. The budget is an inert context
+	// value carrying no deadline, so nothing else in the reconcile is affected by it.
+	ctx = template.WithReconcileBudget(ctx, r.CELCostLimit)
+
+	renderOutput, err := r.Pipeline.Render(ctx, renderInput)
 	if err != nil {
 		msg := fmt.Sprintf("Failed to render resources: %v", err)
 		controller.MarkFalseCondition(releaseBinding, ConditionReleaseSynced,
@@ -1304,6 +1313,12 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Setup field index for connection targets (reads from status.connectionTargets)
 	if err := r.setupConnectionTargetsIndex(ctx, mgr); err != nil {
 		return fmt.Errorf("failed to setup connection targets index: %w", err)
+	}
+
+	// The pipeline carries the CEL cost limit, so a reconciler wired up here rather than
+	// injected from cmd/main.go must still get one.
+	if r.Pipeline == nil {
+		r.Pipeline = componentpipeline.NewPipeline(componentpipeline.WithCostLimit(r.CELCostLimit))
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/releasebinding/controller_costbreach_test.go
+++ b/internal/controller/releasebinding/controller_costbreach_test.go
@@ -1,0 +1,168 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package releasebinding
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+)
+
+// hostileExpr costs far more than any per-expression limit: 2,000 outer
+// iterations each building a 2,000-element list. The engine's cost guard stops
+// it, which is exactly the terminal failure these tests drive.
+const hostileExpr = "${size(lists.range(2000).map(x, lists.range(2000).map(y, x + y)))}"
+
+// costLimitSentinel is the sentinel text of ErrCostLimitExceeded. Asserting on it
+// rather than a loose "cost" substring keeps the specs pinned to the per-expression
+// limit they actually trip.
+const costLimitSentinel = "cel expression cost limit exceeded"
+
+// overForEachCap is one item past the renderer's maxForEachItems fan-out cap. The cap is
+// unexported, so the number is restated here; the spec below fails loudly if the two drift
+// apart, because a forEach within the cap renders successfully.
+const overForEachCap = 101
+
+// runawayTemplate is minimalTemplate with the hostile expression hidden in a
+// label, so rendering the resource trips the cost guard.
+var runawayTemplate = &runtime.RawExtension{
+	Raw: []byte(`{` +
+		`"apiVersion":"apps/v1",` +
+		`"kind":"Deployment",` +
+		`"metadata":{"name":"test-deployment","labels":{"runaway":"` + hostileExpr + `"}},` +
+		`"spec":{` +
+		`"selector":{"matchLabels":{"app":"test"}},` +
+		`"template":{` +
+		`"metadata":{"labels":{"app":"test"}},` +
+		`"spec":{"containers":[{"name":"app","image":"nginx:latest"}]}` +
+		`}}}`,
+	),
+}
+
+// A CEL cost breach must be visible on the object, not only in the logs: these specs
+// pin that a breach surfaces as ReleaseSynced=False carrying the guard's message, and
+// that re-pinning the binding at a cheap snapshot clears it.
+var _ = Describe("ReleaseBinding controller — CEL cost breach", func() {
+	const (
+		rbName      = "rb-cost-breach"
+		projectName = "cost-proj"
+		compName    = "cost-comp"
+		envName     = "cost-env"
+		dpName      = "cost-dp"
+	)
+
+	// runawayCRFixture is crFixture with the runaway template swapped in.
+	runawayCRFixture := func(name string) *openchoreov1alpha1.ComponentRelease {
+		cr := crFixture(name, projectName, compName)
+		cr.Spec.ComponentType.Spec.Resources = []openchoreov1alpha1.ResourceTemplate{
+			{ID: "deployment", Template: runawayTemplate},
+		}
+		return cr
+	}
+
+	// createSupportingResources creates everything the reconcile chain resolves
+	// before it renders: Environment, DataPlane, Component, Project.
+	createSupportingResources := func() {
+		Expect(k8sClient.Create(ctx, dpFixture(dpName))).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, dpFixture(dpName)) })
+		Expect(k8sClient.Create(ctx, envFixture(envName, dpName))).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, envFixture(envName, dpName)) })
+		Expect(k8sClient.Create(ctx, componentFixture(compName, projectName))).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, componentFixture(compName, projectName)) })
+		Expect(k8sClient.Create(ctx, projectFixture(projectName))).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, projectFixture(projectName)) })
+	}
+
+	AfterEach(func() { forceDelete(rbName) })
+
+	// reconcileExpectingRenderError reconciles and asserts the render failure reached the
+	// caller as an error, which is what puts the binding on the reconciler's usual backoff.
+	reconcileExpectingRenderError := func(r *Reconciler) {
+		GinkgoHelper()
+		_, err := r.Reconcile(ctx, reconcileRequest(rbName))
+		Expect(err).To(HaveOccurred())
+	}
+
+	It("marks ReleaseSynced=False with the cost message when rendering breaches the cost guard", func() {
+		createSupportingResources()
+		cr := runawayCRFixture("cost-breach-release")
+		Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, cr) })
+		Expect(k8sClient.Create(ctx,
+			rbFixture(rbName, projectName, compName, envName, cr.Name, true),
+		)).To(Succeed())
+
+		reconcileExpectingRenderError(testReconcilerWithPipeline())
+
+		cond := conditionFor(fetchRB(rbName), string(ConditionReleaseSynced))
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(cond.Reason).To(Equal(string(ReasonRenderingFailed)))
+		Expect(cond.Message).To(ContainSubstring(costLimitSentinel))
+	})
+
+	// The forEach fan-out cap trips on the item count alone, before any sub-render runs.
+	It("reports the fan-out cap when a forEach exceeds it", func() {
+		createSupportingResources()
+
+		cr := crFixture("foreach-breach-release", projectName, compName)
+		// Append rather than replace: the ComponentRelease webhook requires the primary
+		// resource whose id matches workloadType, and the fan-out is an extra resource
+		// alongside it - which is also the realistic shape.
+		cr.Spec.ComponentType.Spec.Resources = append(cr.Spec.ComponentType.Spec.Resources,
+			openchoreov1alpha1.ResourceTemplate{
+				ID:      "fanout",
+				ForEach: fmt.Sprintf("${lists.range(%d)}", overForEachCap),
+				Var:     "item",
+				Template: &runtime.RawExtension{Raw: []byte(
+					`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"cm-${item}"}}`)},
+			})
+		Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, cr) })
+		Expect(k8sClient.Create(ctx,
+			rbFixture(rbName, projectName, compName, envName, cr.Name, true),
+		)).To(Succeed())
+
+		reconcileExpectingRenderError(testReconcilerWithPipeline())
+
+		cond := conditionFor(fetchRB(rbName), string(ConditionReleaseSynced))
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(cond.Reason).To(Equal(string(ReasonRenderingFailed)))
+		Expect(cond.Message).To(ContainSubstring("exceeding the limit of"))
+	})
+
+	// Recovery: a ComponentRelease is immutable, so the fix is to re-pin the
+	// binding at a cheap snapshot, which re-enqueues it through the normal watch.
+	It("recovers on the next reconcile once the binding is re-pinned to a cheap snapshot", func() {
+		createSupportingResources()
+		bad := runawayCRFixture("cost-recovery-bad")
+		Expect(k8sClient.Create(ctx, bad)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, bad) })
+		good := crFixture("cost-recovery-good", projectName, compName)
+		Expect(k8sClient.Create(ctx, good)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, good) })
+		Expect(k8sClient.Create(ctx,
+			rbFixture(rbName, projectName, compName, envName, bad.Name, true),
+		)).To(Succeed())
+
+		r := testReconcilerWithPipeline()
+		reconcileExpectingRenderError(r)
+
+		rb := fetchRB(rbName)
+		rb.Spec.ReleaseName = good.Name
+		Expect(k8sClient.Update(ctx, rb)).To(Succeed())
+
+		mustReconcile(r, reconcileRequest(rbName))
+
+		cond := conditionFor(fetchRB(rbName), string(ConditionReleaseSynced))
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Reason).NotTo(Equal(string(ReasonRenderingFailed)))
+	})
+})

--- a/internal/controller/releasebinding/controller_setup_test.go
+++ b/internal/controller/releasebinding/controller_setup_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package releasebinding
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	crconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	componentpipeline "github.com/openchoreo/openchoreo/internal/pipeline/component"
+)
+
+// The rendering pipeline carries the CEL cost limit, so where the pipeline comes from is part
+// of the guard. cmd/main.go injects one; SetupWithManager is the other way a Reconciler is
+// wired up, and it has to build one from the configured limit rather than leave the field nil.
+// The workflowrun reconciler already does this, which is what makes the omission here a gap
+// rather than a design choice.
+var _ = Describe("ReleaseBinding controller — SetupWithManager", func() {
+	newManager := func() ctrl.Manager {
+		GinkgoHelper()
+		mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+			Scheme:  k8sClient.Scheme(),
+			Metrics: metricsserver.Options{BindAddress: "0"},
+			// Each spec builds its own manager, and controller-runtime rejects a second
+			// controller registered under a name it has already seen.
+			Controller: crconfig.Controller{SkipNameValidation: ptr.To(true)},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		return mgr
+	}
+
+	It("builds a pipeline when none was injected", func() {
+		r := &Reconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), CELCostLimit: 12_345}
+		Expect(r.SetupWithManager(newManager())).To(Succeed())
+		Expect(r.Pipeline).NotTo(BeNil())
+	})
+
+	It("leaves an injected pipeline alone", func() {
+		injected := componentpipeline.NewPipeline(componentpipeline.WithCostLimit(999))
+		r := &Reconciler{Client: k8sClient, Scheme: k8sClient.Scheme(), Pipeline: injected, CELCostLimit: 12_345}
+		Expect(r.SetupWithManager(newManager())).To(Succeed())
+		Expect(r.Pipeline).To(BeIdenticalTo(injected))
+	})
+})

--- a/internal/controller/workflowrun/controller.go
+++ b/internal/controller/workflowrun/controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openchoreo/openchoreo/internal/controller"
 	argoproj "github.com/openchoreo/openchoreo/internal/dataplane/kubernetes/types/argoproj.io/workflow/v1alpha1"
 	workflowpipeline "github.com/openchoreo/openchoreo/internal/pipeline/workflow"
+	"github.com/openchoreo/openchoreo/internal/template"
 )
 
 // Reconciler reconciles a WorkflowRun object
@@ -39,6 +40,10 @@ type Reconciler struct {
 	// This enables CEL environment caching across different workflow runs and reconciliations.
 	Pipeline   *workflowpipeline.Pipeline
 	GatewayURL string
+
+	// CELCostLimit bounds the accumulated cost of a single CEL expression.
+	// Zero selects the template engine's built-in default.
+	CELCostLimit uint64
 }
 
 // +kubebuilder:rbac:groups=openchoreo.dev,resources=workflowruns,verbs=get;list;watch;create;update;patch;delete
@@ -208,6 +213,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 		return ctrl.Result{Requeue: true}, nil
 	}
 
+	// Seed one cost budget for this reconcile, before externalRef name evaluation, so
+	// those renders and the pipeline render below share a single pool. The budget is an
+	// inert context value carrying no deadline, so it rides ctx and the cluster reads
+	// interleaved with rendering are unaffected.
+	ctx = template.WithReconcileBudget(ctx, r.CELCostLimit)
+
 	renderInput := &workflowpipeline.RenderInput{
 		WorkflowRun: workflowRun,
 		Workflow:    workflow,
@@ -237,16 +248,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ct
 			logger.Error(err, "failed to resolve externalRefs",
 				"workflow", workflow.Name,
 				"workflowRun", workflowRun.Name)
-			return ctrl.Result{Requeue: true}, nil
+			return renderFailureResult(workflowRun, err), nil
 		}
 
 		renderInput.Context.ExternalRefs = externalRefs
 	}
 
-	output, err := r.Pipeline.Render(renderInput)
+	output, err := r.Pipeline.Render(ctx, renderInput)
 	if err != nil {
 		logger.Error(err, "failed to render workflow")
-		return ctrl.Result{Requeue: true}, nil
+		return renderFailureResult(workflowRun, err), nil
 	}
 
 	runResNamespace, err := extractRunResourceNamespace(output.Resource)
@@ -467,6 +478,14 @@ func (r *Reconciler) getWorkflowPlaneClient(workflowPlaneResult *controller.Work
 	return wpClient, nil
 }
 
+// renderFailureResult records a render failure - from either entry point, externalRef
+// name evaluation or the pipeline itself - on the object, so an operator can see why
+// nothing was submitted, and requeues the way this reconciler always has.
+func renderFailureResult(workflowRun *openchoreodevv1alpha1.WorkflowRun, err error) ctrl.Result {
+	setWorkflowRenderingFailedCondition(workflowRun, err)
+	return ctrl.Result{Requeue: true}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.K8sClientMgr == nil {
@@ -474,7 +493,9 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	if r.Pipeline == nil {
-		r.Pipeline = workflowpipeline.NewPipeline()
+		r.Pipeline = workflowpipeline.NewPipeline(
+			workflowpipeline.WithCostLimit(r.CELCostLimit),
+		)
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/workflowrun/controller_conditions.go
+++ b/internal/controller/workflowrun/controller_conditions.go
@@ -19,7 +19,9 @@ const (
 )
 
 const (
-	ReasonWorkflowPending               controller.ConditionReason = "WorkflowPending"
+	ReasonWorkflowPending controller.ConditionReason = "WorkflowPending"
+
+	ReasonWorkflowRenderingFailed       controller.ConditionReason = "WorkflowRenderingFailed"
 	ReasonWorkflowRunning               controller.ConditionReason = "WorkflowRunning"
 	ReasonWorkflowSucceeded             controller.ConditionReason = "WorkflowSucceeded"
 	ReasonWorkflowFailed                controller.ConditionReason = "WorkflowFailed"
@@ -170,4 +172,23 @@ func setComponentValidationFailedCondition(workflowRun *openchoreov1alpha1.Workf
 		Message:            message,
 		ObservedGeneration: workflowRun.Generation,
 	})
+}
+
+// setWorkflowRenderingFailedCondition records a failure to render the workflow - either
+// while resolving externalRefs or in the pipeline itself. WorkflowCompleted stays False
+// (nothing was submitted, so the run has not finished) with the render error as the
+// message; WorkflowFailed is deliberately untouched because that condition is
+// True-on-failure and reserved for a run that actually executed.
+//
+// Unlike its neighbors here, this one builds the condition through controller.NewCondition:
+// a render error quotes tenant-authored template text, and that builder is where the message
+// bound lives. The other setters carry API errors of their own making and keep the literal.
+func setWorkflowRenderingFailedCondition(workflowRun *openchoreov1alpha1.WorkflowRun, err error) {
+	meta.SetStatusCondition(&workflowRun.Status.Conditions, controller.NewCondition(
+		ConditionWorkflowCompleted,
+		metav1.ConditionFalse,
+		ReasonWorkflowRenderingFailed,
+		"Failed to render workflow: "+err.Error(),
+		workflowRun.Generation,
+	))
 }

--- a/internal/controller/workflowrun/controller_costbreach_test.go
+++ b/internal/controller/workflowrun/controller_costbreach_test.go
@@ -1,0 +1,222 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package workflowrun
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	openchoreodevv1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	kubernetesClient "github.com/openchoreo/openchoreo/internal/clients/kubernetes"
+	workflowpipeline "github.com/openchoreo/openchoreo/internal/pipeline/workflow"
+)
+
+// hostileExpr costs far more than any per-expression limit: 2,000 outer
+// iterations each building a 2,000-element list. The engine's cost guard stops
+// it, which is exactly the terminal failure these tests drive.
+const hostileExpr = "${size(lists.range(2000).map(x, lists.range(2000).map(y, x + y)))}"
+
+// costLimitSentinel is the sentinel text of ErrCostLimitExceeded. Asserting on it
+// rather than a loose "cost" substring keeps the specs pinned to the per-expression
+// limit they actually trip.
+const costLimitSentinel = "cel expression cost limit exceeded"
+
+// Before this change a render failure was logged and requeued with no condition, so a
+// WorkflowRun whose template trips the CEL cost guard told an operator nothing. These
+// specs pin the replacement: WorkflowCompleted=False/WorkflowRenderingFailed carrying
+// the cost message, from either render entry point.
+var _ = Describe("WorkflowRun controller — CEL cost breach", func() {
+	ctx := context.Background()
+
+	const (
+		workflowName = "cost-breach-wf"
+		runName      = "cost-breach-wfr"
+		planeName    = "default"
+		planeID      = "cost-breach-plane"
+	)
+	nn := types.NamespacedName{Name: runName, Namespace: "default"}
+
+	// runTemplate builds a minimal Argo Workflow body. The runaway variant
+	// hides the hostile expression in a label so rendering trips the guard.
+	runTemplate := func(runaway bool) *runtime.RawExtension {
+		metadata := map[string]any{
+			"name":      "${metadata.workflowRunName}",
+			"namespace": "${metadata.namespace}",
+		}
+		if runaway {
+			metadata["labels"] = map[string]any{"runaway": hostileExpr}
+		}
+		raw, err := json.Marshal(map[string]any{
+			"apiVersion": "argoproj.io/v1alpha1",
+			"kind":       "Workflow",
+			"metadata":   metadata,
+			"spec": map[string]any{
+				"entrypoint":         "main",
+				"serviceAccountName": "wf-sa",
+				"templates": []any{map[string]any{
+					"name":      "main",
+					"container": map[string]any{"image": "alpine", "command": []any{"echo", "hi"}},
+				}},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		return &runtime.RawExtension{Raw: raw}
+	}
+
+	// newReconciler wires the envtest control-plane client to a workflow-plane client that
+	// is never written to: every spec here fails before submission, except the recovery one.
+	//
+	// The workflow-plane client is a fake seeded directly into the client manager's cache
+	// under the key GetK8sClientFromClusterWorkflowPlane computes, so the reconciler gets it
+	// back without opening a cluster-agent connection. The key format is restated here; if it
+	// ever changes, the reconcile returns at the client lookup and the condition assertions
+	// below fail rather than passing vacuously.
+	newReconciler := func() *Reconciler {
+		GinkgoHelper()
+		mgr := kubernetesClient.NewManager()
+		_, err := mgr.GetOrAddClient(
+			fmt.Sprintf("v2/clusterworkflowplane/%s/%s", planeID, planeName),
+			func() (client.Client, error) {
+				return fake.NewClientBuilder().WithScheme(k8sClient.Scheme()).Build(), nil
+			})
+		Expect(err).NotTo(HaveOccurred())
+		return &Reconciler{
+			Client:       k8sClient,
+			Scheme:       k8sClient.Scheme(),
+			K8sClientMgr: mgr,
+			GatewayURL:   "https://gateway.invalid",
+			Pipeline:     workflowpipeline.NewPipeline(),
+		}
+	}
+
+	// createWorkflow creates the ClusterWorkflow the run points at.
+	createWorkflow := func(externalRefs []openchoreodevv1alpha1.ExternalRef, runaway bool) {
+		cwf := &openchoreodevv1alpha1.ClusterWorkflow{
+			ObjectMeta: metav1.ObjectMeta{Name: workflowName},
+			Spec: openchoreodevv1alpha1.ClusterWorkflowSpec{
+				RunTemplate:  runTemplate(runaway),
+				ExternalRefs: externalRefs,
+			},
+		}
+		Expect(k8sClient.Create(ctx, cwf)).To(Succeed())
+		DeferCleanup(func() { forceDeleteClusterWorkflow(ctx, workflowName) })
+	}
+
+	// createRun creates the WorkflowRun with the cleanup finalizer and the
+	// pending condition already recorded, so the next reconcile goes straight
+	// to workflow resolution and rendering.
+	createRun := func() {
+		wfr := &openchoreodevv1alpha1.WorkflowRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       runName,
+				Namespace:  "default",
+				Finalizers: []string{WorkflowRunCleanupFinalizer},
+			},
+			Spec: openchoreodevv1alpha1.WorkflowRunSpec{
+				Workflow: openchoreodevv1alpha1.WorkflowRunConfig{Name: workflowName},
+			},
+		}
+		Expect(k8sClient.Create(ctx, wfr)).To(Succeed())
+		DeferCleanup(func() { forceDelete(ctx, nn) })
+
+		_, err := newReconciler().Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	// The workflow plane is resolved before rendering; with no ref on the
+	// workflow the reconciler looks for the "default" ClusterWorkflowPlane.
+	BeforeEach(func() {
+		cwp := &openchoreodevv1alpha1.ClusterWorkflowPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: planeName},
+			Spec: openchoreodevv1alpha1.ClusterWorkflowPlaneSpec{
+				PlaneID: planeID,
+				ClusterAgent: openchoreodevv1alpha1.ClusterAgentConfig{
+					ClientCA: openchoreodevv1alpha1.ValueFrom{Value: "test-ca"},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, cwp)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, cwp) })
+	})
+
+	fetchRun := func() *openchoreodevv1alpha1.WorkflowRun {
+		GinkgoHelper()
+		wfr := &openchoreodevv1alpha1.WorkflowRun{}
+		Expect(k8sClient.Get(ctx, nn, wfr)).To(Succeed())
+		return wfr
+	}
+
+	expectRenderingFailed := func(wfr *openchoreodevv1alpha1.WorkflowRun) {
+		GinkgoHelper()
+		cond := meta.FindStatusCondition(wfr.Status.Conditions, string(ConditionWorkflowCompleted))
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(cond.Reason).To(Equal(string(ReasonWorkflowRenderingFailed)))
+		Expect(cond.Message).To(ContainSubstring(costLimitSentinel))
+	}
+
+	It("records WorkflowRenderingFailed when the run template breaches the cost guard", func() {
+		createWorkflow(nil, true)
+		createRun()
+
+		_, err := newReconciler().Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+
+		expectRenderingFailed(fetchRun())
+	})
+
+	It("records WorkflowRenderingFailed when an externalRef name breaches the cost guard", func() {
+		createWorkflow([]openchoreodevv1alpha1.ExternalRef{{
+			ID:         "git-creds",
+			APIVersion: "openchoreo.dev/v1alpha1",
+			Kind:       "SecretReference",
+			Name:       hostileExpr,
+		}}, false)
+		createRun()
+
+		_, err := newReconciler().Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+
+		expectRenderingFailed(fetchRun())
+	})
+
+	// Recovery for an UNWATCHED input: the reconciler watches WorkflowRun, not the
+	// (Cluster)Workflow whose spec it renders. Editing the workflow fires no event, so
+	// the requeue the reconciler already does is what picks the fix up.
+	It("recovers once the unwatched ClusterWorkflow spec is fixed", func() {
+		createWorkflow(nil, true)
+		createRun()
+
+		_, err := newReconciler().Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+		expectRenderingFailed(fetchRun())
+
+		By("Fixing the ClusterWorkflow spec without touching the WorkflowRun")
+		cwf := &openchoreodevv1alpha1.ClusterWorkflow{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: workflowName}, cwf)).To(Succeed())
+		cwf.Spec.RunTemplate = runTemplate(false)
+		Expect(k8sClient.Update(ctx, cwf)).To(Succeed())
+
+		By("Running the reconcile the requeue would trigger")
+		_, err = newReconciler().Reconcile(ctx, reconcile.Request{NamespacedName: nn})
+		Expect(err).NotTo(HaveOccurred())
+
+		// The run is submitted, which is what recovery means here. The
+		// WorkflowCompleted reason still reads WorkflowRenderingFailed until
+		// the next status sync overwrites it — the same way the existing
+		// resolution-failure reasons linger after their cause clears.
+		Expect(fetchRun().Status.RunReference).NotTo(BeNil())
+	})
+})

--- a/internal/controller/workflowrun/externalref.go
+++ b/internal/controller/workflowrun/externalref.go
@@ -18,6 +18,9 @@ import (
 // For each ref whose name evaluates to a non-empty string, it fetches the
 // referenced CR from the cluster and returns its spec keyed by the ref's id.
 // Refs whose name evaluates to empty are silently skipped.
+//
+// ctx carries the reconcile's cost budget, so every name evaluation draws from the same
+// pool as the pipeline render that follows.
 func (r *Reconciler) resolveExternalRefs(
 	ctx context.Context,
 	externalRefs []openchoreodevv1alpha1.ExternalRef,
@@ -28,12 +31,12 @@ func (r *Reconciler) resolveExternalRefs(
 		return nil, nil
 	}
 
-	engine := template.NewEngine()
+	engine := template.NewEngineWithOptions(template.WithCostLimit(r.CELCostLimit))
 	resolved := make(map[string]any, len(externalRefs))
 
 	for _, ref := range externalRefs {
-		// Evaluate the name field which may contain CEL expressions
-		name, err := evaluateExternalRefName(engine, ref.Name, celContext)
+		// Evaluate the name field, which may contain CEL expressions.
+		name, err := evaluateExternalRefName(ctx, engine, ref.Name, celContext)
 		if err != nil {
 			return nil, fmt.Errorf("failed to evaluate name for externalRef %q: %w", ref.ID, err)
 		}
@@ -59,8 +62,13 @@ func (r *Reconciler) resolveExternalRefs(
 // evaluateExternalRefName renders an externalRef name string through the template engine.
 // The name may contain CEL expressions like ${parameters.repository.secretRef}.
 // Returns the evaluated string, or empty string if the expression evaluates to empty.
-func evaluateExternalRefName(engine *template.Engine, name string, celContext map[string]any) (string, error) {
-	result, err := engine.Render(name, celContext)
+func evaluateExternalRefName(
+	ctx context.Context,
+	engine *template.Engine,
+	name string,
+	celContext map[string]any,
+) (string, error) {
+	result, err := engine.Render(ctx, name, celContext)
 	if err != nil {
 		return "", err
 	}

--- a/internal/observer/notifications/sender.go
+++ b/internal/observer/notifications/sender.go
@@ -21,7 +21,7 @@ func SendAlertNotification(ctx context.Context, config *NotificationChannelConfi
 	switch config.Type {
 	case "webhook":
 		// Prepare webhook payload
-		payload, err := prepareWebhookPayload(config.Webhook.PayloadTemplate, alertDetails, logger)
+		payload, err := prepareWebhookPayload(ctx, config.Webhook.PayloadTemplate, alertDetails, logger)
 		if err != nil {
 			return fmt.Errorf("failed to prepare webhook payload: %w", err)
 		}
@@ -43,7 +43,7 @@ func SendAlertNotification(ctx context.Context, config *NotificationChannelConfi
 
 	case "email":
 		// Prepare email content
-		subject, body, err := prepareEmailContent(config.Email, alertDetails, logger)
+		subject, body, err := prepareEmailContent(ctx, config.Email, alertDetails, logger)
 		if err != nil {
 			return fmt.Errorf("failed to prepare email content: %w", err)
 		}
@@ -67,7 +67,12 @@ func SendAlertNotification(ctx context.Context, config *NotificationChannelConfi
 }
 
 // prepareWebhookPayload prepares the webhook payload by rendering the template if provided
-func prepareWebhookPayload(templateStr string, alertDetails *types.AlertDetails, logger *slog.Logger) (map[string]interface{}, error) {
+func prepareWebhookPayload(
+	ctx context.Context,
+	templateStr string,
+	alertDetails *types.AlertDetails,
+	logger *slog.Logger,
+) (map[string]interface{}, error) {
 	// Compute CEL inputs once for this notification flow
 	celInputs := alertDetails.ToMap()
 
@@ -86,7 +91,7 @@ func prepareWebhookPayload(templateStr string, alertDetails *types.AlertDetails,
 	}
 
 	// Render the JSON template using CEL expressions with precomputed inputs
-	renderedTemplateMap, err := RenderJSONTemplate(payloadTemplate, celInputs, logger)
+	renderedTemplateMap, err := RenderJSONTemplate(ctx, payloadTemplate, celInputs, logger)
 	if err != nil {
 		logger.Warn("Failed to render webhook payload template, using unrendered template",
 			"error", err,
@@ -101,7 +106,12 @@ func prepareWebhookPayload(templateStr string, alertDetails *types.AlertDetails,
 }
 
 // prepareEmailContent prepares the email subject and body by rendering templates if provided
-func prepareEmailContent(emailConfig EmailConfig, alertDetails *types.AlertDetails, logger *slog.Logger) (string, string, error) {
+func prepareEmailContent(
+	ctx context.Context,
+	emailConfig EmailConfig,
+	alertDetails *types.AlertDetails,
+	logger *slog.Logger,
+) (string, string, error) {
 	// Compute CEL inputs once for this notification flow (reused for both subject and body templates)
 	celInputs := alertDetails.ToMap()
 
@@ -114,13 +124,13 @@ func prepareEmailContent(emailConfig EmailConfig, alertDetails *types.AlertDetai
 	// Build subject using template if available, otherwise use default
 	subject := fmt.Sprintf("OpenChoreo alert triggered: %s", alertDetails.AlertName)
 	if emailConfig.SubjectTemplate != "" {
-		subject = RenderPlaintextTemplate(emailConfig.SubjectTemplate, celInputs, logger)
+		subject = RenderPlaintextTemplate(ctx, emailConfig.SubjectTemplate, celInputs, logger)
 	}
 
 	// Build body using template if available, otherwise use default
 	emailBody := fmt.Sprintf("An alert was triggered at %s UTC.\n\nPayload:\n%s\n", time.Now().UTC().Format(time.RFC3339), string(payload))
 	if emailConfig.BodyTemplate != "" {
-		emailBody = RenderPlaintextTemplate(emailConfig.BodyTemplate, celInputs, logger)
+		emailBody = RenderPlaintextTemplate(ctx, emailConfig.BodyTemplate, celInputs, logger)
 	}
 
 	return subject, emailBody, nil
@@ -130,12 +140,17 @@ func prepareEmailContent(emailConfig EmailConfig, alertDetails *types.AlertDetai
 // It expects the template to be a parsed JSON map and returns the rendered map.
 // If rendering fails, an error is returned.
 // celInputs should be the precomputed map from AlertDetails.ToMap() for better performance.
-func RenderJSONTemplate(templateData map[string]interface{}, celInputs map[string]interface{}, logger *slog.Logger) (map[string]interface{}, error) {
+func RenderJSONTemplate(
+	ctx context.Context,
+	templateData map[string]interface{},
+	celInputs map[string]interface{},
+	logger *slog.Logger,
+) (map[string]interface{}, error) {
 	logger.Debug("Rendering JSON template", "alertData", celInputs, "template", templateData)
 
 	// Render template and data using the shared template engine
 	engine := getTemplateEngine()
-	renderedTemplate, err := engine.Render(templateData, celInputs)
+	renderedTemplate, err := engine.Render(ctx, templateData, celInputs)
 	if err != nil {
 		logger.Warn("Failed to render JSON template",
 			"error", err,
@@ -154,13 +169,20 @@ func RenderJSONTemplate(templateData map[string]interface{}, celInputs map[strin
 // RenderPlaintextTemplate renders a plaintext template with CEL expressions for email subjects and bodies.
 // It treats the template as a plain string and evaluates CEL expressions within it.
 // If any CEL expression fails to resolve, a warning is logged and the original expression is preserved in the output.
+// Rendering is best-effort on purpose: delivering the alert with an unrendered subject or body
+// is preferable to dropping the notification entirely.
 // celInputs should be the precomputed map from AlertDetails.ToMap() for better performance.
-func RenderPlaintextTemplate(templateStr string, celInputs map[string]interface{}, logger *slog.Logger) string {
+func RenderPlaintextTemplate(
+	ctx context.Context,
+	templateStr string,
+	celInputs map[string]interface{},
+	logger *slog.Logger,
+) string {
 	logger.Debug("Rendering plaintext template", "alertData", celInputs)
 
 	// Render the plaintext template as a string with CEL expressions using the shared template engine
 	engine := getTemplateEngine()
-	rendered, err := engine.Render(templateStr, celInputs)
+	rendered, err := engine.Render(ctx, templateStr, celInputs)
 	if err != nil {
 		logger.Warn("Failed to render plaintext template, returning original template",
 			"error", err,

--- a/internal/pipeline/component/benchmark_test.go
+++ b/internal/pipeline/component/benchmark_test.go
@@ -199,7 +199,7 @@ func BenchmarkPipeline_RenderWithRealSample(b *testing.B) {
 	pipeline := NewPipeline()
 
 	// Verify it works before benchmarking
-	output, err := pipeline.Render(input)
+	output, err := pipeline.Render(b.Context(), input)
 	if err != nil {
 		b.Fatalf("Pipeline render failed: %v", err)
 	}
@@ -218,7 +218,7 @@ func BenchmarkPipeline_RenderWithRealSample(b *testing.B) {
 
 	// Run benchmark
 	for b.Loop() {
-		_, err := pipeline.Render(input)
+		_, err := pipeline.Render(b.Context(), input)
 		if err != nil {
 			b.Fatalf("Pipeline render failed: %v", err)
 		}
@@ -242,7 +242,7 @@ func BenchmarkPipeline_RenderWithRealSample_NewPipelinePerRender(b *testing.B) {
 
 	// Verify it works before benchmarking
 	pipeline := NewPipeline()
-	output, err := pipeline.Render(input)
+	output, err := pipeline.Render(b.Context(), input)
 	if err != nil {
 		b.Fatalf("Pipeline render failed: %v", err)
 	}
@@ -257,7 +257,7 @@ func BenchmarkPipeline_RenderWithRealSample_NewPipelinePerRender(b *testing.B) {
 	// This simulates the old controller behavior (cold cache every time)
 	for b.Loop() {
 		pipeline := NewPipeline() // ← NEW INSTANCE per iteration
-		_, err := pipeline.Render(input)
+		_, err := pipeline.Render(b.Context(), input)
 		if err != nil {
 			b.Fatalf("Pipeline render failed: %v", err)
 		}
@@ -439,7 +439,7 @@ spec:
 	pipeline := NewPipeline()
 
 	// Verify it works
-	_, err := pipeline.Render(input)
+	_, err := pipeline.Render(b.Context(), input)
 	if err != nil {
 		b.Fatalf("Pipeline render failed: %v", err)
 	}
@@ -447,7 +447,7 @@ spec:
 	b.ResetTimer()
 
 	for b.Loop() {
-		_, err := pipeline.Render(input)
+		_, err := pipeline.Render(b.Context(), input)
 		if err != nil {
 			b.Fatalf("Pipeline render failed: %v", err)
 		}
@@ -639,7 +639,7 @@ spec:
 	b.ResetTimer()
 
 	for b.Loop() {
-		_, err := pipeline.Render(input)
+		_, err := pipeline.Render(b.Context(), input)
 		if err != nil {
 			b.Fatalf("Pipeline render failed: %v", err)
 		}

--- a/internal/pipeline/component/context/cel_extensions_test.go
+++ b/internal/pipeline/component/context/cel_extensions_test.go
@@ -188,7 +188,7 @@ func TestConfigurationsToConfigFileListMacro(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := engine.Render("${"+tt.expr+"}", tt.inputs)
+			result, err := engine.Render(t.Context(), "${"+tt.expr+"}", tt.inputs)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -211,7 +211,7 @@ func TestToConfigFileListMacroOnlyExpandsForConfigurations(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 
 	// This should work - configurations is the expected receiver
-	_, err := engine.Render(`${configurations.toConfigFileList()}`, map[string]any{
+	_, err := engine.Render(t.Context(), `${configurations.toConfigFileList()}`, map[string]any{
 		"metadata": map[string]any{
 			"componentName":   "app",
 			"environmentName": "dev",
@@ -223,7 +223,7 @@ func TestToConfigFileListMacroOnlyExpandsForConfigurations(t *testing.T) {
 	}
 
 	// This should fail - "other" is not a valid receiver for the macro
-	_, err = engine.Render(`${other.toConfigFileList()}`, map[string]any{
+	_, err = engine.Render(t.Context(), `${other.toConfigFileList()}`, map[string]any{
 		"metadata": map[string]any{
 			"componentName":   "app",
 			"environmentName": "dev",
@@ -235,7 +235,7 @@ func TestToConfigFileListMacroOnlyExpandsForConfigurations(t *testing.T) {
 	}
 
 	// Field access should not be affected by the macro
-	result, err := engine.Render(`${parameters.configFiles.map(f, f.name)}`, map[string]any{
+	result, err := engine.Render(t.Context(), `${parameters.configFiles.map(f, f.name)}`, map[string]any{
 		"parameters": map[string]any{
 			"configFiles": []any{
 				map[string]any{"name": "a.yaml"},
@@ -274,7 +274,7 @@ func TestToConfigFileListCanBeUsedWithCELOperations(t *testing.T) {
 	}
 
 	t.Run("size() operation", func(t *testing.T) {
-		result, err := engine.Render(`${size(configurations.toConfigFileList())}`, inputs)
+		result, err := engine.Render(t.Context(), `${size(configurations.toConfigFileList())}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -284,7 +284,7 @@ func TestToConfigFileListCanBeUsedWithCELOperations(t *testing.T) {
 	})
 
 	t.Run("map() operation", func(t *testing.T) {
-		result, err := engine.Render(`${configurations.toConfigFileList().map(f, f.name)}`, inputs)
+		result, err := engine.Render(t.Context(), `${configurations.toConfigFileList().map(f, f.name)}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -297,7 +297,7 @@ func TestToConfigFileListCanBeUsedWithCELOperations(t *testing.T) {
 	})
 
 	t.Run("list concatenation with inline items", func(t *testing.T) {
-		result, err := engine.Render(`${configurations.toConfigFileList() + [{"name": "inline.yaml", "mountPath": "/inline.yaml"}]}`, inputs)
+		result, err := engine.Render(t.Context(), `${configurations.toConfigFileList() + [{"name": "inline.yaml", "mountPath": "/inline.yaml"}]}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -505,7 +505,7 @@ func TestConfigurationsToSecretFileListMacro(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := engine.Render("${"+tt.expr+"}", tt.inputs)
+			result, err := engine.Render(t.Context(), "${"+tt.expr+"}", tt.inputs)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -528,7 +528,7 @@ func TestToSecretFileListMacroOnlyExpandsForConfigurations(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 
 	// This should work - configurations is the expected receiver
-	_, err := engine.Render(`${configurations.toSecretFileList()}`, map[string]any{
+	_, err := engine.Render(t.Context(), `${configurations.toSecretFileList()}`, map[string]any{
 		"metadata": map[string]any{
 			"componentName":   "app",
 			"environmentName": "dev",
@@ -540,7 +540,7 @@ func TestToSecretFileListMacroOnlyExpandsForConfigurations(t *testing.T) {
 	}
 
 	// This should fail - "other" is not a valid receiver for the macro
-	_, err = engine.Render(`${other.toSecretFileList()}`, map[string]any{
+	_, err = engine.Render(t.Context(), `${other.toSecretFileList()}`, map[string]any{
 		"metadata": map[string]any{
 			"componentName":   "app",
 			"environmentName": "dev",
@@ -580,7 +580,7 @@ func TestToSecretFileListCanBeUsedWithCELOperations(t *testing.T) {
 	}
 
 	t.Run("size() operation", func(t *testing.T) {
-		result, err := engine.Render(`${size(configurations.toSecretFileList())}`, inputs)
+		result, err := engine.Render(t.Context(), `${size(configurations.toSecretFileList())}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -590,7 +590,7 @@ func TestToSecretFileListCanBeUsedWithCELOperations(t *testing.T) {
 	})
 
 	t.Run("map() operation", func(t *testing.T) {
-		result, err := engine.Render(`${configurations.toSecretFileList().map(f, f.name)}`, inputs)
+		result, err := engine.Render(t.Context(), `${configurations.toSecretFileList().map(f, f.name)}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -603,7 +603,7 @@ func TestToSecretFileListCanBeUsedWithCELOperations(t *testing.T) {
 	})
 
 	t.Run("list concatenation with inline items", func(t *testing.T) {
-		result, err := engine.Render(`${configurations.toSecretFileList() + [{"name": "inline.secret", "mountPath": "/inline.secret"}]}`, inputs)
+		result, err := engine.Render(t.Context(), `${configurations.toSecretFileList() + [{"name": "inline.secret", "mountPath": "/inline.secret"}]}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -773,7 +773,7 @@ func TestContainerConfigEnvFromMacro(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := engine.Render("${"+tt.expr+"}", tt.inputs)
+			result, err := engine.Render(t.Context(), "${"+tt.expr+"}", tt.inputs)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -794,7 +794,7 @@ func TestEnvFromMacroValidation(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 
 	// This should work - accessing container config from configurations
-	_, err := engine.Render(`${configurations.toContainerEnvFrom()}`, map[string]any{
+	_, err := engine.Render(t.Context(), `${configurations.toContainerEnvFrom()}`, map[string]any{
 		"metadata": map[string]any{
 			"componentName":   "app",
 			"environmentName": "dev",
@@ -809,7 +809,7 @@ func TestEnvFromMacroValidation(t *testing.T) {
 	}
 
 	// toContainerEnvFrom only works on configurations, not arbitrary variables
-	_, err = engine.Render(`${someVar.toContainerEnvFrom()}`, map[string]any{
+	_, err = engine.Render(t.Context(), `${someVar.toContainerEnvFrom()}`, map[string]any{
 		"metadata": map[string]any{
 			"componentName":   "app",
 			"environmentName": "dev",
@@ -847,7 +847,7 @@ func TestEnvFromCanBeUsedWithCELOperations(t *testing.T) {
 	}
 
 	t.Run("size() operation", func(t *testing.T) {
-		result, err := engine.Render(`${size(configurations.toContainerEnvFrom())}`, inputs)
+		result, err := engine.Render(t.Context(), `${size(configurations.toContainerEnvFrom())}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -857,7 +857,7 @@ func TestEnvFromCanBeUsedWithCELOperations(t *testing.T) {
 	})
 
 	t.Run("map() operation to extract names", func(t *testing.T) {
-		result, err := engine.Render(`${configurations.toContainerEnvFrom().map(e, has(e.configMapRef) ? e.configMapRef.name : e.secretRef.name)}`, inputs)
+		result, err := engine.Render(t.Context(), `${configurations.toContainerEnvFrom().map(e, has(e.configMapRef) ? e.configMapRef.name : e.secretRef.name)}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -868,7 +868,7 @@ func TestEnvFromCanBeUsedWithCELOperations(t *testing.T) {
 	})
 
 	t.Run("concatenation with inline items", func(t *testing.T) {
-		result, err := engine.Render(`${configurations.toContainerEnvFrom() + [{"configMapRef": {"name": "extra-config"}}]}`, inputs)
+		result, err := engine.Render(t.Context(), `${configurations.toContainerEnvFrom() + [{"configMapRef": {"name": "extra-config"}}]}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -994,7 +994,7 @@ func TestConnectionsContextData(t *testing.T) {
 			},
 		}
 
-		result, err := engine.Render(`${dependencies.toContainerEnvs()}`, inputs)
+		result, err := engine.Render(t.Context(), `${dependencies.toContainerEnvs()}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1064,7 +1064,7 @@ func TestContainerConfigVolumeMountsMacro(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := engine.Render("${"+tt.expr+"}", tt.inputs)
+			result, err := engine.Render(t.Context(), "${"+tt.expr+"}", tt.inputs)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -1146,7 +1146,7 @@ func TestConfigurationsToVolumesMacro(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := engine.Render("${"+tt.expr+"}", tt.inputs)
+			result, err := engine.Render(t.Context(), "${"+tt.expr+"}", tt.inputs)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -1250,7 +1250,7 @@ func TestConfigurationsToConfigEnvsByContainerMacro(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := engine.Render("${"+tt.expr+"}", tt.inputs)
+			result, err := engine.Render(t.Context(), "${"+tt.expr+"}", tt.inputs)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -1374,7 +1374,7 @@ func TestConfigurationsToSecretEnvsByContainerMacro(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := engine.Render("${"+tt.expr+"}", tt.inputs)
+			result, err := engine.Render(t.Context(), "${"+tt.expr+"}", tt.inputs)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -1722,7 +1722,7 @@ func TestWorkloadEndpointsToServicePortsMacro(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := engine.Render("${"+tt.expr+"}", tt.inputs)
+			result, err := engine.Render(t.Context(), "${"+tt.expr+"}", tt.inputs)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -1794,7 +1794,7 @@ func TestWorkloadEndpointsToServicePortsMacroErrors(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := engine.Render("${"+tt.expr+"}", tt.inputs)
+			_, err := engine.Render(t.Context(), "${"+tt.expr+"}", tt.inputs)
 			if err == nil {
 				t.Fatal("expected error but got none")
 			}
@@ -1809,7 +1809,7 @@ func TestToServicePortsMacroOnlyExpandsForWorkloadEndpoints(t *testing.T) {
 	engine := template.NewEngineWithOptions(template.WithCELExtensions(CELExtensions()...))
 
 	// This should work - workload.endpoints is the expected receiver
-	_, err := engine.Render(`${workload.toServicePorts()}`, map[string]any{
+	_, err := engine.Render(t.Context(), `${workload.toServicePorts()}`, map[string]any{
 		"workload": map[string]any{
 			"endpoints": map[string]any{},
 		},
@@ -1819,7 +1819,7 @@ func TestToServicePortsMacroOnlyExpandsForWorkloadEndpoints(t *testing.T) {
 	}
 
 	// This should fail - "other" is not a valid receiver for the macro
-	_, err = engine.Render(`${other.toServicePorts()}`, map[string]any{
+	_, err = engine.Render(t.Context(), `${other.toServicePorts()}`, map[string]any{
 		"other": map[string]any{
 			"endpoints": map[string]any{},
 		},
@@ -1829,7 +1829,7 @@ func TestToServicePortsMacroOnlyExpandsForWorkloadEndpoints(t *testing.T) {
 	}
 
 	// This should fail - direct call on non-endpoints field
-	_, err = engine.Render(`${workload.containers.toServicePorts()}`, map[string]any{
+	_, err = engine.Render(t.Context(), `${workload.containers.toServicePorts()}`, map[string]any{
 		"workload": map[string]any{
 			"containers": map[string]any{},
 		},
@@ -1858,7 +1858,7 @@ func TestToServicePortsCanBeUsedWithCELOperations(t *testing.T) {
 	}
 
 	t.Run("size() operation", func(t *testing.T) {
-		result, err := engine.Render(`${size(workload.toServicePorts())}`, inputs)
+		result, err := engine.Render(t.Context(), `${size(workload.toServicePorts())}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1868,7 +1868,7 @@ func TestToServicePortsCanBeUsedWithCELOperations(t *testing.T) {
 	})
 
 	t.Run("map() operation to extract port names", func(t *testing.T) {
-		result, err := engine.Render(`${workload.toServicePorts().map(p, p.name)}`, inputs)
+		result, err := engine.Render(t.Context(), `${workload.toServicePorts().map(p, p.name)}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1881,7 +1881,7 @@ func TestToServicePortsCanBeUsedWithCELOperations(t *testing.T) {
 	})
 
 	t.Run("map() operation to extract port numbers", func(t *testing.T) {
-		result, err := engine.Render(`${workload.toServicePorts().map(p, p.port)}`, inputs)
+		result, err := engine.Render(t.Context(), `${workload.toServicePorts().map(p, p.port)}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1908,7 +1908,7 @@ func TestToServicePortsCanBeUsedWithCELOperations(t *testing.T) {
 				},
 			},
 		}
-		result, err := engine.Render(`${workload.toServicePorts().filter(p, p.protocol == "UDP")}`, udpInputs)
+		result, err := engine.Render(t.Context(), `${workload.toServicePorts().filter(p, p.protocol == "UDP")}`, udpInputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1921,7 +1921,7 @@ func TestToServicePortsCanBeUsedWithCELOperations(t *testing.T) {
 	})
 
 	t.Run("list concatenation with inline items", func(t *testing.T) {
-		result, err := engine.Render(`${workload.toServicePorts() + [{"name": "admin", "port": 9999, "targetPort": 9999, "protocol": "TCP"}]}`, inputs)
+		result, err := engine.Render(t.Context(), `${workload.toServicePorts() + [{"name": "admin", "port": 9999, "targetPort": 9999, "protocol": "TCP"}]}`, inputs)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/internal/pipeline/component/context/embedded_trait.go
+++ b/internal/pipeline/component/context/embedded_trait.go
@@ -4,6 +4,7 @@
 package context
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -69,17 +70,18 @@ type EmbeddedTraitContextInput struct {
 //
 // Returns the resolved parameters and environmentConfigs as maps.
 func ResolveEmbeddedTraitBindings(
+	ctx context.Context,
 	engine *template.Engine,
 	embeddedTrait v1alpha1.ComponentTypeTrait,
 	componentContextMap map[string]any,
 ) (resolvedParams map[string]any, resolvedEnvConfigs map[string]any, err error) {
-	resolvedParams, err = resolveBindings(engine, embeddedTrait.Parameters, componentContextMap)
+	resolvedParams, err = resolveBindings(ctx, engine, embeddedTrait.Parameters, componentContextMap)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to resolve embedded trait %s/%s parameters: %w",
 			embeddedTrait.Name, embeddedTrait.InstanceName, err)
 	}
 
-	resolvedEnvConfigs, err = resolveBindings(engine, embeddedTrait.EnvironmentConfigs, componentContextMap)
+	resolvedEnvConfigs, err = resolveBindings(ctx, engine, embeddedTrait.EnvironmentConfigs, componentContextMap)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to resolve embedded trait %s/%s environmentConfigs: %w",
 			embeddedTrait.Name, embeddedTrait.InstanceName, err)
@@ -92,6 +94,7 @@ func ResolveEmbeddedTraitBindings(
 // evaluates all CEL expressions against the given context, and returns a map with all values
 // resolved to concrete types.
 func resolveBindings(
+	ctx context.Context,
 	engine *template.Engine,
 	raw *runtime.RawExtension,
 	contextMap map[string]any,
@@ -105,7 +108,7 @@ func resolveBindings(
 		return nil, fmt.Errorf("failed to unmarshal bindings: %w", err)
 	}
 
-	resolved, err := engine.Render(data, contextMap)
+	resolved, err := engine.Render(ctx, data, contextMap)
 	if err != nil {
 		return nil, fmt.Errorf("failed to evaluate CEL bindings: %w", err)
 	}

--- a/internal/pipeline/component/context/embedded_trait_test.go
+++ b/internal/pipeline/component/context/embedded_trait_test.go
@@ -147,6 +147,7 @@ func TestResolveEmbeddedTraitBindings(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resolvedParams, resolvedEnvironmentConfigs, err := ResolveEmbeddedTraitBindings(
+				t.Context(),
 				engine,
 				tt.embeddedTrait,
 				tt.componentContext,
@@ -484,7 +485,7 @@ func TestResolveEmbeddedTraitBindings_EnvConfigsError(t *testing.T) {
 		"parameters": map[string]any{},
 	}
 
-	_, _, err := ResolveEmbeddedTraitBindings(engine, embeddedTrait, componentContext)
+	_, _, err := ResolveEmbeddedTraitBindings(t.Context(), engine, embeddedTrait, componentContext)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "environmentConfigs")
 }
@@ -495,12 +496,12 @@ func TestResolveBindings_NilRaw(t *testing.T) {
 	)
 
 	// nil RawExtension
-	result, err := resolveBindings(engine, nil, map[string]any{})
+	result, err := resolveBindings(t.Context(), engine, nil, map[string]any{})
 	require.NoError(t, err)
 	assert.Nil(t, result)
 
 	// Non-nil RawExtension but nil Raw bytes
-	result, err = resolveBindings(engine, &runtime.RawExtension{Raw: nil}, map[string]any{})
+	result, err = resolveBindings(t.Context(), engine, &runtime.RawExtension{Raw: nil}, map[string]any{})
 	require.NoError(t, err)
 	assert.Nil(t, result)
 }
@@ -514,7 +515,7 @@ func TestResolveBindings_UnmarshalError(t *testing.T) {
 		Raw: []byte(`{invalid json`),
 	}
 
-	result, err := resolveBindings(engine, raw, map[string]any{})
+	result, err := resolveBindings(t.Context(), engine, raw, map[string]any{})
 	require.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "unmarshal")

--- a/internal/pipeline/component/pipeline.go
+++ b/internal/pipeline/component/pipeline.go
@@ -12,6 +12,7 @@
 package component
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -19,7 +20,7 @@ import (
 
 	"github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/labels"
-	"github.com/openchoreo/openchoreo/internal/pipeline/component/context"
+	pipelinecontext "github.com/openchoreo/openchoreo/internal/pipeline/component/context"
 	"github.com/openchoreo/openchoreo/internal/pipeline/component/renderer"
 	"github.com/openchoreo/openchoreo/internal/pipeline/component/trait"
 	"github.com/openchoreo/openchoreo/internal/template"
@@ -43,6 +44,15 @@ const (
 // Option is a function that configures a Pipeline.
 type Option func(*Pipeline)
 
+// WithCostLimit sets the maximum accumulated cost for a single CEL expression
+// evaluated by this pipeline's template engine. Zero selects the engine's
+// built-in safe default; it never means unlimited.
+func WithCostLimit(limit uint64) Option {
+	return func(p *Pipeline) {
+		p.celCostLimit = limit
+	}
+}
+
 // NewPipeline creates a new component rendering pipeline.
 func NewPipeline(opts ...Option) *Pipeline {
 	p := &Pipeline{}
@@ -51,7 +61,8 @@ func NewPipeline(opts ...Option) *Pipeline {
 	}
 	if p.templateEngine == nil {
 		p.templateEngine = template.NewEngineWithOptions(
-			template.WithCELExtensions(context.CELExtensions()...),
+			template.WithCELExtensions(pipelinecontext.CELExtensions()...),
+			template.WithCostLimit(p.celCostLimit),
 		)
 	}
 	return p
@@ -68,7 +79,11 @@ func NewPipeline(opts ...Option) *Pipeline {
 //   - Return output
 //
 // Returns an error if any step fails.
-func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
+func (p *Pipeline) Render(ctx context.Context, input *RenderInput) (*RenderOutput, error) {
+	// The forEach budget is per render, not per reconcile: it bounds the fan-out of one
+	// component's own template tree, which is the shape the cumulative cap is about.
+	ctx = renderer.WithForEachBudget(ctx)
+
 	// Validate input
 	if err := p.validateInput(input); err != nil {
 		return nil, fmt.Errorf("invalid input: %w", err)
@@ -81,18 +96,18 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 	// Apply workload overrides from ReleaseBinding if present
 	workload := input.Workload
 	if input.Workload != nil && input.ReleaseBinding != nil && input.ReleaseBinding.Spec.WorkloadOverrides != nil {
-		workload = context.MergeWorkloadOverrides(input.Workload, input.ReleaseBinding.Spec.WorkloadOverrides)
+		workload = pipelinecontext.MergeWorkloadOverrides(input.Workload, input.ReleaseBinding.Spec.WorkloadOverrides)
 	}
 
 	// Pre-compute workload data and configurations once and share across all contexts
-	workloadData := context.ExtractWorkloadData(workload)
-	configurations := context.ExtractConfigurationsFromWorkload(input.SecretReferences, workload)
-	dependenciesData := context.ConnectionsData{
+	workloadData := pipelinecontext.ExtractWorkloadData(workload)
+	configurations := pipelinecontext.ExtractConfigurationsFromWorkload(input.SecretReferences, workload)
+	dependenciesData := pipelinecontext.ConnectionsData{
 		Items: input.DependencyItems,
 	}
 
 	// Build component context
-	componentContext, err := context.BuildComponentContext(&context.ComponentContextInput{
+	componentContext, err := pipelinecontext.BuildComponentContext(&pipelinecontext.ComponentContextInput{
 		Component:                  input.Component,
 		ComponentType:              input.ComponentType,
 		ReleaseBinding:             input.ReleaseBinding,
@@ -110,6 +125,7 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 
 	// Evaluate ComponentType validation rules
 	if err := renderer.EvaluateValidationRules(
+		ctx,
 		p.templateEngine,
 		input.ComponentType.Spec.Validations,
 		componentContext.ToMap(),
@@ -121,7 +137,7 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 
 	// Render base resources from ComponentType
 	resourceRenderer := renderer.NewRenderer(p.templateEngine)
-	renderedResources, err := resourceRenderer.RenderResources(
+	renderedResources, err := resourceRenderer.RenderResources(ctx,
 		input.ComponentType.Spec.Resources,
 		componentContext.ToMap(),
 	)
@@ -145,7 +161,7 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 	}
 
 	// Create schema cache for trait reuse within this render
-	schemaCache := make(map[string]*context.SchemaBundle)
+	schemaCache := make(map[string]*pipelinecontext.SchemaBundle)
 
 	// Process embedded traits from ComponentType (before component-level traits)
 	for _, embeddedTrait := range input.ComponentType.Spec.Traits {
@@ -159,7 +175,8 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 		}
 
 		// Resolve CEL bindings against component context
-		resolvedParams, resolvedEnvironmentConfigs, err := context.ResolveEmbeddedTraitBindings(
+		resolvedParams, resolvedEnvironmentConfigs, err := pipelinecontext.ResolveEmbeddedTraitBindings(
+			ctx,
 			p.templateEngine,
 			embeddedTrait,
 			componentContext.ToMap(),
@@ -170,7 +187,7 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 		}
 
 		// Build embedded trait context
-		traitContext, err := context.BuildEmbeddedTraitContext(&context.EmbeddedTraitContextInput{
+		traitContext, err := pipelinecontext.BuildEmbeddedTraitContext(&pipelinecontext.EmbeddedTraitContextInput{
 			Trait:                      t,
 			InstanceName:               embeddedTrait.InstanceName,
 			ResolvedParameters:         resolvedParams,
@@ -192,6 +209,7 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 
 		// Evaluate trait validation rules
 		if err := renderer.EvaluateValidationRules(
+			ctx,
 			p.templateEngine,
 			t.Spec.Validations,
 			traitContext.ToMap(),
@@ -202,7 +220,7 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 
 		// Process trait (creates + patches)
 		beforeCount := len(renderedResources)
-		renderedResources, err = traitProcessor.ProcessTraits(renderedResources, t, traitContext.ToMap())
+		renderedResources, err = traitProcessor.ProcessTraits(ctx, renderedResources, t, traitContext.ToMap())
 		if err != nil {
 			return nil, fmt.Errorf("failed to process embedded trait %s/%s: %w",
 				embeddedTrait.Name, embeddedTrait.InstanceName, err)
@@ -224,7 +242,7 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 		}
 
 		// Build trait context (BuildTraitContext will handle schema caching)
-		traitContext, err := context.BuildTraitContext(&context.TraitContextInput{
+		traitContext, err := pipelinecontext.BuildTraitContext(&pipelinecontext.TraitContextInput{
 			Trait:                      t,
 			Instance:                   traitInstance,
 			Component:                  input.Component,
@@ -245,6 +263,7 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 
 		// Evaluate trait validation rules
 		if err := renderer.EvaluateValidationRules(
+			ctx,
 			p.templateEngine,
 			t.Spec.Validations,
 			traitContext.ToMap(),
@@ -255,7 +274,7 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 
 		// Process trait (creates + patches)
 		beforeCount := len(renderedResources)
-		renderedResources, err = traitProcessor.ProcessTraits(renderedResources, t, traitContext.ToMap())
+		renderedResources, err = traitProcessor.ProcessTraits(ctx, renderedResources, t, traitContext.ToMap())
 		if err != nil {
 			return nil, fmt.Errorf("failed to process trait %s/%s: %w",
 				traitInstance.Name, traitInstance.InstanceName, err)

--- a/internal/pipeline/component/pipeline_test.go
+++ b/internal/pipeline/component/pipeline_test.go
@@ -928,7 +928,7 @@ spec:
 
 			// Create pipeline and render
 			pipeline := NewPipeline()
-			output, err := pipeline.Render(input)
+			output, err := pipeline.Render(t.Context(), input)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Render() error = %v, wantErr %v", err, tt.wantErr)
@@ -1199,7 +1199,7 @@ spec:
 				Metadata:       baseMetadata,
 			}
 
-			_, err := NewPipeline().Render(input)
+			_, err := NewPipeline().Render(t.Context(), input)
 			if err == nil {
 				t.Fatal("expected validation error, got nil")
 			}
@@ -1423,7 +1423,7 @@ spec:
 				Metadata:      baseMetadata,
 			}
 
-			_, err := NewPipeline().Render(input)
+			_, err := NewPipeline().Render(t.Context(), input)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")

--- a/internal/pipeline/component/render_scope_test.go
+++ b/internal/pipeline/component/render_scope_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package component
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/openchoreo/openchoreo/api/v1alpha1"
+	pipelinecontext "github.com/openchoreo/openchoreo/internal/pipeline/component/context"
+	"github.com/openchoreo/openchoreo/internal/template"
+)
+
+// breachingRule measures 150,009 units on this branch, so a pipeline configured with
+// aggregatorCostLimit trips the per-expression cost limit on it while every other
+// expression in these fixtures stays free (the templates are static).
+//
+// It folds over the range rather than sizing it because cel-go v0.22.1, which this branch
+// pins, ships no runtime tracker for lists.range; the estimator in internal/template now
+// supplies one, but the comprehension is what this fixture is really about.
+const (
+	breachingRule       = "${size(lists.range(9999).map(i, i + 1)) > 0}"
+	aggregatorCostLimit = 1_000
+)
+
+// staticComponentType emits one Deployment with no CEL in it, so the only cost these
+// tests incur is the rule under test.
+const staticComponentType = `
+spec:
+  resources:
+    - id: deployment
+      template: {apiVersion: apps/v1, kind: Deployment, metadata: {name: web}, spec: {replicas: 1}}
+`
+
+func renderScopeTestMetadata() pipelinecontext.MetadataContext {
+	return pipelinecontext.MetadataContext{
+		Name:               "test",
+		Namespace:          "ns",
+		ComponentName:      "app",
+		ComponentUID:       "uid1",
+		ComponentNamespace: "ns",
+		ProjectName:        "proj",
+		ProjectUID:         "uid2",
+		DataPlaneName:      "dp",
+		DataPlaneUID:       "uid3",
+		EnvironmentName:    "dev",
+		EnvironmentUID:     "uid4",
+		Labels:             map[string]string{},
+		Annotations:        map[string]string{},
+		PodSelectors:       map[string]string{"k": "v"},
+	}
+}
+
+func renderScopeInput(t *testing.T, componentTypeYAML, traitsYAML string) *RenderInput {
+	t.Helper()
+	var componentType v1alpha1.ComponentType
+	if err := yaml.Unmarshal([]byte(componentTypeYAML), &componentType); err != nil {
+		t.Fatalf("failed to parse componentType: %v", err)
+	}
+	var traits []v1alpha1.Trait
+	if traitsYAML != "" {
+		if err := yaml.Unmarshal([]byte(traitsYAML), &traits); err != nil {
+			t.Fatalf("failed to parse traits: %v", err)
+		}
+	}
+	return &RenderInput{
+		ComponentType: &componentType,
+		Component:     &v1alpha1.Component{},
+		Traits:        traits,
+		Workload:      &v1alpha1.Workload{},
+		Environment:   &v1alpha1.Environment{},
+		DataPlane:     &v1alpha1.DataPlane{},
+		Metadata:      renderScopeTestMetadata(),
+	}
+}
+
+// TestValidationAggregatorPreservesErrorIdentity covers the place the pipeline aggregates
+// rule failures into one error. ComponentType and trait validations both funnel through
+// renderer.EvaluateValidationRules, so one case covers the aggregator. The aggregator used to collect strings, which erased the
+// sentinel - a reconciler could then not tell a cost breach (terminal, retrying is
+// pointless) from an ordinary rule failure. The errors.Is chain must survive aggregation.
+func TestValidationAggregatorPreservesErrorIdentity(t *testing.T) {
+	cases := []struct {
+		name              string
+		componentTypeYAML string
+		traitsYAML        string
+	}{
+		{
+			name: "componentType validations",
+			componentTypeYAML: staticComponentType + `
+  validations:
+    - rule: "` + breachingRule + `"
+      message: "unreachable"
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			input := renderScopeInput(t, tc.componentTypeYAML, tc.traitsYAML)
+			_, err := NewPipeline(WithCostLimit(aggregatorCostLimit)).Render(t.Context(), input)
+			if err == nil {
+				t.Fatal("expected the breaching rule to fail, got nil")
+			}
+			if !errors.Is(err, template.ErrCostLimitExceeded) {
+				t.Fatalf("aggregation erased the sentinel: %v", err)
+			}
+			if !template.IsTerminalRenderError(err) {
+				t.Errorf("a cost breach must classify as a terminal render error: %v", err)
+			}
+		})
+	}
+}
+
+// TestRenderStopsOnCancelledContext confirms the pipeline threads the caller's context
+// all the way to the engine rather than substituting a background one.
+func TestRenderStopsOnCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	input := renderScopeInput(t, staticComponentType+`
+  validations:
+    - rule: "${size(lists.range(5000).map(i, i + 1)) > 0}"
+      message: "unreachable"
+`, "")
+
+	if _, err := NewPipeline().Render(ctx, input); !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected the cancelled context to reach the engine, got %v", err)
+	}
+}

--- a/internal/pipeline/component/renderer/controlflow.go
+++ b/internal/pipeline/component/renderer/controlflow.go
@@ -4,9 +4,10 @@
 package renderer
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"maps"
-	"strings"
 
 	"github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/template"
@@ -19,12 +20,12 @@ import (
 //   - true if includeWhen evaluates to true
 //   - false if includeWhen evaluates to false
 //   - error for evaluation failures (including missing data)
-func ShouldInclude(engine *template.Engine, includeWhen string, context map[string]any) (bool, error) {
+func ShouldInclude(ctx context.Context, engine *template.Engine, includeWhen string, celContext map[string]any) (bool, error) {
 	if includeWhen == "" {
 		return true, nil
 	}
 
-	result, err := engine.Render(includeWhen, context)
+	result, err := engine.Render(ctx, includeWhen, celContext)
 	if err != nil {
 		return false, err
 	}
@@ -48,17 +49,18 @@ func ShouldInclude(engine *template.Engine, includeWhen string, context map[stri
 // If varName is empty, "item" is used as the default variable name.
 // Returns error if forEach evaluation fails or conversion fails.
 func EvalForEach(
+	ctx context.Context,
 	engine *template.Engine,
 	forEach string,
 	varName string,
-	context map[string]any,
+	celContext map[string]any,
 ) ([]map[string]any, error) {
-	result, err := engine.Render(forEach, context)
+	result, err := engine.Render(ctx, forEach, celContext)
 	if err != nil {
 		return nil, err
 	}
 
-	items, err := ToIterableItems(result)
+	items, err := ToIterableItems(ctx, result)
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +71,7 @@ func EvalForEach(
 
 	contexts := make([]map[string]any, len(items))
 	for i, item := range items {
-		itemContext := maps.Clone(context)
+		itemContext := maps.Clone(celContext)
 		itemContext[varName] = item
 		contexts[i] = itemContext
 	}
@@ -77,43 +79,43 @@ func EvalForEach(
 }
 
 // EvaluateValidationRules evaluates a list of CEL-based validation rules against the given context.
-// All rules are evaluated (no short-circuiting) and all failures are collected into a single error.
+// Every rule is evaluated and all failures are collected into a single joined error; the sole
+// exception is an aborted render — an exhausted cost budget or a cancelled context — which stops
+// the loop, because every remaining rule would fail the same way.
 // Returns nil if there are no rules or all rules pass.
 //
-// Error messages include rule index and rule text for easy identification.
+// Error messages include rule index and rule text for easy identification. Evaluation failures
+// are wrapped rather than stringified, so a caller can classify a cost or deadline breach with
+// errors.Is through the aggregate.
 // The returned error does not include a "validation failed:" prefix — callers add their own context.
-func EvaluateValidationRules(engine *template.Engine, rules []v1alpha1.ValidationRule, context map[string]any) error {
+func EvaluateValidationRules(
+	ctx context.Context,
+	engine *template.Engine,
+	rules []v1alpha1.ValidationRule,
+	celContext map[string]any,
+) error {
 	if len(rules) == 0 {
 		return nil
 	}
-	var errs []string
+	var errs []error
 	for i, rule := range rules {
-		ruleRef := truncateRule(rule.Rule, 120)
-		result, err := engine.Render(rule.Rule, context)
+		ruleRef := template.TruncateTo(rule.Rule, 120)
+		result, err := engine.Render(ctx, rule.Rule, celContext)
 		if err != nil {
-			errs = append(errs, fmt.Sprintf("rule[%d] %q evaluation error: %v", i, ruleRef, err))
+			errs = append(errs, fmt.Errorf("rule[%d] %q evaluation error: %w", i, ruleRef, err))
+			if template.IsRenderAborted(err) {
+				break
+			}
 			continue
 		}
 		boolResult, ok := result.(bool)
 		if !ok {
-			errs = append(errs, fmt.Sprintf("rule[%d] %q must evaluate to boolean, got %T", i, ruleRef, result))
+			errs = append(errs, fmt.Errorf("rule[%d] %q must evaluate to boolean, got %T", i, ruleRef, result))
 			continue
 		}
 		if !boolResult {
-			errs = append(errs, fmt.Sprintf("rule[%d] %q evaluated to false: %s", i, ruleRef, rule.Message))
+			errs = append(errs, fmt.Errorf("rule[%d] %q evaluated to false: %s", i, ruleRef, rule.Message))
 		}
 	}
-	if len(errs) > 0 {
-		return fmt.Errorf("%s", strings.Join(errs, "; "))
-	}
-	return nil
-}
-
-// truncateRule returns the rule string truncated to maxLen runes.
-func truncateRule(rule string, maxLen int) string {
-	runes := []rune(rule)
-	if len(runes) <= maxLen {
-		return rule
-	}
-	return string(runes[:maxLen]) + "..."
+	return errors.Join(errs...)
 }

--- a/internal/pipeline/component/renderer/controlflow_test.go
+++ b/internal/pipeline/component/renderer/controlflow_test.go
@@ -113,7 +113,7 @@ func TestEvaluateValidationRules(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := EvaluateValidationRules(engine, tt.rules, tt.context)
+			err := EvaluateValidationRules(t.Context(), engine, tt.rules, tt.context)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error but got nil")
@@ -135,7 +135,7 @@ func TestEvaluateValidationRules(t *testing.T) {
 func TestEvalForEach_EvalError(t *testing.T) {
 	engine := template.NewEngine()
 
-	_, err := EvalForEach(engine, "${nonexistent.list}", "item", map[string]any{})
+	_, err := EvalForEach(t.Context(), engine, "${nonexistent.list}", "item", map[string]any{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "nonexistent")
 }
@@ -144,7 +144,7 @@ func TestEvalForEach_ConversionError(t *testing.T) {
 	engine := template.NewEngine()
 
 	// forEach expression evaluates to an integer, which is not iterable
-	_, err := EvalForEach(engine, "${parameters.count}", "item", map[string]any{
+	_, err := EvalForEach(t.Context(), engine, "${parameters.count}", "item", map[string]any{
 		"parameters": map[string]any{
 			"count": 42,
 		},
@@ -160,26 +160,11 @@ func TestEvalForEach_DefaultVarName(t *testing.T) {
 		"items": []any{"a", "b"},
 	}
 	// Pass empty varName to use the default "item"
-	contexts, err := EvalForEach(engine, "${items}", "", ctx)
+	contexts, err := EvalForEach(t.Context(), engine, "${items}", "", ctx)
 	require.NoError(t, err)
 	require.Len(t, contexts, 2)
 
 	// Verify the default variable name "item" is used in the context
 	assert.Equal(t, "a", contexts[0]["item"])
 	assert.Equal(t, "b", contexts[1]["item"])
-}
-
-func TestTruncateRule_LongRule(t *testing.T) {
-	// Create a rule string longer than 120 characters
-	longRule := "${" + strings.Repeat("a", 200) + "}"
-	result := truncateRule(longRule, 120)
-	assert.Len(t, []rune(result), 123, "truncated result should be maxLen runes + 3 for '...'")
-	assert.True(t, strings.HasSuffix(result, "..."), "truncated result should end with '...'")
-	assert.True(t, strings.HasPrefix(result, "${"+strings.Repeat("a", 118)), "truncated result should preserve the original prefix")
-}
-
-func TestTruncateRule_ShortRule(t *testing.T) {
-	shortRule := "${parameters.replicas > 0}"
-	result := truncateRule(shortRule, 120)
-	assert.Equal(t, shortRule, result, "short rule should be returned as-is")
 }

--- a/internal/pipeline/component/renderer/foreach.go
+++ b/internal/pipeline/component/renderer/foreach.go
@@ -4,9 +4,87 @@
 package renderer
 
 import (
+	"context"
 	"fmt"
 	"sort"
+	"sync"
+
+	"github.com/openchoreo/openchoreo/internal/template"
 )
+
+// maxForEachItems bounds how many items a single forEach may expand to. Each item
+// drives a full render, so an unbounded tenant-supplied collection amplifies work far
+// beyond what the per-expression CEL cost limit can see.
+//
+// 100 covers what templates actually iterate over - a component's config files, mounts,
+// routes, containers - and none of those collections is large. The cap is on the item
+// count rather than the work per item because a static body charges nothing at all to the
+// cost budget: renderString returns a span-free string without evaluating anything.
+const maxForEachItems = 100
+
+// maxForEachItemsPerRender bounds the sum of every forEach expansion in one pipeline
+// render. The per-loop cap prevents one large fan-out; this cap prevents many legal
+// 100-item loops with cheap or static bodies from recreating the same workload in total.
+//
+// The per-loop cap cannot stand in for it: the number of forEach sites is a product of
+// nested arrays - a ComponentType's resources, and every trait's creates - so bounding
+// each array on its own still leaves their product free to grow.
+const maxForEachItemsPerRender = 10_000
+
+type forEachBudget struct {
+	mu    sync.Mutex
+	spent int
+}
+
+type forEachBudgetKey struct{}
+
+// WithForEachBudget returns a context carrying a render-scoped cumulative expansion
+// budget. An existing budget is preserved so nested pipeline work shares the same total.
+func WithForEachBudget(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Value(forEachBudgetKey{}).(*forEachBudget); ok {
+		return ctx
+	}
+	return context.WithValue(ctx, forEachBudgetKey{}, &forEachBudget{})
+}
+
+// checkForEachLimit rejects a forEach result whose item count exceeds maxForEachItems.
+// Callers must invoke it before copying the result or fanning out sub-renders over it, so
+// an oversized collection costs no more than the length check.
+//
+// What it cannot save is the CEL-to-Go conversion: the engine has already materialized the
+// result by the time a caller can count it. That step is bounded by the per-expression cost
+// limit and the lists.range cap instead - this bound covers the per-item work that follows,
+// which neither of those can see.
+//
+// The error wraps template.ErrExpansionLimitExceeded: the cap depends only on how many
+// items the expression produced, so the same object trips it on every reconcile until a
+// human edits the template or the data behind it.
+func checkForEachLimit(ctx context.Context, n int) error {
+	if n > maxForEachItems {
+		return fmt.Errorf("%w: forEach expanded to %d items, exceeding the limit of %d",
+			template.ErrExpansionLimitExceeded, n, maxForEachItems)
+	}
+	if ctx == nil {
+		return nil
+	}
+
+	budget, ok := ctx.Value(forEachBudgetKey{}).(*forEachBudget)
+	if !ok {
+		return nil
+	}
+	budget.mu.Lock()
+	defer budget.mu.Unlock()
+	if budget.spent > maxForEachItemsPerRender-n {
+		budget.spent = maxForEachItemsPerRender + 1
+		return fmt.Errorf("%w: forEach expansions would exceed the cumulative limit of %d items in one render",
+			template.ErrExpansionLimitExceeded, maxForEachItemsPerRender)
+	}
+	budget.spent += n
+	return nil
+}
 
 // ToIterableItems converts a forEach evaluation result to a slice of items.
 // Arrays are returned as-is. Maps are converted to sorted slice of {key, value} entries.
@@ -21,12 +99,21 @@ import (
 //   - Consistent resource generation across runs
 //   - Predictable test results
 //   - Reproducible deployments
-func ToIterableItems(result any) ([]any, error) {
+//
+// Results with more than maxForEachItems entries are rejected, and contexts created by
+// WithForEachBudget also enforce the cumulative per-render cap.
+func ToIterableItems(ctx context.Context, result any) ([]any, error) {
 	switch v := result.(type) {
 	case []any:
+		if err := checkForEachLimit(ctx, len(v)); err != nil {
+			return nil, err
+		}
 		return v, nil
 
 	case []map[string]any:
+		if err := checkForEachLimit(ctx, len(v)); err != nil {
+			return nil, err
+		}
 		// Convert []map[string]any to []any
 		items := make([]any, len(v))
 		for i, m := range v {
@@ -35,6 +122,9 @@ func ToIterableItems(result any) ([]any, error) {
 		return items, nil
 
 	case map[string]any:
+		if err := checkForEachLimit(ctx, len(v)); err != nil {
+			return nil, err
+		}
 		// Convert map to sorted slice of {key, value} entries
 		// Sort keys for deterministic iteration order
 		keys := make([]string, 0, len(v))

--- a/internal/pipeline/component/renderer/foreach_test.go
+++ b/internal/pipeline/component/renderer/foreach_test.go
@@ -4,8 +4,13 @@
 package renderer
 
 import (
+	"errors"
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/openchoreo/openchoreo/internal/template"
 )
 
 func TestToIterableItems(t *testing.T) {
@@ -131,7 +136,7 @@ func TestToIterableItems(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ToIterableItems(tt.input)
+			got, err := ToIterableItems(t.Context(), tt.input)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ToIterableItems() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -140,6 +145,91 @@ func TestToIterableItems(t *testing.T) {
 				t.Errorf("ToIterableItems() got = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestToIterableItemsRejectsOversizedForEach verifies the fan-out cap: a collection at
+// exactly maxForEachItems is accepted, one item more is rejected. Every supported input
+// type is checked because each branch enforces the cap on its own.
+func TestToIterableItemsRejectsOversizedForEach(t *testing.T) {
+	anyList := func(n int) any {
+		items := make([]any, n)
+		for i := range items {
+			items[i] = i
+		}
+		return items
+	}
+	mapList := func(n int) any {
+		items := make([]map[string]any, n)
+		for i := range items {
+			items[i] = map[string]any{"index": i}
+		}
+		return items
+	}
+	keyedMap := func(n int) any {
+		items := make(map[string]any, n)
+		for i := 0; i < n; i++ {
+			items[fmt.Sprintf("key%d", i)] = i
+		}
+		return items
+	}
+
+	builders := map[string]func(int) any{
+		"[]any":            anyList,
+		"[]map[string]any": mapList,
+		"map[string]any":   keyedMap,
+	}
+
+	for name, build := range builders {
+		t.Run(name, func(t *testing.T) {
+			got, err := ToIterableItems(t.Context(), build(maxForEachItems))
+			if err != nil {
+				t.Fatalf("ToIterableItems() with %d items: unexpected error = %v", maxForEachItems, err)
+			}
+			if len(got) != maxForEachItems {
+				t.Fatalf("ToIterableItems() returned %d items, want %d", len(got), maxForEachItems)
+			}
+
+			over := maxForEachItems + 1
+			got, err = ToIterableItems(t.Context(), build(over))
+			if err == nil {
+				t.Fatalf("ToIterableItems() with %d items: expected error, got %d items", over, len(got))
+			}
+			want := fmt.Sprintf("forEach expanded to %d items, exceeding the limit of %d", over, maxForEachItems)
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("ToIterableItems() error = %v, want it to contain %q", err, want)
+			}
+			// The cap depends only on the item count, so it trips identically on every
+			// reconcile; reconcilers must be able to recognize that and pace the retry.
+			if !errors.Is(err, template.ErrExpansionLimitExceeded) {
+				t.Errorf("ToIterableItems() error must wrap template.ErrExpansionLimitExceeded, got %v", err)
+			}
+			if !template.IsTerminalRenderError(err) {
+				t.Errorf("ToIterableItems() cap breach must classify as terminal, got %v", err)
+			}
+			if got != nil {
+				t.Errorf("ToIterableItems() returned %d items alongside the error, want nil", len(got))
+			}
+		})
+	}
+}
+
+func TestToIterableItemsRejectsCumulativeExpansion(t *testing.T) {
+	ctx := WithForEachBudget(t.Context())
+	items := make([]any, maxForEachItems)
+
+	for i := 0; i < maxForEachItemsPerRender/maxForEachItems; i++ {
+		if _, err := ToIterableItems(ctx, items); err != nil {
+			t.Fatalf("expansion %d unexpectedly exceeded the cumulative limit: %v", i, err)
+		}
+	}
+
+	_, err := ToIterableItems(ctx, []any{"one more"})
+	if !errors.Is(err, template.ErrExpansionLimitExceeded) {
+		t.Fatalf("expected cumulative expansions to breach the limit, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "cumulative limit") {
+		t.Fatalf("expected the error to identify the cumulative cap, got: %v", err)
 	}
 }
 
@@ -156,7 +246,7 @@ func TestToIterableItemsDeterminism(t *testing.T) {
 	// Run multiple times to ensure consistent ordering
 	var previous []any
 	for i := 0; i < 10; i++ {
-		result, err := ToIterableItems(input)
+		result, err := ToIterableItems(t.Context(), input)
 		if err != nil {
 			t.Fatalf("ToIterableItems() error = %v", err)
 		}

--- a/internal/pipeline/component/renderer/renderer.go
+++ b/internal/pipeline/component/renderer/renderer.go
@@ -8,6 +8,7 @@
 package renderer
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -51,14 +52,15 @@ type RenderedResource struct {
 //
 // Returns an error if any template fails to render.
 func (r *Renderer) RenderResources(
+	ctx context.Context,
 	templates []v1alpha1.ResourceTemplate,
-	context map[string]any,
+	celContext map[string]any,
 ) ([]RenderedResource, error) {
 	resources := make([]RenderedResource, 0, len(templates))
 
 	for _, tmpl := range templates {
 		// Check if resource should be included
-		include, err := ShouldInclude(r.templateEngine, tmpl.IncludeWhen, context)
+		include, err := ShouldInclude(ctx, r.templateEngine, tmpl.IncludeWhen, celContext)
 		if err != nil {
 			return nil, fmt.Errorf("failed to evaluate includeWhen for resource %s: %w", tmpl.ID, err)
 		}
@@ -68,7 +70,7 @@ func (r *Renderer) RenderResources(
 
 		// Handle forEach iteration
 		if tmpl.ForEach != "" {
-			rendered, err := r.renderWithForEach(tmpl, context)
+			rendered, err := r.renderWithForEach(ctx, tmpl, celContext)
 			if err != nil {
 				return nil, err
 			}
@@ -83,7 +85,7 @@ func (r *Renderer) RenderResources(
 		}
 
 		// Render single resource
-		rendered, err := r.renderSingleResource(tmpl, context)
+		rendered, err := r.renderSingleResource(ctx, tmpl, celContext)
 		if err != nil {
 			return nil, err
 		}
@@ -99,17 +101,18 @@ func (r *Renderer) RenderResources(
 // renderWithForEach handles ResourceTemplate.forEach iteration.
 // Delegates to the shared EvalForEach helper for iteration logic.
 func (r *Renderer) renderWithForEach(
+	ctx context.Context,
 	tmpl v1alpha1.ResourceTemplate,
-	context map[string]any,
+	celContext map[string]any,
 ) ([]map[string]any, error) {
-	itemContexts, err := EvalForEach(r.templateEngine, tmpl.ForEach, tmpl.Var, context)
+	itemContexts, err := EvalForEach(ctx, r.templateEngine, tmpl.ForEach, tmpl.Var, celContext)
 	if err != nil {
 		return nil, fmt.Errorf("failed to evaluate forEach for resource %s: %w", tmpl.ID, err)
 	}
 
 	resources := make([]map[string]any, 0, len(itemContexts))
 	for _, itemContext := range itemContexts {
-		rendered, err := r.renderSingleResource(tmpl, itemContext)
+		rendered, err := r.renderSingleResource(ctx, tmpl, itemContext)
 		if err != nil {
 			return nil, err
 		}
@@ -127,8 +130,9 @@ func (r *Renderer) renderWithForEach(
 //   - Remove omitted fields
 //   - Validate basic structure (kind, apiVersion, metadata.name)
 func (r *Renderer) renderSingleResource(
+	ctx context.Context,
 	tmpl v1alpha1.ResourceTemplate,
-	context map[string]any,
+	celContext map[string]any,
 ) (map[string]any, error) {
 	// Extract template structure
 	var templateData any
@@ -137,7 +141,7 @@ func (r *Renderer) renderSingleResource(
 	}
 
 	// Render template
-	rendered, err := r.templateEngine.Render(templateData, context)
+	rendered, err := r.templateEngine.Render(ctx, templateData, celContext)
 	if err != nil {
 		return nil, fmt.Errorf("failed to render template for resource %s: %w", tmpl.ID, err)
 	}

--- a/internal/pipeline/component/renderer/renderer_test.go
+++ b/internal/pipeline/component/renderer/renderer_test.go
@@ -226,7 +226,7 @@ func TestRenderResources(t *testing.T) {
 				t.Fatalf("Failed to parse templates YAML: %v", err)
 			}
 
-			got, err := renderer.RenderResources(templates, tt.context)
+			got, err := renderer.RenderResources(t.Context(), templates, tt.context)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("RenderResources() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -295,7 +295,7 @@ func TestShouldInclude(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ShouldInclude(engine, tt.includeWhen, tt.context)
+			got, err := ShouldInclude(t.Context(), engine, tt.includeWhen, tt.context)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ShouldInclude() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -575,7 +575,7 @@ template:
 				t.Fatalf("Failed to parse template YAML: %v", err)
 			}
 
-			got, err := renderer.renderWithForEach(template, tt.context)
+			got, err := renderer.renderWithForEach(t.Context(), template, tt.context)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("renderWithForEach() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -684,7 +684,7 @@ template:
 				t.Fatalf("Failed to parse template YAML: %v", err)
 			}
 
-			got, err := renderer.renderSingleResource(template, tt.context)
+			got, err := renderer.renderSingleResource(t.Context(), template, tt.context)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("renderSingleResource() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -784,7 +784,7 @@ func TestRenderResources_IncludeWhenError(t *testing.T) {
 	var templates []v1alpha1.ResourceTemplate
 	require.NoError(t, yaml.Unmarshal([]byte(templatesYAML), &templates))
 
-	_, err := r.RenderResources(templates, map[string]any{})
+	_, err := r.RenderResources(t.Context(), templates, map[string]any{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "my-service", "error should reference the resource ID")
 	assert.Contains(t, err.Error(), "includeWhen", "error should mention includeWhen")
@@ -807,7 +807,7 @@ func TestRenderResources_ForEachError(t *testing.T) {
 	var templates []v1alpha1.ResourceTemplate
 	require.NoError(t, yaml.Unmarshal([]byte(templatesYAML), &templates))
 
-	_, err := r.RenderResources(templates, map[string]any{})
+	_, err := r.RenderResources(t.Context(), templates, map[string]any{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "my-configmap", "error should reference the resource ID")
 }
@@ -827,7 +827,7 @@ func TestRenderResources_TemplateRenderError(t *testing.T) {
 	var templates []v1alpha1.ResourceTemplate
 	require.NoError(t, yaml.Unmarshal([]byte(templatesYAML), &templates))
 
-	_, err := r.RenderResources(templates, map[string]any{})
+	_, err := r.RenderResources(t.Context(), templates, map[string]any{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "my-deployment", "error should reference the resource ID")
 }
@@ -855,7 +855,7 @@ func TestRenderResources_TargetPlane(t *testing.T) {
 	var templates []v1alpha1.ResourceTemplate
 	require.NoError(t, yaml.Unmarshal([]byte(templatesYAML), &templates))
 
-	results, err := r.RenderResources(templates, map[string]any{})
+	results, err := r.RenderResources(t.Context(), templates, map[string]any{})
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 	assert.Equal(t, "dataplane", results[0].TargetPlane)
@@ -883,7 +883,7 @@ func TestRenderResources_ForEachTargetPlane(t *testing.T) {
 	ctx := map[string]any{
 		"items": []any{"cfg1", "cfg2", "cfg3"},
 	}
-	results, err := r.RenderResources(templates, ctx)
+	results, err := r.RenderResources(t.Context(), templates, ctx)
 	require.NoError(t, err)
 	require.Len(t, results, 3)
 	for i, res := range results {
@@ -902,7 +902,7 @@ func TestRenderResources_ForEachTargetPlane(t *testing.T) {
 func TestShouldInclude_NonBooleanResult(t *testing.T) {
 	engine := template.NewEngine()
 
-	got, err := ShouldInclude(engine, "${parameters.name}", map[string]any{
+	got, err := ShouldInclude(t.Context(), engine, "${parameters.name}", map[string]any{
 		"parameters": map[string]any{
 			"name": "my-app",
 		},

--- a/internal/pipeline/component/trait/error_bounds_test.go
+++ b/internal/pipeline/component/trait/error_bounds_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package trait
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/template"
+)
+
+// The engine bounds every expression it names in an error, but a trait patch or remove
+// that fails is re-wrapped by this package - and a wrap that quotes the raw expression
+// puts the whole tenant-authored fragment back into a message that ends up verbatim in a
+// status condition. An oversized condition is rejected by the API server, and a failed
+// status write is exactly the hot-backoff failure mode the cost guards exist to avoid.
+//
+// maxWrappedErrorLen is a generous ceiling: every message here names a handful of bounded
+// fragments, so a message anywhere near this size means a raw expression leaked through.
+const maxWrappedErrorLen = 4096
+
+// hugeExpr builds a syntactically valid expression that fails at evaluation time (index
+// out of range) and carries a padded string literal, so a wrap that quotes it raw is
+// immediately visible in the message length. A runtime failure is used rather than a
+// compile error because cel-go's own compile diagnostics quote the source line.
+func hugeExpr() string {
+	return `${["` + strings.Repeat("a", 50_000) + `"][7]}`
+}
+
+// traitWithPatch builds a trait carrying one patch, so each case can vary just the
+// expression under test.
+func traitWithPatch(patch v1alpha1.TraitPatch) *v1alpha1.Trait {
+	return &v1alpha1.Trait{Spec: v1alpha1.TraitSpec{Patches: []v1alpha1.TraitPatch{patch}}}
+}
+
+func TestTraitErrorsStayBounded(t *testing.T) {
+	patchOps := []v1alpha1.JSONPatchOperation{{Op: "add", Path: "/data/x", Value: &runtime.RawExtension{Raw: []byte(`"v"`)}}}
+
+	tests := []struct {
+		name string
+		run  func(p *Processor) error
+	}{
+		{
+			name: "patch forEach evaluation failure",
+			run: func(p *Processor) error {
+				return p.ApplyTraitPatches(t.Context(), buildTargets(1), traitWithPatch(v1alpha1.TraitPatch{
+					Target:     v1alpha1.PatchTarget{Kind: "ConfigMap"},
+					ForEach:    hugeExpr(),
+					Operations: patchOps,
+				}), map[string]any{})
+			},
+		},
+		{
+			name: "patch where evaluation failure",
+			run: func(p *Processor) error {
+				return p.ApplyTraitPatches(t.Context(), buildTargets(1), traitWithPatch(v1alpha1.TraitPatch{
+					Target:     v1alpha1.PatchTarget{Kind: "ConfigMap", Where: hugeExpr()},
+					Operations: patchOps,
+				}), map[string]any{})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run(NewProcessor(template.NewEngine()))
+			if err == nil {
+				t.Fatal("expected the expression to fail, got nil")
+			}
+			if got := len(err.Error()); got > maxWrappedErrorLen {
+				t.Fatalf("error message is %d bytes, want at most %d - a raw expression leaked into the wrap: %.500s",
+					got, maxWrappedErrorLen, err.Error())
+			}
+		})
+	}
+}

--- a/internal/pipeline/component/trait/patch_limit_test.go
+++ b/internal/pipeline/component/trait/patch_limit_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package trait
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/pipeline/component/renderer"
+	"github.com/openchoreo/openchoreo/internal/template"
+)
+
+// buildTargets returns n distinct ConfigMaps for a patch to match.
+func buildTargets(n int) []renderer.RenderedResource {
+	resources := make([]renderer.RenderedResource, n)
+	for i := range resources {
+		resources[i] = renderer.RenderedResource{
+			Resource: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata":   map[string]any{"name": fmt.Sprintf("cm-%d", i)},
+				"data":       map[string]any{"seed": "v"},
+			},
+		}
+	}
+	return resources
+}
+
+// forEachPatchTrait returns a trait whose single patch iterates itemCount times and targets
+// every ConfigMap, so it applies itemCount x targets times.
+func forEachPatchTrait(t *testing.T, itemCount int) *v1alpha1.Trait {
+	t.Helper()
+	items := make([]string, itemCount)
+	for i := range items {
+		items[i] = fmt.Sprintf("%q", fmt.Sprintf("k%d", i))
+	}
+	traitYAML := fmt.Sprintf(`
+apiVersion: openchoreo.dev/v1alpha1
+kind: Trait
+metadata:
+  name: fanout
+spec:
+  patches:
+    - target:
+        kind: ConfigMap
+      forEach: '${[%s]}'
+      var: item
+      operations:
+        - op: add
+          path: /data/patched
+          value: "${item}"
+`, strings.Join(items, ", "))
+
+	var trait v1alpha1.Trait
+	if err := yaml.Unmarshal([]byte(traitYAML), &trait); err != nil {
+		t.Fatalf("failed to parse trait YAML: %v", err)
+	}
+	return &trait
+}
+
+// forEach multiplies on both sides of a trait patch: items on one side, matched targets on
+// the other. The product is JSON-Patch work rather than CEL evaluation, so neither the
+// per-expression cost limit nor the reconcile cost budget can see it. maxPatchOperations
+// is the only thing standing between a component and a million applications.
+func TestTraitPatchesRejectOversizedCrossProduct(t *testing.T) {
+	// 200 targets x 100 items = 20,000 applications, twice the cap.
+	const (
+		targets = 200
+		items   = 100
+	)
+
+	processor := NewProcessor(template.NewEngine())
+	err := processor.ApplyTraitPatches(t.Context(), buildTargets(targets), forEachPatchTrait(t, items), map[string]any{})
+	if err == nil {
+		t.Fatalf("expected %d x %d applications to be refused, got nil", items, targets)
+	}
+	if !errors.Is(err, template.ErrExpansionLimitExceeded) {
+		t.Fatalf("expected the error to wrap template.ErrExpansionLimitExceeded, got: %v", err)
+	}
+	if !template.IsTerminalRenderError(err) {
+		t.Fatalf("a patch cross-product breach must classify as terminal, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), fmt.Sprintf("limit of %d", maxPatchOperations)) {
+		t.Fatalf("expected the error to name the cap, got: %v", err)
+	}
+	// The running total tells an operator how far over the cap the component is, and it is
+	// deterministic for fixed inputs: 200 targets divide 10,000 exactly, so the 50th item
+	// charges the counter to the cap and the 51st batch of 200 is the one refused.
+	breachTotal := maxPatchOperations + targets
+	if !strings.Contains(err.Error(), fmt.Sprintf("apply %d operations", breachTotal)) {
+		t.Fatalf("expected the error to name the running total %d, got: %v", breachTotal, err)
+	}
+}
+
+func TestTraitPatchLimitCountsEveryOperation(t *testing.T) {
+	const (
+		targets    = 100
+		items      = 100
+		operations = 2
+	)
+
+	trait := forEachPatchTrait(t, items)
+	op := trait.Spec.Patches[0].Operations[0]
+	trait.Spec.Patches[0].Operations = make([]v1alpha1.JSONPatchOperation, operations)
+	for i := range trait.Spec.Patches[0].Operations {
+		trait.Spec.Patches[0].Operations[i] = op
+		trait.Spec.Patches[0].Operations[i].Path = fmt.Sprintf("/data/patched%d", i)
+	}
+
+	processor := NewProcessor(template.NewEngine())
+	err := processor.ApplyTraitPatches(t.Context(), buildTargets(targets), trait, map[string]any{})
+	if !errors.Is(err, template.ErrExpansionLimitExceeded) {
+		t.Fatalf("expected %d targets x %d items x %d operations to breach the limit, got: %v",
+			targets, items, operations, err)
+	}
+}
+
+// A cross product comfortably inside the cap must still apply, and apply everywhere.
+func TestTraitPatchesWithinCapStillApply(t *testing.T) {
+	const (
+		targets = 10
+		items   = 5
+	)
+
+	resources := buildTargets(targets)
+	processor := NewProcessor(template.NewEngine())
+	if err := processor.ApplyTraitPatches(t.Context(), resources, forEachPatchTrait(t, items), map[string]any{}); err != nil {
+		t.Fatalf("a %d x %d cross product is well inside the cap and must apply: %v", items, targets, err)
+	}
+	if processor.patchOperations != targets*items {
+		t.Fatalf("counted %d operations, want %d", processor.patchOperations, targets*items)
+	}
+	for i := range resources {
+		data, _ := resources[i].Resource["data"].(map[string]any)
+		if data["patched"] != fmt.Sprintf("k%d", items-1) {
+			t.Fatalf("resource %d was not patched by the last iteration: %v", i, data)
+		}
+	}
+}
+
+// The cap is per render, not per trait: the pipeline builds one Processor per
+// Pipeline.Render call, so a component that spreads the same fan-out across several traits
+// must not slip past it.
+func TestPatchOperationsAccumulateAcrossTraits(t *testing.T) {
+	// Each pass is 100 x 60 = 6,000 applications: under the cap alone, over it together.
+	const (
+		targets = 100
+		items   = 60
+	)
+
+	processor := NewProcessor(template.NewEngine())
+	resources := buildTargets(targets)
+
+	if err := processor.ApplyTraitPatches(t.Context(), resources, forEachPatchTrait(t, items), map[string]any{}); err != nil {
+		t.Fatalf("the first trait is under the cap and must apply: %v", err)
+	}
+	err := processor.ApplyTraitPatches(t.Context(), resources, forEachPatchTrait(t, items), map[string]any{})
+	if err == nil {
+		t.Fatal("expected the second trait to push the render over the cap, got nil")
+	}
+	if !errors.Is(err, template.ErrExpansionLimitExceeded) {
+		t.Fatalf("expected the error to wrap template.ErrExpansionLimitExceeded, got: %v", err)
+	}
+}

--- a/internal/pipeline/component/trait/processor.go
+++ b/internal/pipeline/component/trait/processor.go
@@ -8,6 +8,7 @@
 package trait
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"maps"
@@ -19,9 +20,32 @@ import (
 	"github.com/openchoreo/openchoreo/internal/template"
 )
 
+// maxPatchOperations bounds the total number of rendered JSON Patch operations applied
+// across all target resources in one component render.
+//
+// forEach multiplies on both sides of a patch: a ComponentType can expand to hundreds of
+// resources, and a trait patch with its own forEach applies once per item to every matching
+// target, so items x targets grows as a product. That product is JSON-Patch work, not CEL
+// evaluation, so neither the per-expression cost limit nor the reconcile cost budget can see
+// it - each iteration renders the same cheap operations and then does unmetered work
+// proportional to the size of the resource it patches.
+//
+// The bound is per render because the counter lives on the Processor, which the component
+// pipeline builds fresh inside each Pipeline.Render call, so every trait on a component draws
+// from the same allowance. Real samples measure in the tens of operations; 10,000 leaves
+// two orders of magnitude of headroom while capping the cross product well below the
+// million-application shape a hostile pair of forEach expressions can otherwise reach.
+const maxPatchOperations uint64 = 10_000
+
 // Processor handles trait creates and patches.
+//
+// A Processor is scoped to one component render: the pipeline constructs one per
+// Pipeline.Render call, which is what makes patchOperations a per-render count.
+// It is not safe for concurrent use.
 type Processor struct {
 	templateEngine *template.Engine
+
+	patchOperations uint64
 }
 
 // TargetSpec describes how to locate a resource when applying patches.
@@ -42,23 +66,27 @@ func NewProcessor(templateEngine *template.Engine) *Processor {
 
 // ProcessTraits applies all traits to the base resources.
 //
-// For each trait:
+// For each trait, in order:
 //   - Apply creates (new resources with targetPlane)
 //   - Apply patches (modify existing resources, respecting targetPlane)
+//
+// Creates run first so a patch in the same trait can target a resource that trait
+// introduced.
 func (p *Processor) ProcessTraits(
+	ctx context.Context,
 	resources []renderer.RenderedResource,
 	trait *v1alpha1.Trait,
 	traitContext map[string]any,
 ) ([]renderer.RenderedResource, error) {
 	// Apply creates first
 	var err error
-	resources, err = p.ApplyTraitCreates(resources, trait, traitContext)
+	resources, err = p.ApplyTraitCreates(ctx, resources, trait, traitContext)
 	if err != nil {
 		return nil, err
 	}
 
 	// Then apply patches
-	err = p.ApplyTraitPatches(resources, trait, traitContext)
+	err = p.ApplyTraitPatches(ctx, resources, trait, traitContext)
 	if err != nil {
 		return nil, err
 	}
@@ -69,6 +97,7 @@ func (p *Processor) ProcessTraits(
 // ApplyTraitCreates renders and adds new resources from trait.spec.creates with targetPlane metadata.
 // Supports includeWhen for conditional creation and forEach for generating multiple resources.
 func (p *Processor) ApplyTraitCreates(
+	ctx context.Context,
 	resources []renderer.RenderedResource,
 	trait *v1alpha1.Trait,
 	traitContext map[string]any,
@@ -77,7 +106,7 @@ func (p *Processor) ApplyTraitCreates(
 		createPath := fmt.Sprintf("trait %s create #%d", trait.Name, i)
 
 		// Check includeWhen condition using shared helper
-		include, err := renderer.ShouldInclude(p.templateEngine, createTemplate.IncludeWhen, traitContext)
+		include, err := renderer.ShouldInclude(ctx, p.templateEngine, createTemplate.IncludeWhen, traitContext)
 		if err != nil {
 			return nil, fmt.Errorf("failed to evaluate includeWhen for %s: %w", createPath, err)
 		}
@@ -87,19 +116,19 @@ func (p *Processor) ApplyTraitCreates(
 
 		// Handle forEach or single render
 		if createTemplate.ForEach != "" {
-			itemContexts, err := renderer.EvalForEach(p.templateEngine, createTemplate.ForEach, createTemplate.Var, traitContext)
+			itemContexts, err := renderer.EvalForEach(ctx, p.templateEngine, createTemplate.ForEach, createTemplate.Var, traitContext)
 			if err != nil {
 				return nil, fmt.Errorf("failed to evaluate forEach for %s: %w", createPath, err)
 			}
 			for _, itemContext := range itemContexts {
-				rendered, err := p.renderSingleCreate(createTemplate, itemContext, createPath)
+				rendered, err := p.renderSingleCreate(ctx, createTemplate, itemContext, createPath)
 				if err != nil {
 					return nil, err
 				}
 				resources = append(resources, rendered)
 			}
 		} else {
-			rendered, err := p.renderSingleCreate(createTemplate, traitContext, createPath)
+			rendered, err := p.renderSingleCreate(ctx, createTemplate, traitContext, createPath)
 			if err != nil {
 				return nil, err
 			}
@@ -112,8 +141,9 @@ func (p *Processor) ApplyTraitCreates(
 
 // renderSingleCreate renders a single TraitCreate template and returns a RenderedResource.
 func (p *Processor) renderSingleCreate(
+	ctx context.Context,
 	create v1alpha1.TraitCreate,
-	context map[string]any,
+	celContext map[string]any,
 	path string,
 ) (renderer.RenderedResource, error) {
 	var templateData any
@@ -121,7 +151,7 @@ func (p *Processor) renderSingleCreate(
 		return renderer.RenderedResource{}, fmt.Errorf("failed to unmarshal create template for %s: %w", path, err)
 	}
 
-	rendered, err := p.templateEngine.Render(templateData, context)
+	rendered, err := p.templateEngine.Render(ctx, templateData, celContext)
 	if err != nil {
 		return renderer.RenderedResource{}, fmt.Errorf("failed to render create template for %s: %w", path, err)
 	}
@@ -157,12 +187,13 @@ func (p *Processor) renderSingleCreate(
 // The patch package itself only handles the low-level mechanics of applying
 // operations to a single resource.
 func (p *Processor) ApplyTraitPatches(
+	ctx context.Context,
 	resources []renderer.RenderedResource,
 	trait *v1alpha1.Trait,
 	traitContext map[string]any,
 ) error {
 	for i, traitPatch := range trait.Spec.Patches {
-		if err := p.applyPatch(resources, trait.Name, i, traitPatch, traitContext); err != nil {
+		if err := p.applyPatch(ctx, resources, trait.Name, i, traitPatch, traitContext); err != nil {
 			return fmt.Errorf("failed to apply trait patch #%d for trait %s: %w", i, trait.Name, err)
 		}
 	}
@@ -173,6 +204,7 @@ func (p *Processor) ApplyTraitPatches(
 // applyPatch applies a single patch specification to resources.
 // Handles forEach iteration, targeting, filtering, targetPlane matching, and CEL rendering.
 func (p *Processor) applyPatch(
+	ctx context.Context,
 	resources []renderer.RenderedResource,
 	traitName string,
 	patchIndex int,
@@ -181,16 +213,17 @@ func (p *Processor) applyPatch(
 ) error {
 	// Handle forEach iteration if specified
 	if traitPatch.ForEach != "" {
-		return p.applyPatchWithForEach(resources, traitName, patchIndex, traitPatch, baseContext)
+		return p.applyPatchWithForEach(ctx, resources, traitName, patchIndex, traitPatch, baseContext)
 	}
 
 	// No forEach - apply once with base context
-	return p.applyPatchOnce(resources, traitName, patchIndex, traitPatch, baseContext)
+	return p.applyPatchOnce(ctx, resources, traitName, patchIndex, traitPatch, baseContext)
 }
 
 // applyPatchWithForEach handles forEach iteration for a patch.
 // Supports both arrays and maps. For maps, items are {key, value} entries sorted by key.
 func (p *Processor) applyPatchWithForEach(
+	ctx context.Context,
 	resources []renderer.RenderedResource,
 	traitName string,
 	patchIndex int,
@@ -198,13 +231,13 @@ func (p *Processor) applyPatchWithForEach(
 	baseContext map[string]any,
 ) error {
 	// Evaluate the forEach expression to get the list of items
-	itemsRaw, err := p.templateEngine.Render(traitPatch.ForEach, baseContext)
+	itemsRaw, err := p.templateEngine.Render(ctx, traitPatch.ForEach, baseContext)
 	if err != nil {
-		return fmt.Errorf("failed to evaluate forEach expression '%s' for trait %s patch #%d: %w", traitPatch.ForEach, traitName, patchIndex, err)
+		return fmt.Errorf("failed to evaluate forEach expression '%s' for trait %s patch #%d: %w", template.TruncateFragment(traitPatch.ForEach), traitName, patchIndex, err)
 	}
 
 	// Convert result to iterable items (supports arrays and maps)
-	items, err := renderer.ToIterableItems(itemsRaw)
+	items, err := renderer.ToIterableItems(ctx, itemsRaw)
 	if err != nil {
 		return fmt.Errorf("invalid forEach result for trait %s patch #%d: %w", traitName, patchIndex, err)
 	}
@@ -226,7 +259,7 @@ func (p *Processor) applyPatchWithForEach(
 		iterContext[varName] = item
 
 		// Apply patch operations with this iteration's context
-		if err := p.applyPatchOnce(resources, traitName, patchIndex, traitPatch, iterContext); err != nil {
+		if err := p.applyPatchOnce(ctx, resources, traitName, patchIndex, traitPatch, iterContext); err != nil {
 			return fmt.Errorf("forEach iteration %d failed: %w", i, err)
 		}
 	}
@@ -237,11 +270,12 @@ func (p *Processor) applyPatchWithForEach(
 // applyPatchOnce applies a patch to all matching targets with a given context.
 // Respects targetPlane - only patches resources in the same plane.
 func (p *Processor) applyPatchOnce(
+	ctx context.Context,
 	resources []renderer.RenderedResource,
 	traitName string,
 	patchIndex int,
 	traitPatch v1alpha1.TraitPatch,
-	context map[string]any,
+	celContext map[string]any,
 ) error {
 	// Find target resources based on targetPlane and Kind/Group/Version
 	target := TargetSpec{
@@ -261,7 +295,7 @@ func (p *Processor) applyPatchOnce(
 	// Filter targets using where clause if specified
 	var targets []renderer.RenderedResource
 	if target.Where != "" {
-		filtered, err := p.filterTargets(matchedResources, target.Where, context, traitName, patchIndex)
+		filtered, err := p.filterTargets(ctx, matchedResources, target.Where, celContext, traitName, patchIndex)
 		if err != nil {
 			return err
 		}
@@ -271,20 +305,33 @@ func (p *Processor) applyPatchOnce(
 	}
 
 	// Render patch operations with CEL
-	renderedOps, err := p.renderOperations(traitPatch.Operations, context, traitName, patchIndex)
+	renderedOps, err := p.renderOperations(ctx, traitPatch.Operations, celContext, traitName, patchIndex)
 	if err != nil {
 		return err
+	}
+
+	// Every patch application in this render funnels through the loop below. Charge each
+	// operation for every target before applying the batch.
+	if err := p.chargePatchOperations(uint64(len(targets)), uint64(len(renderedOps))); err != nil {
+		return fmt.Errorf("trait %s patch #%d: %w", traitName, patchIndex, err)
 	}
 
 	// Apply rendered operations to each target using the simple patch function
 	// Note: patches modify the Resource field in-place
 	for _, rr := range targets {
+		// Applying a patch performs no CEL evaluation, so the engine's own cancellation
+		// checks never run here. The whole batch was charged up front, and without this
+		// check the remaining applications would run to completion after the reconcile
+		// was already cancelled.
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("trait %s patch #%d interrupted: %w", traitName, patchIndex, err)
+		}
 		if err := patch.ApplyPatches(rr.Resource, renderedOps); err != nil {
 			// Extract resource identity for better error message
 			kind, _ := rr.Resource["kind"].(string)
 			metadata, _ := rr.Resource["metadata"].(map[string]any)
 			name, _ := metadata["name"].(string)
-			resourceID := fmt.Sprintf("%s/%s", kind, name)
+			resourceID := fmt.Sprintf("%s/%s", template.TruncateFragment(kind), template.TruncateFragment(name))
 			if resourceID == "/" {
 				resourceID = "unknown resource"
 			}
@@ -295,9 +342,34 @@ func (p *Processor) applyPatchOnce(
 	return nil
 }
 
+// chargePatchOperations adds targets x operations to this render's running total.
+//
+// The error wraps template.ErrExpansionLimitExceeded because the count depends only on the
+// component's own shape - how many resources it renders and how many items its trait
+// patches iterate - so an unchanged object produces the same count on every reconcile.
+// The message names the total the batch would have reached and the cap; both are deterministic for
+// fixed inputs, so it is stable enough to sit in a status condition, and the total is what
+// tells an operator whether they are marginally or wildly over.
+func (p *Processor) chargePatchOperations(targets, operations uint64) error {
+	if targets == 0 || operations == 0 {
+		return nil
+	}
+
+	// Divide rather than multiply: targets x operations is compared against what is left,
+	// so the check itself cannot overflow the counter it is protecting.
+	remaining := maxPatchOperations - p.patchOperations
+	if targets > remaining/operations {
+		return fmt.Errorf("%w: trait patches would apply %d operations in one render, exceeding the limit of %d",
+			template.ErrExpansionLimitExceeded, p.patchOperations+targets*operations, maxPatchOperations)
+	}
+	p.patchOperations += targets * operations
+	return nil
+}
+
 // filterTargets filters resources based on a where clause.
 // The where clause is evaluated as a CEL expression with "resource" bound to each target's Resource field.
 func (p *Processor) filterTargets(
+	ctx context.Context,
 	targets []renderer.RenderedResource,
 	whereClause string,
 	baseContext map[string]any,
@@ -314,7 +386,7 @@ func (p *Processor) filterTargets(
 		baseContext["resource"] = rr.Resource
 
 		// Evaluate the where clause
-		result, err := p.templateEngine.Render(whereClause, baseContext)
+		result, err := p.templateEngine.Render(ctx, whereClause, baseContext)
 		if err != nil {
 			// Restore previous binding before returning error
 			if had {
@@ -322,7 +394,7 @@ func (p *Processor) filterTargets(
 			} else {
 				delete(baseContext, "resource")
 			}
-			return nil, fmt.Errorf("failed to evaluate where clause '%s' for trait %s patch #%d: %w", whereClause, traitName, patchIndex, err)
+			return nil, fmt.Errorf("failed to evaluate where clause '%s' for trait %s patch #%d: %w", template.TruncateFragment(whereClause), traitName, patchIndex, err)
 		}
 
 		// Check if result is boolean true
@@ -334,7 +406,7 @@ func (p *Processor) filterTargets(
 			} else {
 				delete(baseContext, "resource")
 			}
-			return nil, fmt.Errorf("where clause '%s' must evaluate to boolean for trait %s patch #%d, got %T", whereClause, traitName, patchIndex, result)
+			return nil, fmt.Errorf("where clause '%s' must evaluate to boolean for trait %s patch #%d, got %T", template.TruncateFragment(whereClause), traitName, patchIndex, result)
 		}
 
 		if boolResult {
@@ -355,8 +427,9 @@ func (p *Processor) filterTargets(
 // renderOperations renders all patch operations using CEL.
 // Both the path and value of each operation may contain ${...} expressions.
 func (p *Processor) renderOperations(
+	ctx context.Context,
 	operations []v1alpha1.JSONPatchOperation,
-	context map[string]any,
+	celContext map[string]any,
 	traitName string,
 	patchIndex int,
 ) ([]patch.JSONPatchOperation, error) {
@@ -364,7 +437,7 @@ func (p *Processor) renderOperations(
 
 	for i, op := range operations {
 		// Render the path (which may contain CEL expressions)
-		pathValue, err := p.templateEngine.Render(op.Path, context)
+		pathValue, err := p.templateEngine.Render(ctx, op.Path, celContext)
 		if err != nil {
 			return nil, fmt.Errorf("failed to render path '%s' for trait %s patch #%d operation #%d: %w", op.Path, traitName, patchIndex, i, err)
 		}
@@ -384,7 +457,7 @@ func (p *Processor) renderOperations(
 				}
 
 				// Render the value (which may contain CEL expressions)
-				value, err = p.templateEngine.Render(value, context)
+				value, err = p.templateEngine.Render(ctx, value, celContext)
 				if err != nil {
 					return nil, fmt.Errorf("failed to render value for trait %s patch #%d operation #%d: %w", traitName, patchIndex, i, err)
 				}

--- a/internal/pipeline/component/trait/processor_test.go
+++ b/internal/pipeline/component/trait/processor_test.go
@@ -432,7 +432,7 @@ spec:
 				t.Fatalf("Failed to parse expected resources YAML: %v", err)
 			}
 
-			got, err := processor.ApplyTraitCreates(baseResources, &trait, tt.context)
+			got, err := processor.ApplyTraitCreates(t.Context(), baseResources, &trait, tt.context)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ApplyTraitCreates() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1070,7 +1070,7 @@ spec:
 				t.Fatalf("Failed to parse expected resources YAML: %v", err)
 			}
 
-			err := processor.ApplyTraitPatches(resources, &trait, tt.context)
+			err := processor.ApplyTraitPatches(t.Context(), resources, &trait, tt.context)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ApplyTraitPatches() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1169,7 +1169,7 @@ spec:
 				t.Fatalf("Failed to parse expected resources YAML: %v", err)
 			}
 
-			got, err := processor.ProcessTraits(resources, &trait, tt.context)
+			got, err := processor.ProcessTraits(t.Context(), resources, &trait, tt.context)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ProcessTraits() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -1392,7 +1392,7 @@ spec:
 		},
 	}
 
-	got, err := processor.ApplyTraitCreates(nil, &trait, ctx)
+	got, err := processor.ApplyTraitCreates(t.Context(), nil, &trait, ctx)
 	require.NoError(t, err)
 	assert.Len(t, got, 3)
 
@@ -1432,7 +1432,7 @@ spec:
 
 	ctx := map[string]any{}
 
-	_, err := processor.ApplyTraitCreates(nil, &trait, ctx)
+	_, err := processor.ApplyTraitCreates(t.Context(), nil, &trait, ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forEach")
 }
@@ -1459,7 +1459,7 @@ spec:
 
 	ctx := map[string]any{}
 
-	_, err := processor.ApplyTraitCreates(nil, &trait, ctx)
+	_, err := processor.ApplyTraitCreates(t.Context(), nil, &trait, ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "render")
 }
@@ -1493,7 +1493,7 @@ spec:
 
 	ctx := map[string]any{}
 
-	got, err := processor.ApplyTraitCreates(nil, &trait, ctx)
+	got, err := processor.ApplyTraitCreates(t.Context(), nil, &trait, ctx)
 	require.NoError(t, err)
 	require.Len(t, got, 2)
 
@@ -1548,7 +1548,7 @@ spec:
 		},
 	}
 
-	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	err := processor.ApplyTraitPatches(t.Context(), resources, &trait, ctx)
 	require.NoError(t, err)
 
 	labels := resources[0].Resource["metadata"].(map[string]any)["labels"].(map[string]any)
@@ -1588,7 +1588,7 @@ spec:
 
 	ctx := map[string]any{}
 
-	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	err := processor.ApplyTraitPatches(t.Context(), resources, &trait, ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "forEach")
 }
@@ -1644,7 +1644,7 @@ spec:
 
 	ctx := map[string]any{}
 
-	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	err := processor.ApplyTraitPatches(t.Context(), resources, &trait, ctx)
 	require.NoError(t, err)
 
 	// "web" and "admin" should have annotations, "api" should not
@@ -1690,7 +1690,7 @@ spec:
 
 	ctx := map[string]any{}
 
-	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	err := processor.ApplyTraitPatches(t.Context(), resources, &trait, ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "where clause")
 }
@@ -1734,7 +1734,7 @@ spec:
 
 	ctx := map[string]any{}
 
-	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	err := processor.ApplyTraitPatches(t.Context(), resources, &trait, ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "boolean")
 }
@@ -1782,7 +1782,7 @@ spec:
 
 	ctx := map[string]any{}
 
-	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	err := processor.ApplyTraitPatches(t.Context(), resources, &trait, ctx)
 	require.NoError(t, err)
 
 	// Resource must be completely unmodified
@@ -1834,7 +1834,7 @@ spec:
 		"resource": existingResourceValue,
 	}
 
-	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	err := processor.ApplyTraitPatches(t.Context(), resources, &trait, ctx)
 	require.NoError(t, err)
 
 	// Verify the original "resource" binding is preserved/restored after filtering
@@ -1879,7 +1879,7 @@ spec:
 
 	before := deepCopy(resources[0].Resource)
 
-	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	err := processor.ApplyTraitPatches(t.Context(), resources, &trait, ctx)
 	require.NoError(t, err, "patching with no matching resources should be a no-op")
 
 	if diff := cmp.Diff(before, resources[0].Resource); diff != "" {
@@ -1923,7 +1923,7 @@ spec:
 
 	ctx := map[string]any{}
 
-	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	err := processor.ApplyTraitPatches(t.Context(), resources, &trait, ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Deployment/my-deploy")
 }
@@ -1959,7 +1959,7 @@ spec:
 
 	ctx := map[string]any{}
 
-	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	err := processor.ApplyTraitPatches(t.Context(), resources, &trait, ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "path")
 }
@@ -1999,7 +1999,7 @@ spec:
 		},
 	}
 
-	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	err := processor.ApplyTraitPatches(t.Context(), resources, &trait, ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "string")
 }
@@ -2035,7 +2035,7 @@ func TestRenderOperations_ValueUnmarshalError(t *testing.T) {
 
 	ctx := map[string]any{}
 
-	err := processor.ApplyTraitPatches(resources, &trait, ctx)
+	err := processor.ApplyTraitPatches(t.Context(), resources, &trait, ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unmarshal")
 }
@@ -2074,7 +2074,7 @@ func TestRenderOperations_ValueRenderError(t *testing.T) {
 
 	ctx := map[string]any{}
 
-	err = processor.ApplyTraitPatches(resources, &trait, ctx)
+	err = processor.ApplyTraitPatches(t.Context(), resources, &trait, ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "render value")
 }
@@ -2107,7 +2107,7 @@ spec:
 
 	ctx := map[string]any{}
 
-	_, err := processor.ProcessTraits(resources, &trait, ctx)
+	_, err := processor.ProcessTraits(t.Context(), resources, &trait, ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "render")
 }
@@ -2143,7 +2143,7 @@ spec:
 
 	ctx := map[string]any{}
 
-	_, err := processor.ProcessTraits(resources, &trait, ctx)
+	_, err := processor.ProcessTraits(t.Context(), resources, &trait, ctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "path")
 }

--- a/internal/pipeline/component/types.go
+++ b/internal/pipeline/component/types.go
@@ -15,6 +15,10 @@ import (
 // to generate fully resolved Kubernetes resource manifests.
 type Pipeline struct {
 	templateEngine *template.Engine
+
+	// celCostLimit bounds the accumulated cost of a single CEL expression.
+	// Zero selects the template engine's built-in default.
+	celCostLimit uint64
 }
 
 // RenderInput contains all inputs needed to render a component's resources.

--- a/internal/pipeline/workflow/pipeline.go
+++ b/internal/pipeline/workflow/pipeline.go
@@ -5,6 +5,7 @@
 package workflowpipeline
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -19,16 +20,37 @@ import (
 	"github.com/openchoreo/openchoreo/internal/template"
 )
 
-// NewPipeline creates a new workflow rendering pipeline.
-func NewPipeline() *Pipeline {
-	return &Pipeline{
-		templateEngine: template.NewEngine(),
+// Option is a function that configures a Pipeline.
+type Option func(*Pipeline)
+
+// WithCostLimit sets the maximum accumulated cost for a single CEL expression
+// evaluated by this pipeline's template engine. Zero selects the engine's
+// built-in safe default; it never means unlimited.
+func WithCostLimit(limit uint64) Option {
+	return func(p *Pipeline) {
+		p.celCostLimit = limit
 	}
+}
+
+// NewPipeline creates a new workflow rendering pipeline.
+func NewPipeline(opts ...Option) *Pipeline {
+	p := &Pipeline{}
+	for _, opt := range opts {
+		opt(p)
+	}
+	// Guarded so a future engine-injecting Option (as the component pipeline has for
+	// benchmarking) is not silently overwritten here.
+	if p.templateEngine == nil {
+		p.templateEngine = template.NewEngineWithOptions(
+			template.WithCostLimit(p.celCostLimit),
+		)
+	}
+	return p
 }
 
 // Render orchestrates the complete workflow rendering process.
 // It validates input, builds CEL context, renders the template, and validates output.
-func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
+func (p *Pipeline) Render(ctx context.Context, input *RenderInput) (*RenderOutput, error) {
 	if err := p.validateInput(input); err != nil {
 		return nil, fmt.Errorf("invalid input: %w", err)
 	}
@@ -42,7 +64,7 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 		return nil, fmt.Errorf("failed to build CEL context: %w", err)
 	}
 
-	resource, err := p.renderTemplate(input.Workflow.Spec.RunTemplate, celContext)
+	resource, err := p.renderTemplate(ctx, input.Workflow.Spec.RunTemplate, celContext)
 	if err != nil {
 		return nil, fmt.Errorf("failed to render template: %w", err)
 	}
@@ -52,7 +74,7 @@ func (p *Pipeline) Render(input *RenderInput) (*RenderOutput, error) {
 	}
 
 	// Render additional resources if defined
-	resources, err := p.renderResources(input.Workflow.Spec.Resources, celContext)
+	resources, err := p.renderResources(ctx, input.Workflow.Spec.Resources, celContext)
 	if err != nil {
 		return nil, fmt.Errorf("failed to render resources: %w", err)
 	}
@@ -90,13 +112,17 @@ func (p *Pipeline) validateInput(input *RenderInput) error {
 }
 
 // renderTemplate renders the workflow template with CEL context and post-processes the result.
-func (p *Pipeline) renderTemplate(tmpl *runtime.RawExtension, celContext map[string]any) (map[string]any, error) {
+func (p *Pipeline) renderTemplate(
+	ctx context.Context,
+	tmpl *runtime.RawExtension,
+	celContext map[string]any,
+) (map[string]any, error) {
 	templateData, err := rawExtensionToMap(tmpl)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse runTemplate: %w", err)
 	}
 
-	rendered, err := p.templateEngine.Render(templateData, celContext)
+	rendered, err := p.templateEngine.Render(ctx, templateData, celContext)
 	if err != nil {
 		return nil, fmt.Errorf("failed to render workflow resource: %w", err)
 	}
@@ -117,7 +143,11 @@ func (p *Pipeline) renderTemplate(tmpl *runtime.RawExtension, celContext map[str
 // All rendered resources are forced into the enforced workflow namespace (metadata.namespace)
 // regardless of what the template specifies. This prevents workflow authors from deploying
 // resources into arbitrary namespaces.
-func (p *Pipeline) renderResources(resources []v1alpha1.WorkflowResource, celContext map[string]any) ([]RenderedResource, error) {
+func (p *Pipeline) renderResources(
+	ctx context.Context,
+	resources []v1alpha1.WorkflowResource,
+	celContext map[string]any,
+) ([]RenderedResource, error) {
 	if len(resources) == 0 {
 		return nil, nil
 	}
@@ -130,7 +160,7 @@ func (p *Pipeline) renderResources(resources []v1alpha1.WorkflowResource, celCon
 	renderedResources := make([]RenderedResource, 0, len(resources))
 	for _, res := range resources {
 		// Check if resource should be included based on includeWhen condition
-		include, err := p.shouldIncludeResource(res.IncludeWhen, celContext)
+		include, err := p.shouldIncludeResource(ctx, res.IncludeWhen, celContext)
 		if err != nil {
 			return nil, fmt.Errorf("failed to evaluate includeWhen for resource %q: %w", res.ID, err)
 		}
@@ -138,7 +168,7 @@ func (p *Pipeline) renderResources(resources []v1alpha1.WorkflowResource, celCon
 			continue
 		}
 
-		rendered, err := p.renderTemplate(res.Template, celContext)
+		rendered, err := p.renderTemplate(ctx, res.Template, celContext)
 		if err != nil {
 			return nil, fmt.Errorf("failed to render resource %q: %w", res.ID, err)
 		}
@@ -167,12 +197,12 @@ func (p *Pipeline) renderResources(resources []v1alpha1.WorkflowResource, celCon
 
 // shouldIncludeResource evaluates the includeWhen expression to determine if a resource should be rendered.
 // Returns true if includeWhen is empty (default behavior - resource is always created).
-func (p *Pipeline) shouldIncludeResource(includeWhen string, context map[string]any) (bool, error) {
+func (p *Pipeline) shouldIncludeResource(ctx context.Context, includeWhen string, celContext map[string]any) (bool, error) {
 	if includeWhen == "" {
 		return true, nil
 	}
 
-	result, err := p.templateEngine.Render(includeWhen, context)
+	result, err := p.templateEngine.Render(ctx, includeWhen, celContext)
 	if err != nil {
 		return false, err
 	}

--- a/internal/pipeline/workflow/pipeline_test.go
+++ b/internal/pipeline/workflow/pipeline_test.go
@@ -209,7 +209,7 @@ func TestPipeline_Render(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := NewPipeline()
-			output, err := p.Render(tt.input)
+			output, err := p.Render(t.Context(), tt.input)
 
 			if tt.wantErr {
 				if err == nil {
@@ -736,7 +736,7 @@ func TestPipeline_Render_SchemaWithDefaults(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := NewPipeline()
-			output, err := p.Render(tt.input)
+			output, err := p.Render(t.Context(), tt.input)
 
 			if tt.wantErr {
 				if err == nil {
@@ -953,7 +953,7 @@ func TestPipeline_Render_ComplexParameters(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := NewPipeline()
-			output, err := p.Render(tt.input)
+			output, err := p.Render(t.Context(), tt.input)
 
 			if tt.wantErr {
 				if err == nil {
@@ -1102,7 +1102,7 @@ func TestPipeline_Render_CELContextVariables(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := NewPipeline()
-			output, err := p.Render(tt.input)
+			output, err := p.Render(t.Context(), tt.input)
 
 			if tt.wantErr {
 				if err == nil {
@@ -1174,7 +1174,7 @@ func TestPipeline_Render_ExternalRefVariables(t *testing.T) {
 			},
 		}
 
-		output, err := NewPipeline().Render(input)
+		output, err := NewPipeline().Render(t.Context(), input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1240,7 +1240,7 @@ func TestPipeline_Render_ExternalRefVariables(t *testing.T) {
 			},
 		}
 
-		output, err := NewPipeline().Render(input)
+		output, err := NewPipeline().Render(t.Context(), input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1290,7 +1290,7 @@ func TestPipeline_Render_ExternalRefVariables(t *testing.T) {
 			},
 		}
 
-		output, err := NewPipeline().Render(input)
+		output, err := NewPipeline().Render(t.Context(), input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1331,7 +1331,7 @@ func TestPipeline_Render_ExternalRefVariables(t *testing.T) {
 			},
 		}
 
-		output, err := NewPipeline().Render(input)
+		output, err := NewPipeline().Render(t.Context(), input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1376,7 +1376,7 @@ func TestPipeline_Render_WorkflowPlaneVariables(t *testing.T) {
 			},
 		}
 
-		output, err := NewPipeline().Render(input)
+		output, err := NewPipeline().Render(t.Context(), input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1417,7 +1417,7 @@ func TestPipeline_Render_WorkflowPlaneVariables(t *testing.T) {
 			},
 		}
 
-		output, err := NewPipeline().Render(input)
+		output, err := NewPipeline().Render(t.Context(), input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1512,7 +1512,7 @@ func TestPipeline_Render_EdgeCases(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := NewPipeline()
-			_, err := p.Render(tt.input)
+			_, err := p.Render(t.Context(), tt.input)
 
 			if tt.wantErr {
 				if err == nil {
@@ -1606,7 +1606,7 @@ func TestPipeline_Render_DifferentResourceTypes(t *testing.T) {
 			}
 
 			p := NewPipeline()
-			output, err := p.Render(input)
+			output, err := p.Render(t.Context(), input)
 
 			if tt.wantErr {
 				if err == nil {
@@ -1685,7 +1685,7 @@ func TestPipeline_Render_ResourceNamespaceEnforcement(t *testing.T) {
 		})
 
 		p := NewPipeline()
-		output, err := p.Render(input)
+		output, err := p.Render(t.Context(), input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1716,7 +1716,7 @@ func TestPipeline_Render_ResourceNamespaceEnforcement(t *testing.T) {
 		})
 
 		p := NewPipeline()
-		output, err := p.Render(input)
+		output, err := p.Render(t.Context(), input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1746,7 +1746,7 @@ func TestPipeline_Render_ResourceNamespaceEnforcement(t *testing.T) {
 		})
 
 		p := NewPipeline()
-		output, err := p.Render(input)
+		output, err := p.Render(t.Context(), input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1788,7 +1788,7 @@ func TestPipeline_Render_ResourceNamespaceEnforcement(t *testing.T) {
 		})
 
 		p := NewPipeline()
-		output, err := p.Render(input)
+		output, err := p.Render(t.Context(), input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1889,7 +1889,7 @@ func TestPipeline_Render_OpenAPIV3Schema_Defaults(t *testing.T) {
 		}
 
 		p := NewPipeline()
-		output, err := p.Render(input)
+		output, err := p.Render(t.Context(), input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1980,7 +1980,7 @@ func TestPipeline_Render_OpenAPIV3Schema_Defaults(t *testing.T) {
 		}
 
 		p := NewPipeline()
-		output, err := p.Render(input)
+		output, err := p.Render(t.Context(), input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -2054,7 +2054,7 @@ func TestPipeline_Render_OpenAPIV3Schema_Defaults(t *testing.T) {
 		}
 
 		p := NewPipeline()
-		output, err := p.Render(input)
+		output, err := p.Render(t.Context(), input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -2121,7 +2121,7 @@ func TestPipeline_Render_OpenAPIV3Schema_Defaults(t *testing.T) {
 		}
 
 		p := NewPipeline()
-		output, err := p.Render(input)
+		output, err := p.Render(t.Context(), input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -2172,7 +2172,7 @@ func TestPipeline_Render_OpenAPIV3Schema_Defaults(t *testing.T) {
 		}
 
 		p := NewPipeline()
-		output, err := p.Render(input)
+		output, err := p.Render(t.Context(), input)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/internal/pipeline/workflow/types.go
+++ b/internal/pipeline/workflow/types.go
@@ -12,6 +12,10 @@ import (
 // Workflow to generate fully resolved resources (e.g., Argo Workflow).
 type Pipeline struct {
 	templateEngine *template.Engine
+
+	// celCostLimit bounds the accumulated cost of a single CEL expression.
+	// Zero selects the template engine's built-in default.
+	celCostLimit uint64
 }
 
 // RenderInput contains all required inputs for workflow rendering.

--- a/internal/template/budget.go
+++ b/internal/template/budget.go
@@ -1,0 +1,155 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package template
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync"
+)
+
+// CostBudget accumulates the CEL evaluation cost spent across every Render that shares it.
+// The per-expression cost limit bounds one expression; the budget bounds the whole unit of
+// work, so a template cannot escape the guard by splitting hostile work across many cheap
+// expressions. A reconciler seeds one budget per reconcile and carries it on the context;
+// callers that do not, get a per-Render fallback budget.
+//
+// The mutex makes a budget safe to share, but sharing one across renders that run at the
+// same time would break the bound on how far past the budget a render can go. A budget can
+// only be charged once cel-go reports what an evaluation cost, so admission is a pre-check
+// (see exceeded) followed by a separate charge (see add): concurrent renders could all pass
+// the check and each spend up to a full per-expression limit before any charge lands. The
+// bound holds because rendering is sequential — the pipeline is CPU bound and starts no
+// goroutines. Rendering in parallel under one budget would first need the allowance reserved
+// under the lock before evaluation and reconciled against the actual cost afterwards.
+type CostBudget struct {
+	mu     sync.Mutex
+	spent  uint64
+	budget uint64
+}
+
+// NewCostBudget creates a budget allowing the given total cost. A zero budget is unbounded,
+// which is only appropriate for tests that use it as a meter rather than a guard.
+func NewCostBudget(budget uint64) *CostBudget {
+	return &CostBudget{budget: budget}
+}
+
+// Spent reports the cost charged to the budget so far.
+func (b *CostBudget) Spent() uint64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.spent
+}
+
+// Budget reports the total cost this budget allows. Zero means unbounded.
+func (b *CostBudget) Budget() uint64 {
+	return b.budget
+}
+
+// add charges cost against the budget and reports whether that exhausted it. The cost is
+// always recorded, even when the caller goes on to surface a different error, so that a
+// failed evaluation still counts against the unit of work that provoked it.
+//
+// The breach message names the configured budget but deliberately NOT the amount spent.
+// Reconcilers put this text in a status condition, so it has to be identical on every
+// reconcile of an unchanged object: a message that drifts rewrites the condition, and each
+// rewrite is a watch event that re-triggers the reconcile, defeating the slow requeue meant
+// to pace a terminal failure. The budget is a constant, but the spend at the moment of the
+// breach is not — one budget funds every render of a whole reconcile, so the total at the
+// instant it tips over depends on cluster state the object's own spec does not fix. It is
+// therefore not surfaced at all; a caller that wants it can read Spent() off its own budget.
+func (b *CostBudget) add(cost uint64) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	// Saturate rather than wrap. A single charge can already be near MaxUint64 - the
+	// custom-function estimator combines its own costs with saturatingAdd - and a wrapped
+	// total would read as a small spend, reopening an allowance that is in fact exhausted.
+	if cost > math.MaxUint64-b.spent {
+		b.spent = math.MaxUint64
+		// Overflow proves the true spend exceeds any representable budget, so report the
+		// breach directly: on a budget of exactly MaxUint64 the saturated value would
+		// otherwise read as an exact fit.
+		if b.budget > 0 {
+			return b.breachError()
+		}
+		return nil
+	}
+	b.spent += cost
+	return b.breachLocked()
+}
+
+// exceeded reports the breach error when the budget is already spent, charging nothing.
+// The budget can only be charged after an evaluation returns, so a caller that goes on to
+// evaluate again needs a way to ask first; see the check at the top of evaluateCEL.
+//
+// It refuses on an exactly-spent budget, where add does not, and the asymmetry is the point.
+// add answers "did this charge overspend the allowance?", and a render that lands exactly on
+// the budget has stayed within it - failing it would turn a legitimate render into an error
+// over the last unit it was entitled to. exceeded answers a different question: "is there
+// anything left to fund the next evaluation?" On an exactly-spent budget there is not, and
+// letting it start anyway hands it up to a full per-expression cost limit before the charge
+// that follows can stop it - the unbounded overshoot this pre-check exists to prevent.
+func (b *CostBudget) exceeded() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.budget > 0 && b.spent >= b.budget {
+		return b.breachError()
+	}
+	return nil
+}
+
+// breachLocked reports the breach error if the allowance is overspent. The caller holds b.mu.
+func (b *CostBudget) breachLocked() error {
+	if b.budget > 0 && b.spent > b.budget {
+		return b.breachError()
+	}
+	return nil
+}
+
+func (b *CostBudget) breachError() error {
+	return fmt.Errorf("%w (budget %d)", ErrCostBudgetExceeded, b.budget)
+}
+
+// reconcileBudget returns the cumulative render budget for one reconcile, given the
+// per-expression cost limit the reconciler was configured with. A zero limit resolves to
+// the same built-in default the engine applies, so a reconciler that leaves the limit
+// unset still gets a budget consistent with the engine's own bound.
+//
+// It is unexported so the sizing arithmetic stays beside renderBudgetFactor: callers seed
+// a budget through WithReconcileBudget and never handle the number themselves.
+func reconcileBudget(costLimit uint64) uint64 {
+	if costLimit == 0 {
+		costLimit = defaultCELCostLimit
+	}
+	return costLimit * renderBudgetFactor
+}
+
+type budgetKey struct{}
+
+// WithCostBudget attaches a cost budget to the context so every Render performed under it
+// draws from the same pool.
+func WithCostBudget(ctx context.Context, b *CostBudget) context.Context {
+	return context.WithValue(ctx, budgetKey{}, b)
+}
+
+// WithReconcileBudget returns a context carrying a fresh cost budget sized for one
+// reconcile, derived from the reconciler's configured per-expression cost limit (zero
+// selects the built-in default). Every Render performed under the returned context draws
+// from the same pool, so work split across many expressions is bounded in total.
+//
+// The budget is a plain context value with no deadline: attaching it does not affect the
+// API calls a reconcile interleaves with rendering. Cancellation comes from the reconcile context,
+// which each render entry point applies to itself.
+func WithReconcileBudget(ctx context.Context, costLimit uint64) context.Context {
+	return WithCostBudget(ctx, NewCostBudget(reconcileBudget(costLimit)))
+}
+
+// CostBudgetFrom returns the budget carried by the context, or nil when there is none.
+// Reconcilers use it to report the spend behind a render failure without threading the
+// budget through every call: the context already carries it to the same places.
+func CostBudgetFrom(ctx context.Context) *CostBudget {
+	b, _ := ctx.Value(budgetKey{}).(*CostBudget)
+	return b
+}

--- a/internal/template/budget_test.go
+++ b/internal/template/budget_test.go
@@ -1,0 +1,491 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package template
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"testing"
+	"time"
+)
+
+// heavyExpr costs ~10,733 units: cheap enough to pass any realistic per-expression limit,
+// expensive enough that a handful of them exhaust a budget.
+//
+// It folds over the range rather than merely sizing it. That was originally load-bearing:
+// cel-go v0.22.1 ships no runtime tracker for lists.range, so a bare size(lists.range(n))
+// measured two units whatever n was, and only comprehension iteration tracked the work done.
+// The trackers in ext_overload_costs.go now charge the range by its length as well, so the
+// fold is no longer the only thing being metered here - but it stays, because iteration is
+// the shape the advisory is about and this fixture is what pins its price.
+var heavyExpr = fmt.Sprintf("${size(lists.range(%d).map(i, i + 1))}", 714)
+
+// heavyExprCost is the measured cost of heavyExpr. Tests size their budgets from it so a
+// change to the CEL cost model surfaces as a clear failure here rather than a flaky one.
+// 724 of it - the range's length plus cel-go's base cost for allocating a list - is charged by
+// the ext-overload trackers and was invisible before them.
+const heavyExprCost uint64 = 10_733
+
+// comprehensionExpr runs 5,000 fold iterations - well above interruptCheckFrequency, so a
+// cancelled context interrupts it, and well under the default cost limit, so the interrupt
+// is the only thing that can stop it. A bare builtin like lists.range is atomic and would
+// never observe the cancellation.
+const comprehensionExpr = "${size(lists.range(5000).map(i, i + 1))}"
+
+// expensiveFailureExpr burns real cost and then fails for a reason of its own: the
+// comprehension runs to completion before the index lookup is refused. That combination is
+// what makes the budget's post-hoc charging insufficient on its own — the evaluation is
+// paid for, but the error the caller sees names the index, not the overspend.
+const expensiveFailureExpr = "${lists.range(9000).map(i, i + 1)[999999]}"
+
+// expensiveFailureCost is the measured cost of expensiveFailureExpr, used to size a budget
+// that one such evaluation overshoots. Re-derived with the ext-overload trackers in place:
+// 126,014 of it is the comprehension, the remaining 9,010 the range they added.
+const expensiveFailureCost uint64 = 135_024
+
+func emptyInputs() map[string]any {
+	return map[string]any{"spec": map[string]any{}}
+}
+
+// watchdogTimeout is generous enough to survive the ~10x slowdown of a -race build while
+// still failing long before the go test timeout.
+const watchdogTimeout = 30 * time.Second
+
+// withWatchdog fails the test rather than hanging CI when a guard stops working and an
+// evaluation runs away.
+func withWatchdog(t *testing.T, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(watchdogTimeout):
+		t.Fatalf("render did not return within %s: the cost/cancellation guard is not stopping evaluation", watchdogTimeout)
+	}
+}
+
+// A budget on the context is shared by every Render made under it, so a template cannot
+// evade the per-expression limit by spreading hostile work over many cheap renders.
+func TestCostBudgetAccumulatesAcrossRenders(t *testing.T) {
+	// Room for two heavy expressions but not three.
+	budget := NewCostBudget(heavyExprCost * 5 / 2)
+	ctx := WithCostBudget(t.Context(), budget)
+	e := NewEngine()
+
+	if _, err := e.Render(ctx, heavyExpr, emptyInputs()); err != nil {
+		t.Fatalf("first render must succeed: %v", err)
+	}
+	if _, err := e.Render(ctx, heavyExpr, emptyInputs()); err != nil {
+		t.Fatalf("second render must succeed: %v", err)
+	}
+
+	_, err := e.Render(ctx, heavyExpr, emptyInputs())
+	if !errors.Is(err, ErrCostBudgetExceeded) {
+		t.Fatalf("third render must exhaust the shared budget, got: %v", err)
+	}
+	// The per-expression limit is untouched: only the accumulation trips.
+	if errors.Is(err, ErrCostLimitExceeded) {
+		t.Fatalf("expected a budget breach, not a per-expression cost-limit breach: %v", err)
+	}
+	if spent := budget.Spent(); spent <= budget.budget {
+		t.Fatalf("expected the budget to record an overspend, got spent=%d budget=%d", spent, budget.budget)
+	}
+}
+
+// A fresh context means a fresh budget: budgets are scoped to their carrier, not global.
+func TestCostBudgetIsScopedToItsContext(t *testing.T) {
+	e := NewEngine()
+	exhausted := WithCostBudget(t.Context(), NewCostBudget(1))
+	if _, err := e.Render(exhausted, heavyExpr, emptyInputs()); !errors.Is(err, ErrCostBudgetExceeded) {
+		t.Fatalf("expected the tiny budget to trip, got: %v", err)
+	}
+	if _, err := e.Render(t.Context(), heavyExpr, emptyInputs()); err != nil {
+		t.Fatalf("a render on a budget-free context must not inherit the exhausted budget: %v", err)
+	}
+}
+
+// Callers that supply no budget still get one: a single Render is bounded by
+// costLimit x renderBudgetFactor, so many individually-legal expressions in one template
+// cannot add up to unbounded work.
+func TestRenderFallbackBudgetBoundsASingleRender(t *testing.T) {
+	const limit uint64 = 50_000
+	e := NewEngineWithOptions(WithCostLimit(limit))
+	if got := e.renderBudgetDefault(); got != limit*renderBudgetFactor {
+		t.Fatalf("expected fallback budget %d, got %d", limit*renderBudgetFactor, got)
+	}
+
+	// Six heavy values total ~60k against a 50k budget, while each one stays under the
+	// 50k per-expression limit - only the accumulation can fail this render.
+	data := make(map[string]any, 6)
+	for i := range 6 {
+		data[fmt.Sprintf("field%d", i)] = heavyExpr
+	}
+
+	var err error
+	withWatchdog(t, func() {
+		_, err = e.Render(t.Context(), data, emptyInputs())
+	})
+	if !errors.Is(err, ErrCostBudgetExceeded) {
+		t.Fatalf("expected the per-Render fallback budget to bound the render, got: %v", err)
+	}
+	if errors.Is(err, ErrCostLimitExceeded) {
+		t.Fatalf("no single expression exceeds the limit; expected a budget breach, got: %v", err)
+	}
+}
+
+// A budget breach message must be byte-identical across renders of the same template.
+// Reconcilers put it in a status condition, so a message that varies rewrites the condition
+// every reconcile, and each rewrite is a watch event that re-triggers the reconcile —
+// defeating the slow requeue that paces a terminal failure.
+//
+// Two things used to make it vary, and the fixture is built to catch both: the spend at the
+// moment of the breach (dropped from the message), and which expression is named, which
+// followed Go's randomized map iteration until the render walk was ordered. The expressions
+// here are DISTINCT and each cheap enough to pass the per-expression limit, so only their
+// accumulation trips the budget and any one of them could plausibly be the one named. A
+// fixture using one repeated expression would pass no matter how the walk is ordered.
+func TestBudgetBreachMessageIsDeterministic(t *testing.T) {
+	render := func() string {
+		t.Helper()
+		e := NewEngine()
+		ctx := WithCostBudget(t.Context(), NewCostBudget(heavyExprCost*5/2))
+		data := make(map[string]any, 6)
+		for i := range 6 {
+			data[fmt.Sprintf("field%d", i)] = fmt.Sprintf("${size(lists.range(%d).map(x, x + 1))}", 714-i)
+		}
+		_, err := e.Render(ctx, data, emptyInputs())
+		if !errors.Is(err, ErrCostBudgetExceeded) {
+			t.Fatalf("expected the accumulated cost to exhaust the budget, got: %v", err)
+		}
+		return err.Error()
+	}
+
+	first := render()
+	for range 30 {
+		if got := render(); got != first {
+			t.Fatalf("budget breach message is not deterministic:\n first: %s\n  then: %s", first, got)
+		}
+	}
+}
+
+// Dynamic map keys are evaluated CEL like any other expression, so they must be charged too.
+// A key-only charge point is easy to miss when threading the budget through the walk.
+func TestDynamicMapKeysChargeTheBudget(t *testing.T) {
+	e := NewEngine()
+	ctx := WithCostBudget(t.Context(), NewCostBudget(100))
+	data := map[string]any{
+		fmt.Sprintf("${'key' + string(size(lists.range(%d).map(x, x + 1)))}", 100): "value",
+	}
+
+	_, err := e.Render(ctx, data, emptyInputs())
+	if !errors.Is(err, ErrCostBudgetExceeded) {
+		t.Fatalf("expected a dynamic map key to be charged against the budget, got: %v", err)
+	}
+}
+
+// An exhausted budget must not be masked when the expression also fails: the underlying
+// failure is reported, and the spend is still recorded so the next expression trips.
+func TestCostLimitBreachTakesPrecedenceOverBudget(t *testing.T) {
+	// A limit and a budget of the same size is the worst case for masking: with
+	// renderBudgetFactor at 1 every per-expression breach is also a budget breach, so the
+	// two errors compete on exactly the expression an operator most needs named.
+	const limit uint64 = 50_000
+	e := NewEngineWithOptions(WithCostLimit(limit))
+	budget := NewCostBudget(limit)
+	ctx := WithCostBudget(t.Context(), budget)
+
+	var err error
+	withWatchdog(t, func() {
+		_, err = e.Render(ctx, comprehensionExpr, emptyInputs())
+	})
+	if !errors.Is(err, ErrCostLimitExceeded) {
+		t.Fatalf("a per-expression breach must surface as ErrCostLimitExceeded, got: %v", err)
+	}
+	if spent := budget.Spent(); spent == 0 {
+		t.Fatal("the cost burned by a failed evaluation must still be charged to the budget")
+	}
+	// The spend was recorded, so the next expression on the same context trips the budget.
+	if _, err := e.Render(ctx, "${spec}", emptyInputs()); !errors.Is(err, ErrCostBudgetExceeded) {
+		t.Fatalf("expected the recorded overspend to trip the next render, got: %v", err)
+	}
+}
+
+// oc_omit() returns the sentinel through the error path, so it is the one success path that
+// could swallow a budget breach and let a template keep rendering past its allowance.
+func TestOmitDoesNotSwallowABudgetBreach(t *testing.T) {
+	e := NewEngine()
+	ctx := WithCostBudget(t.Context(), NewCostBudget(1))
+
+	if _, err := e.Render(ctx, heavyExpr, emptyInputs()); !errors.Is(err, ErrCostBudgetExceeded) {
+		t.Fatalf("expected the heavy expression to exhaust the budget, got: %v", err)
+	}
+
+	got, err := e.Render(ctx, "${oc_omit()}", emptyInputs())
+	if !errors.Is(err, ErrCostBudgetExceeded) {
+		t.Fatalf("omit must surface the exhausted budget rather than the sentinel, got=%v err=%v", got, err)
+	}
+}
+
+// A cancelled reconcile must stop evaluation rather than run the comprehension to completion,
+// and the error must classify as context.Canceled for the caller.
+func TestRenderStopsOnCancelledContext(t *testing.T) {
+	e := NewEngine()
+
+	// Control: the same expression completes normally, so a failure below is the
+	// cancellation and not a broken expression.
+	if _, err := e.Render(t.Context(), comprehensionExpr, emptyInputs()); err != nil {
+		t.Fatalf("control render must succeed under a live context: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	var err error
+	withWatchdog(t, func() {
+		_, err = e.Render(ctx, comprehensionExpr, emptyInputs())
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected the error to wrap context.Canceled, got: %v", err)
+	}
+}
+
+func TestRenderStopsOnExpiredDeadline(t *testing.T) {
+	e := NewEngine()
+	ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	var err error
+	withWatchdog(t, func() {
+		_, err = e.Render(ctx, comprehensionExpr, emptyInputs())
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected the error to wrap context.DeadlineExceeded, got: %v", err)
+	}
+}
+
+// Render is called with a nil context by no production path, but a zero value must not panic.
+func TestRenderAcceptsNilContext(t *testing.T) {
+	e := NewEngine()
+	//nolint:staticcheck // deliberately passing a nil context to prove it is normalized
+	got, err := e.Render(nil, "${spec.replicas}", map[string]any{"spec": map[string]any{"replicas": int64(3)}})
+	if err != nil || got != int64(3) {
+		t.Fatalf("nil context must be treated as context.Background(): got=%v err=%v", got, err)
+	}
+}
+
+// TestHeavyExprCostIsStable and TestExpensiveFailureCostIsStable pin the two measured
+// constants every budget size here is derived from. If the CEL cost model shifts - a tracker
+// removed, a formula reworded - the failure lands in one of these two with the new number,
+// rather than turning the budget tests into flaky ones.
+func TestHeavyExprCostIsStable(t *testing.T) {
+	budget := NewCostBudget(0)
+	ctx := WithCostBudget(t.Context(), budget)
+	e := NewEngineWithOptions(WithCostLimit(1 << 40))
+	if _, err := e.Render(ctx, heavyExpr, emptyInputs()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cost := budget.Spent(); cost != heavyExprCost {
+		t.Fatalf("heavyExpr cost changed: expected %d, got %d - resize the budget tests", heavyExprCost, cost)
+	}
+}
+
+// The same for expensiveFailureExpr. Nothing pinned it until now, and it had drifted: the
+// constant read 135,024 while the expression measured 126,014, which no test could notice
+// because both are far above the half-sized budget the tests derive from it.
+func TestExpensiveFailureCostIsStable(t *testing.T) {
+	budget := NewCostBudget(0)
+	ctx := WithCostBudget(t.Context(), budget)
+	e := NewEngineWithOptions(WithCostLimit(1 << 40))
+	if _, err := e.Render(ctx, expensiveFailureExpr, emptyInputs()); err == nil {
+		t.Fatal("expected the expression to fail on its own terms")
+	}
+	if cost := budget.Spent(); cost != expensiveFailureCost {
+		t.Fatalf("expensiveFailureExpr cost changed: expected %d, got %d - resize the budget tests",
+			expensiveFailureCost, cost)
+	}
+}
+
+// A render walking a large, entirely static structure never reaches a CEL evaluation, so
+// ContextEval cannot interrupt it. renderString checks the context itself so an enabled
+// context deadline still stops the traversal.
+func TestStaticRenderObservesCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	e := NewEngine()
+	_, err := e.Render(ctx, map[string]any{"a": "no expressions here"}, emptyInputs())
+	if err == nil {
+		t.Fatal("expected an expression-free render under a cancelled context to fail, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected the error to wrap context.Canceled, got: %v", err)
+	}
+	if IsTerminalRenderError(err) {
+		t.Fatalf("a cancelled context is transient, not terminal: %v", err)
+	}
+	if !IsRenderAborted(err) {
+		t.Fatalf("a cancelled context must abort the render: %v", err)
+	}
+}
+
+// An expression can burn most of a reconcile's allowance and still fail for its own reason,
+// in which case that reason is what surfaces and the breach is deferred (see
+// TestPerExpressionBreachIsNamedAheadOfTheBudget). Deferring is only safe if the next
+// request to evaluate is refused outright: the pipelines aggregate render errors and keep
+// going, so without the refusal every remaining expression would be evaluated in full and
+// the budget would bound nothing at all.
+func TestExhaustedBudgetRefusesFurtherEvaluation(t *testing.T) {
+	budget := NewCostBudget(expensiveFailureCost / 2)
+	ctx := WithCostBudget(t.Context(), budget)
+	e := NewEngine()
+
+	// The first evaluation overshoots the allowance but reports its own failure.
+	_, err := e.Render(ctx, expensiveFailureExpr, emptyInputs())
+	if err == nil {
+		t.Fatal("expected the expression to fail on its own terms")
+	}
+	if errors.Is(err, ErrCostBudgetExceeded) {
+		t.Fatalf("the concrete failure must be named ahead of the breach, got: %v", err)
+	}
+	spent := budget.Spent()
+	if spent <= budget.Budget() {
+		t.Fatalf("expected the failed evaluation to overshoot the budget, got spent=%d budget=%d",
+			spent, budget.Budget())
+	}
+
+	// The second is refused before any work is done - the breach surfaces, and the spend
+	// does not move. A charge here would mean the expression ran anyway.
+	if _, err := e.Render(ctx, expensiveFailureExpr, emptyInputs()); !errors.Is(err, ErrCostBudgetExceeded) {
+		t.Fatalf("an exhausted budget must refuse the next evaluation, got: %v", err)
+	}
+	if after := budget.Spent(); after != spent {
+		t.Fatalf("a refused evaluation must charge nothing: spent %d -> %d", spent, after)
+	}
+}
+
+// The refusal must not depend on the expression being the expensive one: any evaluation
+// under an exhausted budget is refused, including one that would have cost almost nothing.
+func TestExhaustedBudgetRefusesEvenACheapExpression(t *testing.T) {
+	budget := NewCostBudget(expensiveFailureCost / 2)
+	ctx := WithCostBudget(t.Context(), budget)
+	e := NewEngine()
+
+	if _, err := e.Render(ctx, expensiveFailureExpr, emptyInputs()); err == nil {
+		t.Fatal("expected the expression to fail on its own terms")
+	}
+	spent := budget.Spent()
+
+	if _, err := e.Render(ctx, "${1 + 1}", emptyInputs()); !errors.Is(err, ErrCostBudgetExceeded) {
+		t.Fatalf("expected the exhausted budget to refuse a cheap expression, got: %v", err)
+	}
+	if after := budget.Spent(); after != spent {
+		t.Fatalf("a refused evaluation must charge nothing: spent %d -> %d", spent, after)
+	}
+}
+
+// A charge can arrive near MaxUint64 (the custom-function estimator combines its own costs
+// with saturatingAdd), so the meter must saturate. A wrapped total would read as a small
+// spend and reopen an allowance that is in fact long exhausted.
+// Overflow at a budget of MaxUint64 is the one case the saturated value cannot report:
+// it lands exactly on the budget, which breachLocked would read as an exact fit. The true
+// spend exceeds any representable budget, so the overflowing charge itself must breach.
+func TestOverflowBreachesAMaxUint64Budget(t *testing.T) {
+	budget := NewCostBudget(math.MaxUint64)
+	if err := budget.add(math.MaxUint64 - 1); err != nil {
+		t.Fatalf("a charge within the budget must not breach it, got: %v", err)
+	}
+	if err := budget.add(2); !errors.Is(err, ErrCostBudgetExceeded) {
+		t.Fatalf("an overflowing charge is an overspend, not an exact fit, got: %v", err)
+	}
+	if spent := budget.Spent(); spent != math.MaxUint64 {
+		t.Fatalf("overflowing spend must saturate, got %d", spent)
+	}
+}
+
+func TestCostBudgetSaturatesOnOverflow(t *testing.T) {
+	budget := NewCostBudget(1000)
+	if err := budget.add(math.MaxUint64 - 1); !errors.Is(err, ErrCostBudgetExceeded) {
+		t.Fatalf("a charge far past the budget must breach it, got: %v", err)
+	}
+	if err := budget.add(2); !errors.Is(err, ErrCostBudgetExceeded) {
+		t.Fatalf("overflowing charge must keep the budget breached, got: %v", err)
+	}
+	if spent := budget.Spent(); spent != math.MaxUint64 {
+		t.Fatalf("overflowing spend wrapped instead of saturating: got %d", spent)
+	}
+	if err := budget.exceeded(); !errors.Is(err, ErrCostBudgetExceeded) {
+		t.Fatalf("a saturated meter must stay breached, got: %v", err)
+	}
+}
+
+// A render that lands exactly on its budget has stayed within it, so it must succeed - and
+// then nothing may be evaluated under that budget again. The two halves pull in opposite
+// directions, which is why add and exceeded ask different questions of the same counter:
+// without the second half, an exactly-spent budget funds one more expression at up to the
+// full per-expression limit, which is the unbounded overshoot the pre-check exists to stop.
+func TestExactlySpentBudgetCompletesTheRenderThenRefusesTheNext(t *testing.T) {
+	budget := NewCostBudget(heavyExprCost)
+	ctx := WithCostBudget(t.Context(), budget)
+	e := NewEngine()
+
+	if _, err := e.Render(ctx, heavyExpr, emptyInputs()); err != nil {
+		t.Fatalf("a render costing exactly its budget is within it and must succeed, got: %v", err)
+	}
+	if spent := budget.Spent(); spent != budget.Budget() {
+		t.Fatalf("expected the render to spend the budget exactly, got spent=%d budget=%d",
+			spent, budget.Budget())
+	}
+
+	spent := budget.Spent()
+	if _, err := e.Render(ctx, "${1 + 1}", emptyInputs()); !errors.Is(err, ErrCostBudgetExceeded) {
+		t.Fatalf("an exactly-spent budget has nothing left to fund the next evaluation, got: %v", err)
+	}
+	if after := budget.Spent(); after != spent {
+		t.Fatalf("a refused evaluation must charge nothing: spent %d -> %d", spent, after)
+	}
+}
+
+// add reports only that a charge overspent the allowance. An exact fit has not, and failing
+// it would turn a legitimate render into an error over the last unit it was entitled to.
+func TestExactFitChargeIsNotABreach(t *testing.T) {
+	budget := NewCostBudget(1000)
+	if err := budget.add(1000); err != nil {
+		t.Fatalf("a charge landing exactly on the budget is within it, got: %v", err)
+	}
+	if err := budget.exceeded(); !errors.Is(err, ErrCostBudgetExceeded) {
+		t.Fatalf("but nothing may be evaluated afterwards, got: %v", err)
+	}
+}
+
+// A cancelled render must stop on data that holds no strings at all. Numbers and booleans
+// reach neither the expression paths (which ContextEval interrupts) nor renderString (which
+// checks the context itself), so before the walk checked for itself, a cancelled render over
+// a large primitive list ran to completion and returned a result as though nothing had
+// happened. Bounding the deadline is only worth anything if the walk observes it.
+func TestCancelledRenderStopsOnPrimitiveOnlyData(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	items := make([]any, 50_000)
+	for i := range items {
+		items[i] = i%2 == 0
+	}
+
+	e := NewEngine()
+	_, err := e.Render(ctx, items, emptyInputs())
+	if err == nil {
+		t.Fatal("expected a cancelled render over primitive-only data to fail, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected the error to wrap context.Canceled, got: %v", err)
+	}
+	if !IsRenderAborted(err) {
+		t.Fatalf("a cancelled context must abort the render: %v", err)
+	}
+}

--- a/internal/template/cel_extensions_test.go
+++ b/internal/template/cel_extensions_test.go
@@ -596,7 +596,7 @@ portStr: ${string(parameters.port)}
 			var input map[string]any
 			require.NoError(t, json.Unmarshal([]byte(tt.inputs), &input))
 
-			rendered, err := engine.Render(tpl, input)
+			rendered, err := engine.Render(t.Context(), tpl, input)
 			require.NoError(t, err)
 
 			cleaned := RemoveOmittedFields(rendered)

--- a/internal/template/cost_test.go
+++ b/internal/template/cost_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package template
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// hostileExpr is the denial-of-service proof of concept: 2,000 outer iterations each
+// building a 2,000-element list, or 4M inner iterations. It runs for roughly a second
+// unguarded, and every cost-limit test drives the guard with it.
+const hostileExpr = "${size(lists.range(2000).map(x, lists.range(2000).map(y, x + y)))}"
+
+func TestCELUnboundedEvaluation(t *testing.T) {
+	e := NewEngine()
+	start := time.Now()
+	_, err := e.Render(t.Context(), hostileExpr, map[string]any{"spec": map[string]any{}})
+	t.Logf("elapsed=%s err=%v", time.Since(start), err)
+}
+
+func TestCostLimitStopsHeavyExpression(t *testing.T) {
+	e := NewEngine()
+	start := time.Now()
+	_, err := e.Render(t.Context(), hostileExpr, map[string]any{"spec": map[string]any{}})
+	if err == nil {
+		t.Fatalf("expected cost-limit error, got nil (took %s)", time.Since(start))
+	}
+	if !strings.Contains(err.Error(), "cost limit exceeded") {
+		t.Fatalf("expected cost-limit error, got: %v", err)
+	}
+	if !errors.Is(err, ErrCostLimitExceeded) {
+		t.Fatalf("expected error matching ErrCostLimitExceeded, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "lists.range(2000)") {
+		t.Fatalf("expected error to name the offending expression, got: %v", err)
+	}
+}
+
+func TestCostLimitAllowsNormalExpression(t *testing.T) {
+	e := NewEngine()
+	got, err := e.Render(t.Context(), "${spec.replicas}", map[string]any{"spec": map[string]any{"replicas": int64(3)}})
+	if err != nil || got != int64(3) {
+		t.Fatalf("normal expr broke: got=%v err=%v", got, err)
+	}
+}
+
+// The cost limit is a property of the engine, so every construction path must carry it.
+// A zero limit selects the default rather than disabling the guard.
+func TestCostLimitDefaultsOnEveryConstructor(t *testing.T) {
+	tests := []struct {
+		name   string
+		engine *Engine
+	}{
+		{name: "NewEngine", engine: NewEngine()},
+		{name: "NewEngineWithOptions without WithCostLimit", engine: NewEngineWithOptions(DisableCache())},
+		{name: "WithCostLimit(0) selects the default", engine: NewEngineWithOptions(WithCostLimit(0))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.engine.costLimit != defaultCELCostLimit {
+				t.Fatalf("expected cost limit %d, got %d", defaultCELCostLimit, tt.engine.costLimit)
+			}
+		})
+	}
+}
+
+// Pipelines construct engines through NewEngineWithOptions(WithCELExtensions(...)) without
+// asking for a cost limit, so that path must end up bounded end-to-end and surface the
+// typed sentinel rather than merely failing.
+func TestNewEngineWithOptionsDefaultsCostLimit(t *testing.T) {
+	e := NewEngineWithOptions(WithCELExtensions())
+	if e.costLimit != defaultCELCostLimit {
+		t.Fatalf("expected the default cost limit %d, got %d", defaultCELCostLimit, e.costLimit)
+	}
+	_, err := e.Render(t.Context(), hostileExpr, map[string]any{"spec": map[string]any{}})
+	if !errors.Is(err, ErrCostLimitExceeded) {
+		t.Fatalf("options-constructed engine must enforce the default limit, got: %v", err)
+	}
+}
+
+func TestWithCostLimitOverridesDefault(t *testing.T) {
+	e := NewEngineWithOptions(WithCostLimit(50))
+	if e.costLimit != 50 {
+		t.Fatalf("expected cost limit 50, got %d", e.costLimit)
+	}
+	_, err := e.Render(t.Context(), "${size(lists.range(100).map(x, x + 1))}", map[string]any{"spec": map[string]any{}})
+	if !errors.Is(err, ErrCostLimitExceeded) {
+		t.Fatalf("expected a low limit to be enforced, got: %v", err)
+	}
+}
+
+// Cost must be charged on every evaluation path, including the two that return before a
+// result is produced: oc_omit(), which short-circuits the walk, and an expression that
+// breaches the per-expression limit. Work performed counts even when its result is
+// discarded, or a template could spend the reconcile's whole allowance for free by making
+// every expression fail.
+func TestBudgetIsChargedOnEveryEvaluationPath(t *testing.T) {
+	budget := NewCostBudget(0) // unbounded: used here as a meter, not a guard
+	ctx := WithCostBudget(t.Context(), budget)
+	e := NewEngine()
+
+	inputs := map[string]any{"spec": map[string]any{"replicas": int64(3)}}
+	if _, err := e.Render(ctx, "${spec.replicas}", inputs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	afterPlain := budget.Spent()
+	if afterPlain == 0 {
+		t.Fatal("expected an ordinary evaluation to charge the budget")
+	}
+
+	if _, err := e.Render(ctx, "${oc_omit()}", inputs); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	afterOmit := budget.Spent()
+	if afterOmit <= afterPlain {
+		t.Fatalf("expected oc_omit() to charge the budget: %d -> %d", afterPlain, afterOmit)
+	}
+
+	if _, err := e.Render(ctx, hostileExpr, inputs); !errors.Is(err, ErrCostLimitExceeded) {
+		t.Fatalf("expected the breaching expression to exceed the cost limit, got: %v", err)
+	}
+	// A breach must report the cost it actually burned rather than being skipped, so the
+	// reconcile budget still sees the work an aborted evaluation did.
+	if burned := budget.Spent() - afterOmit; burned <= defaultCELCostLimit {
+		t.Fatalf("expected the breach to charge more than the limit %d, got %d", defaultCELCostLimit, burned)
+	}
+}

--- a/internal/template/custom_function_costs_test.go
+++ b/internal/template/custom_function_costs_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package template
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// observedCost renders one expression with an effectively unlimited cost limit and reports
+// what the engine charged for it. A single expression under a fresh unbounded budget spends
+// exactly its own cost, so the budget doubles as the meter.
+func observedCost(t *testing.T, expr string, inputs map[string]any) uint64 {
+	t.Helper()
+	budget := NewCostBudget(0)
+	ctx := WithCostBudget(t.Context(), budget)
+	e := NewEngineWithOptions(WithCostLimit(1 << 40))
+	if _, err := e.Render(ctx, expr, inputs); err != nil {
+		t.Fatalf("render of %q failed: %v", expr, err)
+	}
+	return budget.Spent()
+}
+
+// Without a runtime cost tracker, cel-go charges one unit for any overload it does not
+// recognize, so an oc_* call over a megabyte of tenant data spends the same as one over an
+// empty string. These are the overloads that traverse their input; each must charge for what
+// it walked, or the per-expression limit and the reconcile budget are blind to it.
+func TestCustomFunctionCostGrowsWithInputSize(t *testing.T) {
+	tests := []struct {
+		name  string
+		expr  string
+		build func(size int) map[string]any
+	}{
+		{
+			name:  "oc_hash",
+			expr:  "${oc_hash(payload)}",
+			build: func(size int) map[string]any { return map[string]any{"payload": strings.Repeat("a", size)} },
+		},
+		{
+			name:  "oc_generate_name string",
+			expr:  "${oc_generate_name(payload)}",
+			build: func(size int) map[string]any { return map[string]any{"payload": strings.Repeat("a", size)} },
+		},
+		{
+			name:  "oc_dns_label string",
+			expr:  "${oc_dns_label(payload)}",
+			build: func(size int) map[string]any { return map[string]any{"payload": strings.Repeat("a", size)} },
+		},
+		{
+			name: "oc_generate_name list",
+			expr: "${oc_generate_name([payload, payload])}",
+			build: func(size int) map[string]any {
+				return map[string]any{"payload": strings.Repeat("a", size/2)}
+			},
+		},
+		{
+			name: "oc_generate_name list charges empty elements",
+			expr: "${oc_generate_name(payload)}",
+			build: func(size int) map[string]any {
+				return map[string]any{"payload": emptyStrings(size)}
+			},
+		},
+		{
+			name: "oc_dns_label list charges empty elements",
+			expr: "${oc_dns_label(payload)}",
+			build: func(size int) map[string]any {
+				return map[string]any{"payload": emptyStrings(size)}
+			},
+		},
+		{
+			name: "oc_merge",
+			expr: "${oc_merge(left, right)}",
+			build: func(size int) map[string]any {
+				left := make(map[string]any, size)
+				for i := range size {
+					left[fmt.Sprintf("k%d", i)] = "v"
+				}
+				return map[string]any{"left": left, "right": map[string]any{"other": "v"}}
+			},
+		},
+	}
+
+	// The small and large inputs differ by 100x, so a cost model that still charges O(1)
+	// cannot pass: it would report the same number twice.
+	const (
+		small = 100
+		large = 10_000
+	)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			smallCost := observedCost(t, tt.expr, tt.build(small))
+			largeCost := observedCost(t, tt.expr, tt.build(large))
+			t.Logf("%s: cost(%d)=%d cost(%d)=%d", tt.name, small, smallCost, large, largeCost)
+
+			if largeCost <= smallCost {
+				t.Fatalf("cost did not grow with input size: cost(%d)=%d, cost(%d)=%d — "+
+					"the overload is still metered as O(1)", small, smallCost, large, largeCost)
+			}
+
+			// Growth must track the input, not merely be non-zero: a 100x larger input has to
+			// cost at least an order of magnitude more.
+			if largeCost < smallCost*10 {
+				t.Errorf("cost grew sublinearly for a 100x larger input: cost(%d)=%d, cost(%d)=%d",
+					small, smallCost, large, largeCost)
+			}
+		})
+	}
+}
+
+func emptyStrings(size int) []any {
+	items := make([]any, size)
+	for i := range items {
+		items[i] = ""
+	}
+	return items
+}
+
+// oc_hash's charge is proportional to the bytes it hashes, so a large enough argument trips
+// the ordinary per-expression limit — the outcome that was unreachable while the overload
+// was metered as a single unit.
+func TestHugeCustomFunctionInputBreachesDefaultLimit(t *testing.T) {
+	// At StringTraversalCostFactor (0.1 per byte) the default limit of 2,000,000 units
+	// corresponds to ~20MB of traversal; go comfortably past it.
+	payload := strings.Repeat("a", 32<<20)
+
+	e := NewEngine()
+	_, err := e.Render(t.Context(), "${oc_hash(payload)}", map[string]any{"payload": payload})
+	if err == nil {
+		t.Fatal("expected a cost breach for a 32MB oc_hash argument, got nil")
+	}
+	if !errors.Is(err, ErrCostLimitExceeded) && !errors.Is(err, ErrCostBudgetExceeded) {
+		t.Fatalf("expected a cost limit or budget breach, got: %v", err)
+	}
+	if !IsTerminalRenderError(err) {
+		t.Fatalf("a cost breach must classify as terminal, got: %v", err)
+	}
+}
+
+// oc_omit does no size-proportional work and is deliberately left on cel-go's default cost.
+// It is the one custom overload without a tracker, so pin that it still evaluates.
+func TestOmitStaysCheap(t *testing.T) {
+	cost := observedCost(t, `${{"a": oc_omit()}}`, emptyInputs())
+	if cost == 0 {
+		t.Fatal("expected oc_omit to be charged cel-go's default cost, got 0")
+	}
+	t.Logf("oc_omit cost = %d", cost)
+}
+
+// The estimator runs inside cel-go's cost observer, where a panic takes down the reconcile
+// rather than failing the render. Arity is cel-go's to choose: the checker enforces it for
+// these overloads today, and the variadic forms are macros that always expand to exactly one
+// argument, so a zero-argument call is not reachable from a template. Nothing in a cost
+// function should depend on that holding.
+func TestCustomFunctionCostToleratesMissingArguments(t *testing.T) {
+	for _, function := range []string{"oc_hash", "oc_generate_name", "oc_dns_label", "oc_merge"} {
+		t.Run(function, func(t *testing.T) {
+			got := customFunctionCostEstimator{}.CallCost(function, "", nil, nil)
+			if got == nil {
+				t.Fatalf("%s returned no cost", function)
+			}
+		})
+	}
+}

--- a/internal/template/custom_functions.go
+++ b/internal/template/custom_functions.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"maps"
+	"math"
 	"reflect"
 
 	"github.com/google/cel-go/cel"
@@ -14,11 +15,69 @@ import (
 	"github.com/google/cel-go/common/ast"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
 	"github.com/google/cel-go/ext"
+	"github.com/google/cel-go/interpreter"
 	"github.com/google/cel-go/parser"
 
 	"github.com/openchoreo/openchoreo/internal/dataplane/kubernetes"
 )
+
+// maxListsRangeSize bounds lists.range so a single call cannot materialize more than
+// ~maxListsRangeSize x 24B of slice memory. Set to 10_000 because cel-go's cost model is
+// a poor proxy for CPU once a list grows past ~10k elements: a measured
+// lists.range(10000).map(...) costs 150k and runs in 85ms, while the same expression at
+// 100k costs 1.5M and runs in 6.4s — 10x the cost for 75x the time. No sample uses
+// lists.range, so the tightening costs nothing in practice.
+//
+// This closes one route to a huge list, not all of them: split() on a large
+// tenant-supplied string is another, and is unaffected by this cap
+// (v.split(",").map(...) over an 800KB value burns ~9.7s before the cost limit fires).
+// The per-expression cost limit therefore bounds memory, not wall-clock. The control for
+// the residual routes is the cumulative reconcile budget.
+const maxListsRangeSize int64 = 10_000
+
+// boundedListsRange re-declares lists.range with a size ceiling.
+//
+// On main this is ext.Lists(ext.ListsMaxRangeSize(...)), but that option landed in cel-go
+// v0.29. This release line is pinned to cel-go v0.22.1 because k8s.io/apiserver v0.32.3
+// requires it, and cel-go's v0.22.1 genRange is unbounded: lists.range(50_000_000) boxes
+// fifty million ints before cel-go's cost tracker charges anything, so the per-expression
+// cost limit never fires. Re-declaring the same overload ID with a checked binding
+// replaces cel-go's, which is why this option must come after ext.Lists().
+//
+// The message matches upstream's, so the size cap behaves identically across release
+// lines: a plain evaluation error, not a sentinel. The rest of the overload does not.
+// cel-go from v0.29 rejects a negative size outright, while the binding below clamps the
+// allocation and returns an empty list, so a template computing a negative size renders
+// here and fails there.
+//
+// The check has to happen here rather than in the cost tracker: cel-go charges lists.range
+// only once it returns, so by the time the cost limit could fire the whole slice is already
+// resident. That makes this cap load-bearing against memory exhaustion, not a convenience.
+// The tracker in ext_overload_costs.go charges the range afterwards, which is what bounds
+// how many capped ranges one expression may build.
+func boundedListsRange() cel.EnvOption {
+	return cel.Function("lists.range",
+		cel.Overload("lists_range",
+			[]*cel.Type{cel.IntType}, cel.ListType(cel.IntType),
+			cel.FunctionBinding(func(args ...ref.Val) ref.Val {
+				n, ok := args[0].(types.Int)
+				if !ok {
+					return types.MaybeNoSuchOverloadErr(args[0])
+				}
+				if int64(n) > maxListsRangeSize {
+					return types.NewErr("lists.range: size %d exceeds maximum allowed (%d)", int64(n), maxListsRangeSize)
+				}
+				out := make([]ref.Val, 0, max(int64(n), 0))
+				for i := types.Int(0); i < n; i++ {
+					out = append(out, i)
+				}
+				return types.DefaultTypeAdapter.NativeToValue(out)
+			}),
+		),
+	)
+}
 
 // BaseCELExtensions returns the CEL extensions used across OpenChoreo.
 // This includes optional types, common utility extensions for strings, encoding,
@@ -30,6 +89,7 @@ func BaseCELExtensions() []cel.EnvOption {
 		ext.Encoders(),
 		ext.Math(),
 		ext.Lists(),
+		boundedListsRange(),
 		ext.Sets(),
 		ext.TwoVarComprehensions(),
 	}
@@ -193,6 +253,10 @@ func (o *omitCELValue) Value() interface{} {
 //	oc_hash("test")  -> "4fdcca5d"  # Same input, same output
 //
 // All custom functions use the "oc_" prefix to avoid potential conflicts with upstream CEL-go.
+//
+// Any new oc_* function that does size-proportional work must also get a CallCost case in
+// customFunctionCostEstimator below; otherwise cel-go meters it at a flat one cost unit and
+// the per-expression limit and reconcile budget stay blind to whatever it traverses.
 func CustomFunctions() []cel.EnvOption {
 	return []cel.EnvOption{
 		cel.Macros(generateNameMacro, dnslabelMacro, mergeMacro),
@@ -443,3 +507,135 @@ var mergeMacro = cel.GlobalVarArgMacro("oc_merge",
 			return result, nil
 		}
 	})
+
+// customFunctionCostEstimator charges runtime cost for the oc_* functions registered by
+// CustomFunctions.
+//
+// cel-go charges one cost unit for any overload it does not recognize, so without this
+// estimator every oc_* call is metered as O(1) no matter how much data it walks. That makes
+// the per-expression cost limit and the reconcile budget blind to the one class of work a
+// template author fully controls: `${oc_hash(hugeParameter)}` repeated across a large
+// template traverses gigabytes while spending a handful of cost units.
+//
+// Each case below charges for the input the function actually traverses, using cel-go's own
+// conventions so a custom call and an equivalent built-in call cost the same order of
+// magnitude:
+//
+//   - String traversal is charged at common.StringTraversalCostFactor (0.1 per byte), the
+//     same factor cel-go applies to startsWith, string conversion, and concatenation.
+//   - Map traversal is charged one unit per entry, the same convention cel-go applies to
+//     list containment (`in`).
+//
+// Dispatch is by function name rather than overload ID. Template inputs are declared as
+// cel.DynType, so the checker cannot always pick a single overload for a function that
+// declares more than one — oc_generate_name and oc_dns_label each declare a string and a
+// list form — and an overload-keyed tracker silently misses those calls. The function name
+// is always known, and the argument's own type tells the two forms apart.
+//
+// oc_omit takes no arguments and does no proportional work, so it falls through to cel-go's
+// default cost of one.
+//
+// On this branch the estimator carries a second job. cel-go v0.22.1 ships no runtime cost
+// trackers for its own strings, lists and encoders extensions — later releases do — so those
+// overloads are metered as O(1) too, and the trackers for them live in ext_overload_costs.go
+// behind extOverloadCost. That half must be dropped on the first bump past v0.24; see that
+// file for why a partial bump is the awkward case.
+type customFunctionCostEstimator struct{}
+
+// CallCost implements interpreter.ActualCostEstimator. A nil return means "no estimate",
+// which falls back to cel-go's O(1) default — the blind spot this exists to close — so
+// every function handled here returns a real cost.
+func (customFunctionCostEstimator) CallCost(function, overloadID string, args []ref.Val, result ref.Val) *uint64 {
+	cost := uint64(1)
+
+	// Arguments are read through argAt for the same reason the ext trackers do: this runs
+	// inside cel-go's cost observer, where an index out of range panics the reconcile rather
+	// than failing the render. The checker enforces arity for these overloads today, so a
+	// zero-argument call is not reachable from a template; nothing here should depend on it.
+	switch function {
+	case "oc_hash":
+		cost = saturatingAdd(cost, traversalCost(stringBytes(argAt(args, 0))))
+
+	case "oc_generate_name", "oc_dns_label":
+		cost = saturatingAdd(cost, nameInputCost(argAt(args, 0)))
+
+	case "oc_merge":
+		for _, arg := range args {
+			cost = saturatingAdd(cost, collectionSize(arg))
+		}
+
+	default:
+		return extOverloadCost(function, overloadID, args, result)
+	}
+
+	return &cost
+}
+
+// CustomFunctionCostOptions returns the program options that install the estimator.
+//
+// cel.CostTracking feeds the same cost tracker that cel.CostLimit bounds, so a breach
+// interrupts evaluation exactly as a built-in overload's cost would.
+func CustomFunctionCostOptions() []cel.ProgramOption {
+	return []cel.ProgramOption{cel.CostTracking(customFunctionCostEstimator{})}
+}
+
+// traversalCost converts a byte count into cost units at cel-go's string traversal factor.
+func traversalCost(size uint64) uint64 {
+	return scaledCost(size, common.StringTraversalCostFactor)
+}
+
+// Lists cost by both entry count and bytes: even empty strings require iteration and allocation.
+func nameInputCost(val ref.Val) uint64 {
+	if lister, ok := val.(traits.Lister); ok {
+		n := collectionLen(lister)
+		var bytes uint64
+		for i := int64(0); i < n; i++ {
+			bytes = saturatingAdd(bytes, stringBytes(lister.Get(types.Int(i))))
+		}
+		return saturatingAdd(collectionSize(lister), traversalCost(bytes))
+	}
+	return traversalCost(stringBytes(val))
+}
+
+// CEL's string size is a rune count; these functions traverse bytes, so use the native string.
+func stringBytes(val ref.Val) uint64 {
+	if val == nil {
+		return 0
+	}
+	s, _ := val.Value().(string)
+	return uint64(len(s))
+}
+
+func collectionSize(val ref.Val) uint64 {
+	n := collectionLen(val)
+	if n < 0 {
+		return 0
+	}
+	return uint64(n)
+}
+
+// collectionLen reports a collection's entry count as CEL's own int64 size, so it indexes a
+// Lister without a further conversion. Anything that cannot be sized reports -1, which reads
+// as an empty collection to both the loop above and collectionSize.
+func collectionLen(val ref.Val) int64 {
+	sz, ok := val.(traits.Sizer)
+	if !ok {
+		return -1
+	}
+	n, ok := sz.Size().(types.Int)
+	if !ok {
+		return -1
+	}
+	return int64(n)
+}
+
+// saturatingAdd adds two costs without wrapping. A wrapped total would read as a tiny cost
+// and let the very evaluation the guard exists to stop run unmetered.
+func saturatingAdd(a, b uint64) uint64 {
+	if a > math.MaxUint64-b {
+		return math.MaxUint64
+	}
+	return a + b
+}
+
+var _ interpreter.ActualCostEstimator = customFunctionCostEstimator{}

--- a/internal/template/custom_functions_env_test.go
+++ b/internal/template/custom_functions_env_test.go
@@ -1,0 +1,93 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package template_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	celcontext "github.com/openchoreo/openchoreo/internal/pipeline/component/context"
+	"github.com/openchoreo/openchoreo/internal/template"
+)
+
+// This file lives in the external test package because it builds the same CEL
+// environments the component validation webhook builds, and that package imports
+// internal/template.
+
+// The lists.range ceiling comes from re-declaring cel-go's own lists_range overload, so it
+// holds only while that re-declaration is the last one to win. Anything that appends
+// ext.Lists() after BaseCELExtensions, or that declares lists.range a second time, either
+// restores the unbounded builtin or fails env construction outright. The render engine's
+// own env is covered in package template; these are the other environments that admit
+// tenant-authored CEL, and each builds its env rather than reusing the engine's.
+func TestListsRangeCeilingHoldsInEveryEnvironment(t *testing.T) {
+	t.Parallel()
+
+	const maxRange = template.MaxListsRangeSizeForTest
+
+	envs := map[string]func() (*cel.Env, error){
+		// Mirrors createBaseEnv(true) in internal/validation/component/cel_env.go.
+		"component validation": func() (*cel.Env, error) {
+			opts := template.BaseCELExtensions()
+			opts = append(opts, celcontext.CELValidationExtensions()...)
+			return cel.NewEnv(opts...)
+		},
+		// Mirrors createBaseEnv(false), the bare base env with no config extensions.
+		// On release-v1.1 this case covers the resource validation webhook, which builds
+		// the same env; that package does not exist on this branch.
+		"base env without config extensions": func() (*cel.Env, error) {
+			return cel.NewEnv(template.BaseCELExtensions()...)
+		},
+		// Mirrors the component render surface, which adds the non-validation helpers.
+		"component render": func() (*cel.Env, error) {
+			opts := template.BaseCELExtensions()
+			opts = append(opts, celcontext.CELExtensions()...)
+			return cel.NewEnv(opts...)
+		},
+	}
+
+	for name, build := range envs {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			env, err := build()
+			require.NoError(t, err, "a duplicate lists.range declaration would fail env construction here")
+
+			out, err := evalRange(t, env, maxRange)
+			require.NoError(t, err, "a range at the cap must still materialize")
+			assert.Equal(t, maxRange, listLen(t, out))
+
+			_, err = evalRange(t, env, maxRange+1)
+			require.Error(t, err, "the bounded overload must win over cel-go's builtin")
+			assert.Contains(t, err.Error(), "exceeds maximum allowed")
+		})
+	}
+}
+
+// evalRange compiles and runs lists.range(size) against env.
+func evalRange(t *testing.T, env *cel.Env, size int64) (ref.Val, error) {
+	t.Helper()
+	compiled, iss := env.Compile(fmt.Sprintf("lists.range(%d)", size))
+	require.NoError(t, iss.Err())
+	prg, err := env.Program(compiled)
+	require.NoError(t, err)
+	val, _, err := prg.Eval(map[string]any{})
+	return val, err
+}
+
+func listLen(t *testing.T, val ref.Val) int64 {
+	t.Helper()
+	sizer, ok := val.(traits.Sizer)
+	require.True(t, ok, "expected a sizable list, got %T", val)
+	n, ok := sizer.Size().(types.Int)
+	require.True(t, ok, "expected an integer size, got %v", sizer.Size())
+	return int64(n)
+}

--- a/internal/template/custom_functions_test.go
+++ b/internal/template/custom_functions_test.go
@@ -4,6 +4,7 @@
 package template
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/cel-go/common/types"
@@ -164,3 +165,83 @@ func TestGenerateK8sDNSLabel_InputTypes(t *testing.T) {
 		assert.LessOrEqual(t, len(val), 63)
 	})
 }
+
+// TestListsRangeCeiling verifies the lowered lists.range guard across its whole
+// domain: sizes at and below maxListsRangeSize still materialize, anything above it
+// is refused before a single element is allocated, and the boundary sits exactly
+// where the constant says it does.
+//
+// The negative and zero cases pin behavior that differs from cel-go v0.29+, where
+// genRange rejects a negative size outright. On v0.22.1 the re-declared binding
+// clamps the allocation instead and yields an empty list, so a template that passes
+// a computed negative size keeps rendering rather than failing.
+func TestListsRangeCeiling(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		size int64
+		want int // expected element count when the call is allowed
+	}{
+		{name: "negative size yields an empty list", size: -3, want: 0},
+		{name: "zero yields an empty list", size: 0, want: 0},
+		{name: "ordinary size", size: 10, want: 10},
+		{name: "just below the cap", size: maxListsRangeSize - 1, want: int(maxListsRangeSize - 1)},
+		{name: "exactly at the cap is allowed", size: maxListsRangeSize, want: int(maxListsRangeSize)},
+		{name: "one past the cap is refused", size: maxListsRangeSize + 1, want: -1},
+		{name: "far past the cap is refused", size: maxListsRangeSize * 2, want: -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			e := NewEngine()
+			expr := fmt.Sprintf("${lists.range(%d)}", tt.size)
+			got, err := e.Render(t.Context(), expr, emptyInputs())
+
+			if tt.want < 0 {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "exceeds maximum allowed")
+				assert.Contains(t, err.Error(), fmt.Sprintf("(%d)", maxListsRangeSize))
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, got, tt.want)
+		})
+	}
+}
+
+// The cap has to hold when the size arrives through a variable too. Template inputs are
+// declared as cel.DynType, so a dynamic argument bypasses the checker's overload
+// resolution and reaches the binding at runtime — the path a hostile template would
+// actually take to smuggle an oversized range past a literal-only guard.
+func TestListsRangeCeilingWithDynamicArgument(t *testing.T) {
+	t.Parallel()
+
+	e := NewEngine()
+
+	allowed, err := e.Render(t.Context(), "${lists.range(spec.n)}",
+		map[string]any{"spec": map[string]any{"n": maxListsRangeSize}})
+	require.NoError(t, err)
+	assert.Len(t, allowed, int(maxListsRangeSize))
+
+	_, err = e.Render(t.Context(), "${lists.range(spec.n)}",
+		map[string]any{"spec": map[string]any{"n": maxListsRangeSize + 1}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed")
+
+	// A non-integer dynamic argument must be refused as an unresolved overload rather
+	// than crash the binding's type assertion or silently render something.
+	_, err = e.Render(t.Context(), "${lists.range(spec.n)}",
+		map[string]any{"spec": map[string]any{"n": "not-an-int"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no such overload")
+	assert.NotContains(t, err.Error(), "exceeds maximum allowed",
+		"a non-integer argument is an overload failure, not a cap breach")
+}
+
+// MaxListsRangeSizeForTest re-exports the cap for the external test package in
+// custom_functions_env_test.go, which builds the validation environments and therefore
+// cannot live in package template.
+const MaxListsRangeSizeForTest = maxListsRangeSize

--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -4,29 +4,36 @@
 package template
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/interpreter"
 )
 
 // Engine evaluates CEL backed templates that can contain inline expressions, map keys, and nested structures.
 type Engine struct {
 	cache                *EngineCache
 	celExtensions        []cel.EnvOption
+	costLimit            uint64
 	cacheDisabled        bool
 	programCacheDisabled bool
 }
 
 // NewEngine creates a new CEL template engine with default cache settings.
 func NewEngine() *Engine {
-	return &Engine{
+	e := &Engine{
 		cache: newEngineCache(false, false),
 	}
+	e.applyCostDefaults()
+	return e
 }
 
 // NewEngineWithOptions creates a new CEL template engine with custom options.
@@ -48,7 +55,16 @@ func NewEngineWithOptions(opts ...EngineOption) *Engine {
 	if e.cache == nil {
 		e.cache = newEngineCache(e.cacheDisabled, e.programCacheDisabled)
 	}
+	e.applyCostDefaults()
 	return e
+}
+
+// applyCostDefaults installs the built-in cost limit unless a caller supplied one.
+// Every engine is bounded: a zero limit selects the default, it never means "unlimited".
+func (e *Engine) applyCostDefaults() {
+	if e.costLimit == 0 {
+		e.costLimit = defaultCELCostLimit
+	}
 }
 
 // WithCELExtensions adds custom CEL environment options to the engine.
@@ -59,15 +75,57 @@ func WithCELExtensions(extensions ...cel.EnvOption) EngineOption {
 	}
 }
 
+// renderState carries the per-Render context and cost budget through the recursive walk so
+// every expression in one tree - values, list items, and dynamic map keys alike - draws from
+// the same pool and observes the same cancellation.
+type renderState struct {
+	ctx    context.Context
+	budget *CostBudget
+}
+
 // Render walks the provided structure and evaluates CEL expressions against the supplied inputs.
-func (e *Engine) Render(data any, inputs map[string]any) (any, error) {
+//
+// Evaluation is bounded twice: each expression is capped by the engine's cost limit, and the
+// whole walk is charged against the cost budget carried by ctx (see WithCostBudget). Callers
+// without a budget on the context get one scoped to this Render. A cancelled or expired ctx
+// interrupts evaluation, and the resulting error wraps context.Canceled or
+// context.DeadlineExceeded so callers can classify it.
+func (e *Engine) Render(ctx context.Context, data any, inputs map[string]any) (any, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	budget := CostBudgetFrom(ctx)
+	if budget == nil {
+		budget = NewCostBudget(e.renderBudgetDefault())
+	}
+	return e.render(&renderState{ctx: ctx, budget: budget}, data, inputs)
+}
+
+func (e *Engine) render(rs *renderState, data any, inputs map[string]any) (any, error) {
+	// Every value in the tree passes through here, so this is where a walk notices that the
+	// context deadline expired or the reconcile was cancelled. Checking only in renderString
+	// is not enough: a list of numbers or booleans reaches none of the expression paths and
+	// none of the string path either, so a cancelled render would walk it to the end. The
+	// check costs a field read per value and charges nothing against the cost budget - no
+	// CEL work is being paid for.
+	if ctxErr := rs.ctx.Err(); ctxErr != nil {
+		return nil, fmt.Errorf("template render interrupted: %w", ctxErr)
+	}
+
 	switch v := data.(type) {
 	case string:
-		return e.renderString(v, inputs)
+		return e.renderString(rs, v, inputs)
 	case map[string]any:
 		result := make(map[string]any, len(v))
-		for key, value := range v {
-			renderedKey, err := e.renderString(key, inputs)
+		// Walk keys in sorted order. Go randomizes map iteration, and this walk both charges
+		// the cost budget and stops at the first failing expression, so an unordered walk makes
+		// "which expression is named in the error" vary run to run. Reconcilers put that text
+		// in a status condition; a message that changes on every reconcile rewrites the
+		// condition, and each rewrite is a watch event that immediately re-triggers the
+		// reconcile. The rendered result is a map, so ordering the walk changes no output.
+		for _, key := range slices.Sorted(maps.Keys(v)) {
+			value := v[key]
+			renderedKey, err := e.renderString(rs, key, inputs)
 			if err != nil {
 				return nil, err
 			}
@@ -76,10 +134,10 @@ func (e *Engine) Render(data any, inputs map[string]any) (any, error) {
 				evaluatedKey = keyStr
 			} else if renderedKey != key {
 				// Dynamic key expression evaluated to non-string
-				return nil, fmt.Errorf("dynamic map key '%s' must evaluate to a string, got %T: %v", key, renderedKey, renderedKey)
+				return nil, fmt.Errorf("dynamic map key '%s' must evaluate to a string, got %T: %v", TruncateFragment(key), renderedKey, FormatFragment(renderedKey))
 			}
 
-			renderedValue, err := e.Render(value, inputs)
+			renderedValue, err := e.render(rs, value, inputs)
 			if err != nil {
 				return nil, err
 			}
@@ -92,7 +150,7 @@ func (e *Engine) Render(data any, inputs map[string]any) (any, error) {
 	case []any:
 		result := make([]any, 0, len(v))
 		for _, item := range v {
-			rendered, err := e.Render(item, inputs)
+			rendered, err := e.render(rs, item, inputs)
 			if err != nil {
 				return nil, err
 			}
@@ -124,26 +182,42 @@ func (e *Engine) Render(data any, inputs map[string]any) (any, error) {
 //   - Numbers: formatted with minimal precision (%d for integers, %g for floats)
 //   - Booleans: formatted as "true" or "false"
 //   - Objects/arrays: JSON-marshaled, falling back to %v formatting on error
-func (e *Engine) renderString(str string, inputs map[string]any) (any, error) {
-	expressions, err := FindCELExpressions(str)
+func (e *Engine) renderString(rs *renderState, str string, inputs map[string]any) (any, error) {
+	// Map keys reach here without passing through render, so the walk's cancellation check
+	// is repeated for them. The expression paths below are interrupted by ContextEval, but a
+	// template that is almost entirely static never reaches an evaluation and would otherwise
+	// run the whole traversal out under an expired context deadline.
+	if ctxErr := rs.ctx.Err(); ctxErr != nil {
+		return nil, fmt.Errorf("template render interrupted: %w", ctxErr)
+	}
+
+	spans, err := findCELSpans(str)
 	if err != nil {
 		return nil, err
 	}
-	if len(expressions) == 0 {
+	if len(spans) == 0 {
 		return str, nil
 	}
 
 	// Standalone expression: return native type (e.g., ${spec.replicas} returns int, not "3")
 	trimmed := strings.TrimSpace(str)
-	if len(expressions) == 1 && expressions[0].FullExpr == trimmed {
-		result, err := e.evaluateCEL(expressions[0].InnerExpr, inputs)
+	if len(spans) == 1 && str[spans[0].start:spans[0].end] == trimmed {
+		result, err := e.evaluateCEL(rs, spans[0].inner, inputs)
 		return normalizeCELResult(result, err)
 	}
 
-	// Interpolation mode: substitute all expressions into the string
-	rendered := str
-	for _, match := range expressions {
-		value, err := e.evaluateCEL(match.InnerExpr, inputs)
+	// Interpolation mode: substitute all expressions into the string.
+	//
+	// This is a single left-to-right pass over str rather than one strings.Replace per
+	// expression. Replace rebuilds the whole string every time, so a template holding many
+	// expressions copied the accumulated result once per expression - quadratic in the
+	// template size, and invisible to the cost guards because a constant expression like
+	// ${"x"} evaluates for almost nothing. Walking the spans in order costs one pass.
+	var b strings.Builder
+	b.Grow(len(str))
+	cursor := 0
+	for _, span := range spans {
+		value, err := e.evaluateCEL(rs, span.inner, inputs)
 		if err != nil {
 			return nil, err
 		}
@@ -169,10 +243,13 @@ func (e *Engine) renderString(str string, inputs map[string]any) (any, error) {
 			}
 		}
 
-		rendered = strings.Replace(rendered, match.FullExpr, replacement, 1)
+		b.WriteString(str[cursor:span.start])
+		b.WriteString(replacement)
+		cursor = span.end
 	}
+	b.WriteString(str[cursor:])
 
-	return rendered, nil
+	return b.String(), nil
 }
 
 // CELMatch represents a CEL expression found in a template string.
@@ -202,7 +279,35 @@ var ErrNestedExpression = errors.New("nested CEL expressions must be quoted")
 //   - Output: [{FullExpr: "${spec.image}", InnerExpr: "spec.image"},
 //     {FullExpr: "${spec.tag}", InnerExpr: "spec.tag"}]
 func FindCELExpressions(str string) ([]CELMatch, error) {
-	var matches []CELMatch
+	spans, err := findCELSpans(str)
+	if err != nil {
+		return nil, err
+	}
+	if len(spans) == 0 {
+		return nil, nil
+	}
+	matches := make([]CELMatch, len(spans))
+	for i, span := range spans {
+		matches[i] = CELMatch{
+			FullExpr:  str[span.start:span.end],
+			InnerExpr: span.inner,
+		}
+	}
+	return matches, nil
+}
+
+// celSpan is a CEL expression located within its source string: the byte range the
+// ${...} marker occupies, plus the expression text inside it. Interpolation substitutes
+// at these offsets, which is what keeps it to a single pass over the string.
+type celSpan struct {
+	start int // index of the '$' opening the marker
+	end   int // index one past the '}' closing it
+	inner string
+}
+
+// findCELSpans is the scanner behind FindCELExpressions, returning the located form.
+func findCELSpans(str string) ([]celSpan, error) {
+	var matches []celSpan
 	i := 0
 	for i < len(str) {
 		start := strings.Index(str[i:], "${")
@@ -246,7 +351,7 @@ func FindCELExpressions(str string) ([]CELMatch, error) {
 				escaped = false
 			case '$':
 				if !inSingleQuote && !inDoubleQuote && pos+1 < len(str) && str[pos+1] == '{' {
-					return nil, fmt.Errorf("%w: %s", ErrNestedExpression, str[start:pos+2])
+					return nil, fmt.Errorf("%w: %s", ErrNestedExpression, TruncateFragment(str[start:pos+2]))
 				}
 				escaped = false
 			default:
@@ -256,9 +361,10 @@ func FindCELExpressions(str string) ([]CELMatch, error) {
 		}
 
 		if brace == 0 {
-			matches = append(matches, CELMatch{
-				FullExpr:  str[start:pos],
-				InnerExpr: str[start+2 : pos-1],
+			matches = append(matches, celSpan{
+				start: start,
+				end:   pos,
+				inner: str[start+2 : pos-1],
 			})
 			i = pos
 		} else {
@@ -287,7 +393,19 @@ func normalizeCELResult(result any, err error) (any, error) {
 	return result, nil
 }
 
-func (e *Engine) evaluateCEL(expression string, inputs map[string]any) (any, error) {
+func (e *Engine) evaluateCEL(rs *renderState, expression string, inputs map[string]any) (any, error) {
+	// Refuse before doing any work when the allowance is already spent. cel-go reports what
+	// an evaluation cost only once it returns, so the budget is always charged after the
+	// fact; without this check the overshoot is unbounded. Two callers make that concrete:
+	// the error aggregators in the pipelines keep evaluating past a failed expression, and
+	// an expression that fails for its own reason returns that reason rather than the
+	// breach - so nothing would ever stop the sweep, and each remaining expression would
+	// burn up to the full per-expression limit. Checking here bounds the overshoot to the
+	// one expression that crossed the line.
+	if budgetErr := rs.budget.exceeded(); budgetErr != nil {
+		return nil, fmt.Errorf("CEL evaluation skipped for expression '%s': %w", TruncateFragment(expression), budgetErr)
+	}
+
 	env, err := e.getOrCreateEnv(inputs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build CEL environment: %w", err)
@@ -303,24 +421,66 @@ func (e *Engine) evaluateCEL(expression string, inputs map[string]any) (any, err
 		// Compile and cache the program
 		ast, issues := env.Compile(expression)
 		if issues != nil && issues.Err() != nil {
-			return nil, fmt.Errorf("CEL compilation error in expression '%s': %w", expression, issues.Err())
+			return nil, fmt.Errorf("CEL compilation error in expression '%s': %w", TruncateFragment(expression), issues.Err())
 		}
 
-		program, err = env.Program(ast)
+		// The cost limit is frozen into the cached program; changing it requires a controller restart.
+		// CustomFunctionCostOptions feeds the same cost tracker the limit bounds, so our oc_*
+		// overloads are metered by the data they traverse instead of cel-go's O(1) default.
+		programOptions := append([]cel.ProgramOption{
+			cel.CostLimit(e.costLimit),
+			cel.InterruptCheckFrequency(interruptCheckFrequency),
+		}, CustomFunctionCostOptions()...)
+		program, err = env.Program(ast, programOptions...)
 		if err != nil {
-			return nil, fmt.Errorf("CEL program creation error for expression '%s': %w", expression, err)
+			return nil, fmt.Errorf("CEL program creation error for expression '%s': %w", TruncateFragment(expression), err)
 		}
 
 		// Store in cache for future use
 		e.cache.SetProgram(envKey, expression, program)
 	}
 
-	result, _, err := program.Eval(inputs)
+	// ContextEval, rather than Eval, so a cancelled or expired context interrupts a long
+	// running comprehension instead of running it to completion.
+	result, details, err := program.ContextEval(rs.ctx, inputs)
+
+	// Read the cost before any early return so omit() and failed evaluations are still accounted for.
+	var actual uint64
+	if details != nil {
+		if ac := details.ActualCost(); ac != nil {
+			actual = *ac
+		}
+	}
+	// Charge the budget on every path, including the failing ones: work that was performed
+	// counts even when its result is discarded. A concrete evaluation failure is reported
+	// ahead of the budget breach because the underlying cause names what to fix. Deferring
+	// the breach that way is safe because the spend is recorded regardless, and the check at
+	// the top of this function turns it into a refusal the moment anything asks to evaluate
+	// again.
+	budgetErr := rs.budget.add(actual)
+
 	if err != nil {
 		if err.Error() == omitErrMsg {
+			if budgetErr != nil {
+				return nil, fmt.Errorf("CEL evaluation error in expression '%s': %w", TruncateFragment(expression), budgetErr)
+			}
 			return omitSentinel, nil
 		}
-		return nil, fmt.Errorf("CEL evaluation error in expression '%s': %w", expression, err)
+		// cel-go signals an interrupted evaluation without consistently wrapping the context's
+		// own error, so wrap it here: callers classify cancellation and deadlines with
+		// errors.Is against context.Canceled / context.DeadlineExceeded.
+		if ctxErr := rs.ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("CEL evaluation interrupted in expression '%s': %w: %w", TruncateFragment(expression), ctxErr, err)
+		}
+		var cancelled interpreter.EvalCancelledError
+		if errors.As(err, &cancelled) && cancelled.Cause == interpreter.CostLimitExceeded {
+			return nil, fmt.Errorf("CEL evaluation error in expression '%s': %w: %w", TruncateFragment(expression), ErrCostLimitExceeded, err)
+		}
+		return nil, fmt.Errorf("CEL evaluation error in expression '%s': %w", TruncateFragment(expression), err)
+	}
+
+	if budgetErr != nil {
+		return nil, fmt.Errorf("CEL evaluation error in expression '%s': %w", TruncateFragment(expression), budgetErr)
 	}
 
 	return convertCELValue(result), nil

--- a/internal/template/engine_cache.go
+++ b/internal/template/engine_cache.go
@@ -40,6 +40,69 @@ func DisableProgramCacheOnly() EngineOption {
 	}
 }
 
+// CEL evaluation guards - bound the work a single expression can do.
+const (
+	// Measured over the heaviest real samples driven with worst-case-legit inputs when
+	// this limit was derived: the costliest single expression came to 36,141. It is a
+	// transformMapEntry comprehension, which cel-go expands and meters natively, so adding
+	// runtime cost trackers for the oc_* custom functions left it unchanged. The limit is
+	// bounded by the headroom arm (36,141 x 100 = 3.6M) and the memory arm: a quarter of
+	// the controller-manager's 1Gi limit (268MB) divided by 10 concurrent reconciles x
+	// ~10 bytes per cost unit (cel-go StringTraversalCostFactor 0.1) = 2.68M, rounded down
+	// to 2,000,000. That leaves 55x headroom over the measured worst case and caps
+	// transient allocation at 20MB per evaluation at the default maxConcurrentReconciles
+	// of 1. The workflow pipeline was measured afterwards: its heaviest whole reconcile is
+	// three orders of magnitude below this limit, so it does not constrain the number.
+	//
+	// The measurements are upstream's, taken on a tree that also had project and resource
+	// pipelines; neither of those exists on this branch, and nothing here was re-measured.
+	// The ext-overload trackers in ext_overload_costs.go can only raise a measured cost, so
+	// the headroom figures above are upper bounds rather than current readings.
+	//
+	// The control-plane chart states this same number as its celCostLimit default rather
+	// than leaving it at 0, so the two have to be changed together: a chart that pins the
+	// old value would otherwise keep overriding a new default here.
+	defaultCELCostLimit     uint64 = 2_000_000
+	interruptCheckFrequency uint   = 100 // internal; how often ContextEval checks ctx. Not user-configurable.
+)
+
+// renderBudgetFactor scales the resolved per-expression cost limit into the
+// per-reconcile (or per-Render fallback) cumulative budget. An operator raising the
+// cost limit proportionally raises the budget.
+//
+// Sized so the budget leaves at least 10x headroom over the heaviest legitimate reconcile
+// upstream measured: ceil((Rmax_global x 10) / defaultCELCostLimit) = ceil(694,370 /
+// 2,000,000) = 1. Rmax_global is 69,437, the component pipeline's heaviest whole render;
+// the workflow pipeline, driven through its real entry-point sequence on one shared budget,
+// is far below it. The resulting budget of 2,000,000 leaves 28.8x headroom. See
+// defaultCELCostLimit above for what these numbers are and are not.
+//
+// Rmax_global rose from 68,966 when the oc_* custom functions gained runtime cost
+// trackers (see CustomFunctionCostOptions): the samples call oc_generate_name and
+// oc_dns_label throughout, and each call now charges for the bytes it walks instead of
+// a single unit. The factor is unchanged - 10x headroom needs only 694,370 of the
+// 2,000,000 budget.
+//
+// The ext-overload trackers this branch carries (ext_overload_costs.go) charge the cel-go
+// lists and strings overloads the same way, so a template using them costs more here than
+// the figure above. Nothing in the shipped samples was re-measured; the factor has an order
+// of magnitude of slack, which is where that unmeasured increase is absorbed.
+const renderBudgetFactor uint64 = 1
+
+// renderBudgetDefault is the fallback budget used when the caller's context carries none.
+// It bounds a single Render rather than a whole reconcile.
+func (e *Engine) renderBudgetDefault() uint64 {
+	return e.costLimit * renderBudgetFactor
+}
+
+// WithCostLimit sets the maximum accumulated cost for a single CEL expression evaluation.
+// 0 selects the built-in safe default; it never means "unlimited".
+func WithCostLimit(limit uint64) EngineOption {
+	return func(e *Engine) {
+		e.costLimit = limit
+	}
+}
+
 // Default cache sizes - limits memory usage while providing good hit rates
 const (
 	defaultEnvCacheSize = 100 // CEL environments (typically 2-10 unique contexts)

--- a/internal/template/engine_cache_test.go
+++ b/internal/template/engine_cache_test.go
@@ -129,7 +129,7 @@ func TestNewEngineWithOptions_DisableCache(t *testing.T) {
 	tpl := map[string]any{"name": "${metadata.name}"}
 	inputs := map[string]any{"metadata": map[string]any{"name": "test"}}
 
-	result, err := engine.Render(tpl, inputs)
+	result, err := engine.Render(t.Context(), tpl, inputs)
 	require.NoError(t, err)
 
 	resultMap, ok := result.(map[string]any)
@@ -139,7 +139,7 @@ func TestNewEngineWithOptions_DisableCache(t *testing.T) {
 	assert.Equal(t, 0, engine.cache.ProgramCacheSize())
 
 	// Render again — should still work without cache
-	result2, err := engine.Render(tpl, inputs)
+	result2, err := engine.Render(t.Context(), tpl, inputs)
 	require.NoError(t, err)
 
 	resultMap2, ok := result2.(map[string]any)
@@ -157,7 +157,7 @@ func TestNewEngineWithOptions_DisableProgramCacheOnly(t *testing.T) {
 	tpl := map[string]any{"name": "${metadata.name}"}
 	inputs := map[string]any{"metadata": map[string]any{"name": "test"}}
 
-	result, err := engine.Render(tpl, inputs)
+	result, err := engine.Render(t.Context(), tpl, inputs)
 	require.NoError(t, err)
 
 	resultMap, ok := result.(map[string]any)
@@ -183,7 +183,7 @@ func TestNewEngineWithOptions_WithCELExtensions(t *testing.T) {
 	tpl := map[string]any{"result": "${oc_test_double(x)}"}
 	inputs := map[string]any{"x": int64(21)}
 
-	result, err := engine.Render(tpl, inputs)
+	result, err := engine.Render(t.Context(), tpl, inputs)
 	require.NoError(t, err)
 
 	resultMap, ok := result.(map[string]any)
@@ -200,7 +200,7 @@ func TestNewEngineWithOptions_NoOptions(t *testing.T) {
 	tpl := map[string]any{"val": "${x + y}"}
 	inputs := map[string]any{"x": int64(1), "y": int64(2)}
 
-	result, err := engine.Render(tpl, inputs)
+	result, err := engine.Render(t.Context(), tpl, inputs)
 	require.NoError(t, err)
 
 	resultMap, ok := result.(map[string]any)
@@ -222,7 +222,7 @@ func TestNewEngineWithOptions_BadExtensionCausesRenderError(t *testing.T) {
 	tpl := map[string]any{"val": "${x}"}
 	inputs := map[string]any{"x": int64(1)}
 
-	_, err := engine.Render(tpl, inputs)
+	_, err := engine.Render(t.Context(), tpl, inputs)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to build CEL environment")
 }
@@ -249,10 +249,10 @@ replicas: ${replicas}
 			"replicas":    int64(3),
 		}
 
-		result1, err := engine.Render(tpl, inputs)
+		result1, err := engine.Render(t.Context(), tpl, inputs)
 		require.NoError(t, err)
 
-		result2, err := engine.Render(tpl, inputs)
+		result2, err := engine.Render(t.Context(), tpl, inputs)
 		require.NoError(t, err)
 
 		yaml1, _ := yaml.Marshal(result1)
@@ -278,7 +278,7 @@ item2: ${metadata.name}-${item}
 				"item":     fmt.Sprintf("value-%d", i),
 			}
 
-			result, err := engine.Render(tpl, inputs)
+			result, err := engine.Render(t.Context(), tpl, inputs)
 			require.NoError(t, err, "iteration %d", i)
 
 			resultMap := result.(map[string]any)
@@ -300,11 +300,11 @@ item2: ${metadata.name}-${item}
 		inputs2Vars := map[string]any{"x": int64(10), "y": int64(20)}
 		inputs3Vars := map[string]any{"x": int64(5), "y": int64(15), "z": int64(100)}
 
-		result2, err := engine.Render(tpl, inputs2Vars)
+		result2, err := engine.Render(t.Context(), tpl, inputs2Vars)
 		require.NoError(t, err)
 		assert.Equal(t, int64(30), result2.(map[string]any)["value"])
 
-		result3, err := engine.Render(tpl, inputs3Vars)
+		result3, err := engine.Render(t.Context(), tpl, inputs3Vars)
 		require.NoError(t, err)
 		assert.Equal(t, int64(20), result3.(map[string]any)["value"])
 	})
@@ -315,7 +315,7 @@ item2: ${metadata.name}-${item}
 		engine := NewEngine()
 
 		tpl := map[string]any{"val": "${x}"}
-		_, err := engine.Render(tpl, map[string]any{"x": int64(1)})
+		_, err := engine.Render(t.Context(), tpl, map[string]any{"x": int64(1)})
 		require.NoError(t, err)
 
 		assert.Greater(t, engine.cache.ProgramCacheSize(), 0, "cache should have entries")

--- a/internal/template/engine_test.go
+++ b/internal/template/engine_test.go
@@ -6,6 +6,8 @@ package template
 import (
 	"encoding/json"
 	"fmt"
+	"runtime"
+	"strings"
 	"sync"
 	"testing"
 
@@ -554,7 +556,7 @@ dynamicHash: 578fbe87
 			var input map[string]any
 			require.NoError(t, json.Unmarshal([]byte(tt.inputs), &input))
 
-			rendered, err := engine.Render(tpl, input)
+			rendered, err := engine.Render(t.Context(), tpl, input)
 			require.NoError(t, err)
 
 			cleaned := RemoveOmittedFields(rendered)
@@ -733,7 +735,7 @@ value: '${oc_merge({"a": 1})}'
 			var input map[string]any
 			require.NoError(t, json.Unmarshal([]byte(tt.inputs), &input))
 
-			_, err := engine.Render(tpl, input)
+			_, err := engine.Render(t.Context(), tpl, input)
 
 			if tt.wantErr {
 				require.Error(t, err, "expected error containing %q", tt.errContains)
@@ -1065,7 +1067,7 @@ func TestRenderString_InterpolationTypes(t *testing.T) {
 			var input map[string]any
 			require.NoError(t, json.Unmarshal([]byte(tt.inputs), &input))
 
-			rendered, err := engine.Render(tpl, input)
+			rendered, err := engine.Render(t.Context(), tpl, input)
 			require.NoError(t, err)
 
 			got, err := yaml.Marshal(rendered)
@@ -1117,7 +1119,7 @@ func TestRender_ErrorPropagation(t *testing.T) {
 			var input map[string]any
 			require.NoError(t, json.Unmarshal([]byte(tt.inputs), &input))
 
-			_, err := engine.Render(tpl, input)
+			_, err := engine.Render(t.Context(), tpl, input)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.errContains)
 		})
@@ -1136,7 +1138,7 @@ func TestRender_OmitSentinelExclusion(t *testing.T) {
 			"keep":   "value",
 			"remove": "${oc_omit()}",
 		}
-		result, err := engine.Render(tpl, map[string]any{})
+		result, err := engine.Render(t.Context(), tpl, map[string]any{})
 		require.NoError(t, err)
 
 		resultMap, ok := result.(map[string]any)
@@ -1150,7 +1152,7 @@ func TestRender_OmitSentinelExclusion(t *testing.T) {
 		t.Parallel()
 
 		tpl := []any{"first", "${oc_omit()}", "third"}
-		result, err := engine.Render(tpl, map[string]any{})
+		result, err := engine.Render(t.Context(), tpl, map[string]any{})
 		require.NoError(t, err)
 
 		resultSlice, ok := result.([]any)
@@ -1164,15 +1166,15 @@ func TestRender_DefaultPassthrough(t *testing.T) {
 
 	engine := NewEngine()
 
-	result, err := engine.Render(int64(42), map[string]any{})
+	result, err := engine.Render(t.Context(), int64(42), map[string]any{})
 	require.NoError(t, err)
 	assert.Equal(t, int64(42), result)
 
-	result, err = engine.Render(true, map[string]any{})
+	result, err = engine.Render(t.Context(), true, map[string]any{})
 	require.NoError(t, err)
 	assert.Equal(t, true, result)
 
-	result, err = engine.Render(nil, map[string]any{})
+	result, err = engine.Render(t.Context(), nil, map[string]any{})
 	require.NoError(t, err)
 	assert.Nil(t, result)
 }
@@ -1201,7 +1203,7 @@ replicas: ${spec.replicas}
 				"metadata": map[string]any{"name": "app"},
 				"spec":     map[string]any{"replicas": int64(idx)},
 			}
-			result, err := engine.Render(tpl, inputs)
+			result, err := engine.Render(t.Context(), tpl, inputs)
 			if err != nil {
 				errs <- err
 				return
@@ -1225,5 +1227,87 @@ replicas: ${spec.replicas}
 
 	for err := range errs {
 		t.Errorf("concurrent render error: %v", err)
+	}
+}
+
+// Interpolation substitutes at each expression's own position. The previous implementation
+// called strings.Replace(rendered, fullExpr, replacement, 1) per match, which replaces the
+// first REMAINING occurrence of the marker text rather than the one that was evaluated.
+// That coincides with position order only until a replacement value itself contains the
+// marker text — then the next expression substitutes into the injected text and the output
+// is wrong. This is the behavior the single-pass rewrite has to get right, and the only
+// input shape that tells the two implementations apart.
+func TestInterpolationSubstitutesAtEachPosition(t *testing.T) {
+	e := NewEngine()
+
+	// The value of ${a} is the literal text of a marker that appears LATER in the template,
+	// which is what tells the two implementations apart: a first-occurrence replace
+	// substitutes ${b} into the text it just injected at x, leaving the real ${b} at z
+	// untouched. It would produce "x=second y=${b} z=${b}"; substituting at each
+	// expression's own position produces the want below.
+	inputs := map[string]any{
+		"a": "${b}",
+		"b": "second",
+	}
+	got, err := e.Render(t.Context(), "x=${a} y=${a} z=${b}", inputs)
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+	want := "x=${b} y=${b} z=second"
+	if got != want {
+		t.Fatalf("interpolation substituted at the wrong positions:\n got %q\nwant %q", got, want)
+	}
+}
+
+// A template holding many expressions must cost one pass over the string, not one copy of
+// the whole string per expression.
+//
+// The test measures bytes allocated rather than elapsed time: allocation is what the
+// quadratic form actually spends, and it does not vary with how loaded the machine is.
+// Rebuilding a ~600KB string once per expression across 20,000 expressions allocates on the
+// order of 10GB; a single pass allocates a few times the template size. The threshold sits
+// two orders of magnitude below the quadratic figure and two above the linear one, so it
+// cannot be reached by ordinary variation in either direction.
+func TestInterpolationIsLinearInTemplateSize(t *testing.T) {
+	const (
+		expressions = 20_000
+		filler      = 25
+	)
+
+	var b strings.Builder
+	for range expressions {
+		b.WriteString(strings.Repeat("x", filler))
+		b.WriteString(`${"v"}`)
+	}
+	tmpl := b.String()
+
+	e := NewEngine()
+	// Compile and cache the program first: program construction allocates, and that cost
+	// belongs to neither implementation's substitution loop.
+	if _, err := e.Render(t.Context(), `${"v"}`, emptyInputs()); err != nil {
+		t.Fatalf("warmup render failed: %v", err)
+	}
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	got, err := e.Render(t.Context(), tmpl, emptyInputs())
+	runtime.ReadMemStats(&after)
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+
+	want := strings.Repeat(strings.Repeat("x", filler)+"v", expressions)
+	if got != want {
+		t.Fatalf("rendered output is wrong: got %d bytes, want %d bytes", len(got.(string)), len(want))
+	}
+
+	allocated := after.TotalAlloc - before.TotalAlloc
+	const budget = 100 << 20 // 100MB
+	t.Logf("template=%d bytes expressions=%d allocated=%d bytes", len(tmpl), expressions, allocated)
+	if allocated > budget {
+		t.Fatalf("interpolating %d expressions allocated %d bytes, over the %d-byte budget; "+
+			"substitution is copying the whole template per expression again",
+			expressions, allocated, budget)
 	}
 }

--- a/internal/template/errors.go
+++ b/internal/template/errors.go
@@ -1,0 +1,194 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package template
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+	"unicode/utf8"
+)
+
+// ErrCostLimitExceeded reports that a single CEL expression exceeded the
+// per-expression cost limit. Reconcilers use errors.Is against it to classify
+// the failure as terminal (the template is immutable; retrying cannot succeed).
+var ErrCostLimitExceeded = errors.New("cel expression cost limit exceeded")
+
+// ErrCostBudgetExceeded reports that the cumulative render cost budget for a
+// reconcile (or a single Render, for standalone callers) was exhausted.
+var ErrCostBudgetExceeded = errors.New("template render cost budget exceeded")
+
+// ErrExpansionLimitExceeded reports that a fan-out guard refused to expand a
+// collection: a forEach whose item count exceeds the cap, or a trait patch whose
+// item-by-target cross product exceeds the cap. The lists.range() size cap is
+// deliberately not among them — cel-go raises it as an untyped error and refuses
+// before allocating, so it needs neither a message match nor paced retries.
+//
+// These guards trip on the shape of the inputs, not on how busy the process is,
+// so the same object trips the same guard on every reconcile until a human edits
+// the template or the data behind it (see IsTerminalRenderError).
+var ErrExpansionLimitExceeded = errors.New("template expansion limit exceeded")
+
+// IsTerminalRenderError reports whether a render error is deterministic for
+// unchanged inputs: a per-expression cost-limit breach, an exhausted reconcile
+// cost budget, or a fan-out guard breach. Deadline expiry is deliberately
+// excluded — it is load-dependent and therefore transient.
+func IsTerminalRenderError(err error) bool {
+	return errors.Is(err, ErrCostLimitExceeded) ||
+		errors.Is(err, ErrCostBudgetExceeded) ||
+		errors.Is(err, ErrExpansionLimitExceeded)
+}
+
+// IsRenderAborted reports whether a render error means no further expression in the same
+// unit of work is worth evaluating: a terminal cost breach, or a cancelled or expired
+// context. Error aggregators that would otherwise evaluate every rule consult it so an
+// exhausted budget is reported once instead of being spent again on every remaining rule.
+func IsRenderAborted(err error) bool {
+	return IsTerminalRenderError(err) ||
+		errors.Is(err, context.Canceled) ||
+		errors.Is(err, context.DeadlineExceeded)
+}
+
+// maxErrorExprLen bounds how much of a tenant-authored fragment an error may quote.
+// Render errors are copied verbatim into status conditions; a tenant is free to author a
+// multi-hundred-kilobyte expression, and an object that large is rejected by the API
+// server. The status write then fails, and the breach is never recorded on the object.
+const maxErrorExprLen = 256
+
+// TruncationMarker is appended to a fragment that TruncateTo had to cut, so a reader
+// can tell a bounded message from a complete one.
+const TruncationMarker = "…(truncated)"
+
+// TruncateFragment bounds a fragment of tenant-authored input - an expression, a where
+// clause, a forEach item value - for inclusion in an error message. Fragments shorter than
+// the bound are returned unchanged, so error text that names a short expression reads
+// exactly as it always has.
+//
+// Every layer that names such a fragment in an error must route it through here. The engine
+// bounds what it names, but an outer wrap that re-quotes the raw input puts the whole
+// fragment back into the message, and it is the outermost message that reaches the status
+// condition.
+func TruncateFragment(s string) string {
+	return TruncateTo(s, maxErrorExprLen)
+}
+
+// FormatFragment bounds a tenant-authored *value* - a rendered forEach item, a dynamic map
+// key that came back as the wrong type - for inclusion in an error message. It is the
+// value-shaped counterpart to TruncateFragment, and exists because the obvious spelling,
+// TruncateFragment(fmt.Sprintf("%v", val)), bounds only the result: fmt serializes the
+// whole value into its own buffer first, so a rendered item large enough to be worth
+// guarding against is paid for in full merely to display 256 bytes of it. This walks the
+// value instead and stops as soon as it has enough, so the work is proportional to what
+// survives rather than to what was rendered.
+//
+// The rendering follows fmt's %v for the shapes a rendered template value takes - maps
+// print as map[k:v ...] with sorted keys, lists as [a b c] - so bounded previews read the
+// same as the unbounded ones they replace.
+func FormatFragment(val any) string {
+	if s, ok := val.(string); ok {
+		return TruncateFragment(s)
+	}
+	// One byte of headroom over the bound: a value that needed more than the bound then
+	// arrives here longer than it, so TruncateTo marks the cut instead of returning an
+	// exactly-sized string that reads as complete.
+	return TruncateFragment(string(appendFragment(nil, val, maxErrorExprLen+1)))
+}
+
+// appendFragment appends a %v-like rendering of val to dst, giving up as soon as dst has
+// reached limit. Containers are walked here rather than handed to fmt so that a large one
+// is abandoned partway; the scalars at the leaves are small enough to format whole.
+func appendFragment(dst []byte, val any, limit int) []byte {
+	if len(dst) >= limit {
+		return dst
+	}
+	switch v := val.(type) {
+	case nil:
+		return append(dst, "<nil>"...)
+	case string:
+		return appendBounded(dst, v, limit)
+	case map[string]any:
+		// Sorted keys, as fmt does: an unordered preview would name a different entry on
+		// every reconcile, rewriting the status condition that carries it.
+		dst = append(dst, "map["...)
+		for i, k := range slices.Sorted(maps.Keys(v)) {
+			if len(dst) >= limit {
+				break
+			}
+			if i > 0 {
+				dst = append(dst, ' ')
+			}
+			dst = appendBounded(dst, k, limit)
+			dst = append(dst, ':')
+			dst = appendFragment(dst, v[k], limit)
+		}
+		return append(dst, ']')
+	case []any:
+		dst = append(dst, '[')
+		for i, item := range v {
+			if len(dst) >= limit {
+				break
+			}
+			if i > 0 {
+				dst = append(dst, ' ')
+			}
+			dst = appendFragment(dst, item, limit)
+		}
+		return append(dst, ']')
+	default:
+		// Scalars: numbers, booleans, and the occasional type that is not part of a
+		// rendered value's shape. Formatting one whole costs no more than reading it.
+		return appendBounded(dst, fmt.Sprintf("%v", v), limit)
+	}
+}
+
+// appendBounded appends as much of s as the room up to limit allows, cutting on a rune
+// boundary. A preview assembled from pieces has to stay valid UTF-8 at every cut, not just
+// the final one: the API server rejects invalid UTF-8 in a status condition, and a cut in
+// the middle of the preview is not one the outer TruncateTo would ever repair.
+func appendBounded(dst []byte, s string, limit int) []byte {
+	room := limit - len(dst)
+	if room <= 0 {
+		return dst
+	}
+	if room >= len(s) {
+		return append(dst, s...)
+	}
+	for room > 0 && !utf8.RuneStart(s[room]) {
+		room--
+	}
+	return append(dst, s[:room]...)
+}
+
+// TruncateTo bounds s to maxBytes, appending a truncation marker when it cuts. The marker
+// is counted against the bound, so the returned string never exceeds maxBytes - callers
+// bound a message precisely because something downstream rejects one that is too large,
+// and a return value that overshoots by the marker's length defeats that.
+//
+// A bound too small to hold the marker leaves no room to say anything about the cut, so
+// the text is cut to the bound and the marker is dropped rather than pushing past it.
+// A non-positive bound returns an empty string.
+//
+// The cut lands on a rune boundary: a fragment sliced mid-rune is invalid UTF-8, and the
+// API server rejects invalid UTF-8 in a status condition - which would recreate the very
+// failure this bound exists to prevent.
+func TruncateTo(s string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(s) <= maxBytes {
+		return s
+	}
+	marker := TruncationMarker
+	cut := maxBytes - len(marker)
+	if cut <= 0 {
+		marker = ""
+		cut = maxBytes
+	}
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + marker
+}

--- a/internal/template/errors_test.go
+++ b/internal/template/errors_test.go
@@ -1,0 +1,217 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package template
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestIsTerminalRenderError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"cost limit", ErrCostLimitExceeded, true},
+		{"cost budget", ErrCostBudgetExceeded, true},
+		{
+			name: "wrapped cost limit",
+			err:  fmt.Errorf("render resource %q: %w", "deployment", ErrCostLimitExceeded),
+			want: true,
+		},
+		{
+			name: "doubly wrapped cost budget",
+			err:  fmt.Errorf("render: %w", fmt.Errorf("rule 3: %w", ErrCostBudgetExceeded)),
+			want: true,
+		},
+		{
+			name: "joined with a plain error",
+			err:  errors.Join(errors.New("output foo failed"), ErrCostLimitExceeded),
+			want: true,
+		},
+		{
+			name: "deadline exceeded is transient, not terminal",
+			err:  context.DeadlineExceeded,
+			want: false,
+		},
+		{
+			name: "wrapped deadline exceeded is transient, not terminal",
+			err:  fmt.Errorf("render aborted: %w", context.DeadlineExceeded),
+			want: false,
+		},
+		{"cancelled is transient, not terminal", context.Canceled, false},
+		{"plain error", errors.New("template parse failed"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTerminalRenderError(tt.err); got != tt.want {
+				t.Fatalf("IsTerminalRenderError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// Render errors are copied into status conditions, and a tenant may author an expression far
+// larger than an object can hold. The engine bounds how much of it any error quotes.
+func TestErrorMessagesBoundExpressionText(t *testing.T) {
+	e := NewEngine()
+	// A long but syntactically broken expression: the compile error names it.
+	expr := "${" + strings.Repeat("averyverylongidentifier.", 5_000) + "&&&}"
+
+	_, err := e.Render(t.Context(), expr, emptyInputs())
+	if err == nil {
+		t.Fatal("expected a compilation error, got nil")
+	}
+	if len(err.Error()) > 8_000 {
+		t.Fatalf("error message quoted an unbounded expression: %d bytes", len(err.Error()))
+	}
+	if !strings.Contains(err.Error(), TruncationMarker) {
+		t.Fatalf("expected the quoted expression to be marked truncated, got: %v", err)
+	}
+}
+
+// Truncation must only apply beyond the bound, so error text naming an ordinary expression
+// reads exactly as it always has.
+func TestShortExpressionsAreNotTruncated(t *testing.T) {
+	e := NewEngine()
+	_, err := e.Render(t.Context(), "${spec.missing.field}", map[string]any{"spec": map[string]any{}})
+	if err == nil {
+		t.Fatal("expected an evaluation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "spec.missing.field") {
+		t.Fatalf("expected the error to name the short expression in full, got: %v", err)
+	}
+	if strings.Contains(err.Error(), TruncationMarker) {
+		t.Fatalf("a short expression must not be truncated, got: %v", err)
+	}
+}
+
+// A cut landing mid-rune produces invalid UTF-8, which the API server rejects in a status
+// condition — recreating the failure the bound exists to prevent.
+func TestTruncateExprCutsOnRuneBoundaries(t *testing.T) {
+	// Three-byte runes do not divide evenly into the bound, so at least one offset lands
+	// mid-rune; sweep the surrounding lengths to catch every alignment.
+	for length := maxErrorExprLen - 4; length <= maxErrorExprLen+4; length++ {
+		runes := strings.Repeat("あ", length)
+		got := TruncateFragment(runes)
+		body := strings.TrimSuffix(got, TruncationMarker)
+		if !utf8.ValidString(body) {
+			t.Fatalf("truncation produced invalid UTF-8 for a %d-rune input", length)
+		}
+	}
+}
+
+func TestTruncateToNonPositiveBoundReturnsEmpty(t *testing.T) {
+	for _, maxBytes := range []int{0, -1} {
+		if got := TruncateTo("tenant-authored text", maxBytes); got != "" {
+			t.Fatalf("TruncateTo(..., %d) = %q, want empty", maxBytes, got)
+		}
+	}
+}
+
+// FormatFragment exists so that bounding a value's preview does not first cost the whole
+// value. Its output has to satisfy the same contract as TruncateFragment's: within the
+// bound, valid UTF-8, and unchanged when the value is small enough to show in full.
+func TestFormatFragmentBoundsLargeValues(t *testing.T) {
+	huge := strings.Repeat("z", 100_000)
+	cases := map[string]any{
+		"bare string":  huge,
+		"list":         []any{huge, huge},
+		"map":          map[string]any{"a": huge, "b": huge},
+		"nested":       []any{map[string]any{"k": []any{huge}}},
+		"huge map key": map[string]any{huge: 1},
+	}
+	for name, val := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := FormatFragment(val)
+			if len(got) > maxErrorExprLen {
+				t.Fatalf("preview is %d bytes, want at most %d", len(got), maxErrorExprLen)
+			}
+			if !strings.HasSuffix(got, TruncationMarker) {
+				t.Fatalf("a cut preview must say so, got: %q", got)
+			}
+		})
+	}
+}
+
+// Small values must read exactly as fmt's %v did before the bound was introduced: the
+// preview is what tells an operator which item failed, and most items are small.
+func TestFormatFragmentLeavesSmallValuesAsFmtWouldRenderThem(t *testing.T) {
+	for _, val := range []any{
+		"alpha",
+		42,
+		3.5,
+		true,
+		nil,
+		[]any{"a", "b"},
+		map[string]any{"b": 2, "a": 1},
+		[]any{map[string]any{"name": "web", "port": 8080}},
+	} {
+		want := fmt.Sprintf("%v", val)
+		if got := FormatFragment(val); got != want {
+			t.Errorf("FormatFragment(%#v) = %q, want %q", val, got, want)
+		}
+	}
+}
+
+// A preview is assembled from pieces, so a cut can land inside any of them, not just at the
+// end. The API server rejects invalid UTF-8 in a status condition, which is the failure the
+// whole bound exists to prevent.
+func TestFormatFragmentCutsOnRuneBoundaries(t *testing.T) {
+	multibyte := strings.Repeat("世", 10_000)
+	for _, val := range []any{
+		multibyte,
+		[]any{multibyte},
+		map[string]any{multibyte: multibyte},
+	} {
+		got := FormatFragment(val)
+		if !utf8.ValidString(got) {
+			t.Fatalf("preview is not valid UTF-8: %q", got)
+		}
+		if len(got) > maxErrorExprLen {
+			t.Fatalf("preview is %d bytes, want at most %d", len(got), maxErrorExprLen)
+		}
+	}
+}
+
+// countingValue reports how many times it has been formatted. FormatFragment's whole reason
+// to exist is the work it does *not* do, which the output alone cannot show.
+type countingValue struct {
+	formatted *int
+	text      string
+}
+
+func (c countingValue) String() string {
+	*c.formatted++
+	return c.text
+}
+
+// The point of walking the value instead of handing it to fmt is that a large container is
+// abandoned as soon as there is enough to show. fmt.Sprintf("%v", …) formats every element
+// first and truncates afterwards, so it would pay for all 1,000 of these to display three.
+func TestFormatFragmentStopsWalkingOnceBounded(t *testing.T) {
+	formatted := 0
+	items := make([]any, 1000)
+	for i := range items {
+		items[i] = countingValue{&formatted, strings.Repeat("x", 100)}
+	}
+
+	got := FormatFragment(items)
+	if len(got) > maxErrorExprLen {
+		t.Fatalf("preview is %d bytes, want at most %d", len(got), maxErrorExprLen)
+	}
+
+	// 256 bytes of preview at ~100 bytes an element: a handful, nowhere near all of them.
+	if want := 10; formatted > want {
+		t.Fatalf("formatted %d of %d elements to fill a %d-byte preview, want at most %d",
+			formatted, len(items), maxErrorExprLen, want)
+	}
+}

--- a/internal/template/ext_overload_costs.go
+++ b/internal/template/ext_overload_costs.go
@@ -1,0 +1,263 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package template
+
+import (
+	"math"
+
+	"github.com/google/cel-go/common"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+)
+
+// This file carries the runtime cost trackers for the cel-go extension overloads that the
+// pinned cel-go release does not meter itself.
+//
+// Newer cel-go installs its own interpreter.OverloadCostTracker functions for these
+// extensions, so `lists.range(n)` is charged by the list it allocates and `s.lowerAscii()` by
+// the bytes it walks. They arrive one extension at a time: lists in v0.25, strings in v0.28,
+// encoders in v0.30. On v0.22.1, which this branch pins, ext.listsLib.ProgramOptions,
+// ext.stringLib.ProgramOptions and ext.encoderLib.ProgramOptions all return an empty
+// slice. Every one of those overloads therefore falls through to cel-go's
+// flat one-unit default, and the per-expression cost limit and the reconcile budget see
+// nothing. Two shapes made that concrete before these trackers existed:
+//
+//   - `size(lists.range(10000).distinct())` measured 3 units and ran for ~160ms, so a template
+//     could repeat it a few hundred times inside a 2,000,000-unit budget.
+//   - `size([lists.range(10000), ...x4500])` measured 4,511 units and allocated ~1GB.
+//
+// The formulas below mirror the ones newer cel-go ships, so a template costs the same order of
+// magnitude here as it will after an upgrade. THEY MUST BE DELETED ON THE FIRST BUMP PAST
+// v0.24, and the ones still live re-checked at every bump after it: the library's own trackers
+// take precedence over an ActualCostEstimator (see CostTracker.costCall, which consults
+// overloadTrackers first and returns), so a duplicate is dead code at best, and any formula
+// that diverged would silently become the losing one. A partial bump is the worst case,
+// because a version that meters lists but not strings leaves half this file live.
+//
+// ext.Sets() is deliberately absent. It installs its own trackers as far back as v0.22.1, and
+// those already win over anything this estimator returns.
+//
+// Sizes differ from cel-go's own ext.actualSize in one respect, noted on runtimeSize: strings
+// are measured in bytes rather than runes.
+
+// extOverloadCost prices one extension-overload call, or reports nil to leave the call on
+// cel-go's own accounting.
+//
+// Dispatch is by overload ID wherever cel-go resolves one. It does not always: a function
+// whose overloads share an arity cannot be resolved from a DynType argument, and every
+// template input is declared DynType, so `payload.sort()` and `payload.reverse()` arrive with
+// an empty ID. Those are the calls a tenant actually controls, so the three affected functions
+// - sort, @sortByAssociatedKeys and reverse - are keyed by name instead, which covers the
+// resolved and unresolved forms in one case. reverse is the only name shared by a list and a
+// string overload, and the receiver's own type tells them apart.
+func extOverloadCost(function, overloadID string, args []ref.Val, result ref.Val) *uint64 {
+	var cost uint64
+
+	switch overloadID {
+	case "lists_range", "list_reverse", "list_slice":
+		cost = allocatingListCost(1, runtimeSize(result))
+
+	case "list_distinct":
+		cost = listSelfCompareCost(argAt(args, 0))
+
+	case "list_flatten", "list_flatten_int":
+		cost = listFlattenCost(args, result)
+
+	case "list_join", "list_join_string":
+		cost = listJoinCost(argAt(args, 0), result)
+
+	case "string_split_string", "string_split_string_int":
+		cost = stringSplitCost(argAt(args, 0), result)
+
+	case "string_replace_string_string", "string_replace_string_string_int":
+		cost = stringReplaceCost(args, result)
+
+	case "string_lower_ascii", "string_upper_ascii", "string_trim", "string_reverse",
+		"string_substring_int", "string_substring_int_int":
+		cost = stringTransformCost(argAt(args, 0), result)
+
+	case "string_index_of_string", "string_index_of_string_int",
+		"string_last_index_of_string", "string_last_index_of_string_int":
+		cost = stringSearchCost(argAt(args, 0), argAt(args, 1))
+
+	case "string_char_at_int":
+		cost = stringCharAtCost(argAt(args, 0))
+
+	case "base64_encode_bytes", "base64_decode_string":
+		cost = byteScanCost(argAt(args, 0))
+
+	default:
+		switch function {
+		case "sort":
+			cost = listSelfCompareCost(argAt(args, 0))
+		case "@sortByAssociatedKeys":
+			// The sort is driven by the key list, which is what newer cel-go charges for.
+			cost = listSelfCompareCost(argAt(args, 1))
+		case "reverse":
+			if _, isList := argAt(args, 0).(traits.Lister); isList {
+				cost = allocatingListCost(1, runtimeSize(result))
+			} else {
+				cost = stringTransformCost(argAt(args, 0), result)
+			}
+		default:
+			return nil
+		}
+	}
+
+	return &cost
+}
+
+// allocatingListCost charges a call that builds a list: the elements it produced, scaled by
+// how many times each is touched, plus the dispatch and the allocation itself.
+func allocatingListCost(costFactor float64, size uint64) uint64 {
+	if costFactor < 0 {
+		costFactor = 1.0
+	}
+	return saturatingAdd(saturatingAdd(scaledCost(size, costFactor), callDispatchCost), common.ListCreateBaseCost)
+}
+
+// listSelfCompareCost charges a worst-case O(n^2) pass in which every element is compared
+// against every other: distinct, sort and sortBy all do this. Comparing strings or bytes walks
+// their contents as well, which is the extra factor.
+func listSelfCompareCost(val ref.Val) uint64 {
+	size := runtimeSize(val)
+	costFactor := 2.0
+	lister, ok := val.(traits.Lister)
+	if !ok || size == 0 {
+		return allocatingListCost(costFactor, 0)
+	}
+	switch lister.Get(types.IntZero).Type() {
+	case types.StringType, types.BytesType:
+		costFactor += common.StringTraversalCostFactor
+	}
+	return allocatingListCost(costFactor, saturatingMul(size, size))
+}
+
+// listFlattenCost charges a flatten by whichever is larger: the list it produced, or the depth
+// it was asked to descend times the list it was handed. Neither bound dominates the other -
+// a deep flatten visits more elements than it returns, a shallow one over nested lists returns
+// more than it was given - and cel-go has used each of the two formulas in turn.
+func listFlattenCost(args []ref.Val, result ref.Val) uint64 {
+	depth := uint64(1)
+	if d, ok := argAt(args, 1).(types.Int); ok && int64(d) > 1 {
+		depth = uint64(d) //nolint:gosec // guarded above: d is greater than 1, so the conversion is in range
+	}
+	traversed := saturatingMul(depth, runtimeSize(argAt(args, 0)))
+	return allocatingListCost(1, max(traversed, runtimeSize(result)))
+}
+
+// listJoinCost charges a join by the elements walked plus the string built.
+func listJoinCost(input, result ref.Val) uint64 {
+	return saturatingAdd(
+		saturatingAdd(callDispatchCost, traversalCost(saturatingAdd(runtimeSize(input), 1))),
+		runtimeSize(result))
+}
+
+// stringSplitCost charges a split by the string walked, the allocation of the result list,
+// and the number of pieces it holds - the piece count, not their bytes, which is what
+// newer cel-go charges here too.
+func stringSplitCost(input, result ref.Val) uint64 {
+	scan := saturatingAdd(callDispatchCost, traversalCost(saturatingAdd(runtimeSize(input), 1)))
+	return saturatingAdd(saturatingAdd(scan, runtimeSize(result)), common.ListCreateBaseCost)
+}
+
+// stringTransformCost charges an O(n) rewrite of a string by what it read and what it wrote.
+func stringTransformCost(input, result ref.Val) uint64 {
+	return saturatingAdd(
+		saturatingAdd(callDispatchCost, traversalCost(runtimeSize(input))),
+		runtimeSize(result))
+}
+
+// stringSearchCost charges an O(n*m) scan of a haystack for a needle.
+func stringSearchCost(haystack, needle ref.Val) uint64 {
+	return saturatingAdd(callDispatchCost,
+		traversalCost(saturatingMul(runtimeSize(haystack), runtimeSize(needle))))
+}
+
+// stringReplaceCost charges the search for every occurrence plus the string that was built.
+// An empty target or needle still costs a pass, so neither is allowed to zero the product.
+func stringReplaceCost(args []ref.Val, result ref.Val) uint64 {
+	targetSize := max(runtimeSize(argAt(args, 0)), 1)
+	needleSize := max(runtimeSize(argAt(args, 1)), 1)
+	search := traversalCost(saturatingMul(targetSize, needleSize))
+	return saturatingAdd(saturatingAdd(callDispatchCost, search), runtimeSize(result))
+}
+
+// stringCharAtCost charges a single character read: cel-go converts the whole string to runes
+// to index it, so the cost is proportional to the string, not to the one character returned.
+func stringCharAtCost(input ref.Val) uint64 {
+	return saturatingAdd(saturatingAdd(callDispatchCost, traversalCost(runtimeSize(input))), 1)
+}
+
+// byteScanCost charges a call that reads its argument end to end and writes a proportional
+// result, which is what the base64 codecs do.
+func byteScanCost(input ref.Val) uint64 {
+	return saturatingAdd(callDispatchCost, traversalCost(runtimeSize(input)))
+}
+
+// callDispatchCost is what cel-go charges for reaching an overload at all, before anything it
+// reads or writes is counted.
+const callDispatchCost uint64 = 1
+
+// runtimeSize reports the size cel-go's own trackers would use for a value: the entry count of
+// a collection, the length of a string or byte sequence, and one for a scalar that reports no
+// size at all.
+//
+// It differs from cel-go's ext.actualSize in measuring a string in bytes rather than runes.
+// These overloads walk bytes, and a rune count under-charges multi-byte input by up to a
+// factor of four - or sixteen where two sizes are multiplied, as in stringSearchCost and
+// stringReplaceCost. Over-charging is the direction that matters, because the cost is a
+// guard rather than a bill.
+func runtimeSize(val ref.Val) uint64 {
+	if val == nil {
+		return 0
+	}
+	switch v := val.Value().(type) {
+	case string:
+		return uint64(len(v))
+	case []byte:
+		return uint64(len(v))
+	}
+	size := collectionLen(val)
+	if size < 0 {
+		return 1
+	}
+	return uint64(size)
+}
+
+// argAt reads one argument without assuming the arity cel-go dispatched with. A tracker runs
+// inside the cost observer, where an index out of range would panic the reconcile rather than
+// mismeter it.
+func argAt(args []ref.Val, i int) ref.Val {
+	if i < 0 || i >= len(args) {
+		return nil
+	}
+	return args[i]
+}
+
+// scaledCost multiplies a size by a cost factor and rounds up, saturating rather than wrapping
+// or producing an implementation-defined conversion at the top of the uint64 range.
+func scaledCost(size uint64, factor float64) uint64 {
+	scaled := math.Ceil(float64(size) * factor)
+	if scaled <= 0 {
+		return 0
+	}
+	if scaled >= math.MaxUint64 {
+		return math.MaxUint64
+	}
+	return uint64(scaled)
+}
+
+// saturatingMul multiplies two costs without wrapping, for the same reason saturatingAdd does:
+// a wrapped product of an n^2 term would read as a tiny cost.
+func saturatingMul(a, b uint64) uint64 {
+	if a == 0 || b == 0 {
+		return 0
+	}
+	if a > math.MaxUint64/b {
+		return math.MaxUint64
+	}
+	return a * b
+}

--- a/internal/template/ext_overload_costs_test.go
+++ b/internal/template/ext_overload_costs_test.go
@@ -1,0 +1,404 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package template
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+// The cel-go release this branch pins (v0.22.1) ships no runtime cost trackers for the
+// strings, lists and encoders extensions: ext.listsLib.ProgramOptions and its string and
+// encoder equivalents all return an empty slice, and cel-go therefore charges every one of
+// those overloads a flat unit no matter how much data it walks. Newer cel-go installs
+// trackers for all of them, so on this branch customFunctionCostEstimator carries them
+// instead.
+//
+// Each case below feeds the same expression a small and a large input. Without a tracker the
+// two measurements are identical, which is what makes these tests fail if the estimator's
+// cases are removed.
+func TestExtOverloadCostGrowsWithInputSize(t *testing.T) {
+	// String inputs are supplied as bound variables rather than built inside the expression.
+	// A whole-collection identifier reference charges roughly constant, so the growth these
+	// tests observe comes from the overload under test and not from the fixture.
+	stringInput := func(size int) map[string]any {
+		return map[string]any{"spec": map[string]any{}, "payload": strings.Repeat("a", size)}
+	}
+	base64Input := func(size int) map[string]any {
+		return map[string]any{"spec": map[string]any{}, "payload": strings.Repeat("YWJj", size/4)}
+	}
+	bytesInput := func(size int) map[string]any {
+		return map[string]any{"spec": map[string]any{}, "payload": []byte(strings.Repeat("a", size))}
+	}
+	stringListInput := func(size int) map[string]any {
+		items := make([]any, size)
+		for i := range items {
+			items[i] = "x"
+		}
+		return map[string]any{"spec": map[string]any{}, "payload": items}
+	}
+	intListInput := func(size int) map[string]any {
+		items := make([]any, size)
+		for i := range items {
+			items[i] = int64(i)
+		}
+		return map[string]any{"spec": map[string]any{}, "payload": items}
+	}
+	sized := func(format string) func(int) string {
+		return func(n int) string { return fmt.Sprintf(format, n) }
+	}
+	fixed := func(expr string) func(int) string {
+		return func(int) string { return expr }
+	}
+
+	tests := []struct {
+		name   string
+		expr   func(size int) string
+		inputs func(size int) map[string]any
+	}{
+		{name: "lists_range", expr: sized("${size(lists.range(%d))}"), inputs: emptyInputsSized},
+		{name: "list_reverse", expr: sized("${size(lists.range(%d).reverse())}"), inputs: emptyInputsSized},
+		{name: "list_slice", expr: sized("${size(lists.range(%d).slice(0, %[1]d))}"), inputs: emptyInputsSized},
+		{name: "list_flatten", expr: sized("${size([lists.range(%d)].flatten())}"), inputs: emptyInputsSized},
+		{name: "list_flatten_int", expr: sized("${size([lists.range(%d)].flatten(1))}"), inputs: emptyInputsSized},
+		{name: "list_distinct", expr: sized("${size(lists.range(%d).distinct())}"), inputs: emptyInputsSized},
+		{name: "list_int_sort", expr: sized("${size(lists.range(%d).sort())}"), inputs: emptyInputsSized},
+		{name: "list_int_sortByAssociatedKeys", expr: sized("${size(lists.range(%d).sortBy(e, e))}"), inputs: emptyInputsSized},
+
+		// The dynamic forms are separate cases because cel-go hands the estimator an empty
+		// overload ID when a DynType argument stops the planner resolving one, and every
+		// template input is declared DynType.
+		{name: "sort over a dyn list", expr: fixed("${size(payload.sort())}"), inputs: intListInput},
+		{name: "sortBy over a dyn list", expr: fixed("${size(payload.sortBy(e, e))}"), inputs: intListInput},
+		{name: "reverse over a dyn list", expr: fixed("${size(payload.reverse())}"), inputs: intListInput},
+		{name: "reverse over a dyn string", expr: fixed("${size(payload.reverse())}"), inputs: stringInput},
+
+		{name: "list_join", expr: fixed("${size(payload.join())}"), inputs: stringListInput},
+		{name: "list_join_string", expr: fixed(`${size(payload.join(","))}`), inputs: stringListInput},
+
+		{name: "string_split_string", expr: fixed(`${size(payload.split("a"))}`), inputs: stringInput},
+		{name: "string_split_string_int", expr: fixed(`${size(payload.split("a", -1))}`), inputs: stringInput},
+		{name: "string_replace_string_string", expr: fixed(`${size(payload.replace("a", "b"))}`), inputs: stringInput},
+		{name: "string_replace_string_string_int", expr: fixed(`${size(payload.replace("a", "b", -1))}`), inputs: stringInput},
+		{name: "string_substring_int", expr: fixed("${size(payload.substring(0))}"), inputs: stringInput},
+		{name: "string_substring_int_int", expr: sized("${size(payload.substring(0, %d))}"), inputs: stringInput},
+		{name: "string_trim", expr: fixed("${size(payload.trim())}"), inputs: stringInput},
+		{name: "string_lower_ascii", expr: fixed("${size(payload.lowerAscii())}"), inputs: stringInput},
+		{name: "string_upper_ascii", expr: fixed("${size(payload.upperAscii())}"), inputs: stringInput},
+		{name: "string_char_at_int", expr: fixed("${payload.charAt(0)}"), inputs: stringInput},
+		{name: "string_index_of_string", expr: fixed(`${payload.indexOf("zzz")}`), inputs: stringInput},
+		{name: "string_index_of_string_int", expr: fixed(`${payload.indexOf("zzz", 0)}`), inputs: stringInput},
+		{name: "string_last_index_of_string", expr: fixed(`${payload.lastIndexOf("zzz")}`), inputs: stringInput},
+		{name: "string_last_index_of_string_int", expr: fixed(`${payload.lastIndexOf("zzz", 0)}`), inputs: stringInput},
+
+		{name: "base64_encode_bytes", expr: fixed("${size(base64.encode(payload))}"), inputs: bytesInput},
+		{name: "base64_decode_string", expr: fixed("${size(base64.decode(payload))}"), inputs: base64Input},
+	}
+
+	// The two inputs differ by 100x, so an overload still metered as O(1) reports the same
+	// number twice and cannot pass.
+	const (
+		small = 100
+		large = 10_000
+	)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			smallCost := observedCost(t, tt.expr(small), tt.inputs(small))
+			largeCost := observedCost(t, tt.expr(large), tt.inputs(large))
+			t.Logf("%s: cost(%d)=%d cost(%d)=%d", tt.name, small, smallCost, large, largeCost)
+
+			if largeCost <= smallCost {
+				t.Fatalf("cost did not grow with input size: cost(%d)=%d, cost(%d)=%d — "+
+					"the overload is still metered as O(1)", small, smallCost, large, largeCost)
+			}
+			if largeCost < smallCost*10 {
+				t.Errorf("cost grew sublinearly for a 100x larger input: cost(%d)=%d, cost(%d)=%d",
+					small, smallCost, large, largeCost)
+			}
+		})
+	}
+}
+
+func emptyInputsSized(int) map[string]any {
+	return emptyInputs()
+}
+
+// distinct() compares every element against every other, so cel-go's newer releases charge it
+// as O(n^2). Unmetered on this branch it costs three units and runs for ~160ms, which is what
+// let the shape below sit inside the default limit and be repeated at will.
+func TestDistinctOverALargeRangeBreachesTheDefaultLimit(t *testing.T) {
+	e := NewEngine()
+
+	var err error
+	var elapsed time.Duration
+	withWatchdog(t, func() {
+		start := time.Now()
+		_, err = e.Render(t.Context(), "${size(lists.range(10000).distinct())}", emptyInputs())
+		elapsed = time.Since(start)
+	})
+	t.Logf("elapsed=%s err=%v", elapsed, err)
+
+	if !errors.Is(err, ErrCostLimitExceeded) {
+		t.Fatalf("expected an O(n^2) distinct over 10,000 elements to breach the per-expression limit, got: %v", err)
+	}
+}
+
+// A list literal is charged once for its construction, so repeating a cheap-to-meter call
+// inside one literal multiplied the allocation without moving the meter: 4,500 ranges of
+// 10,000 ints measured 4,511 units and allocated on the order of a gigabyte.
+func TestLargeListLiteralOfRangesBreachesTheDefaultLimit(t *testing.T) {
+	const copies = 4500
+	parts := make([]string, copies)
+	for i := range parts {
+		parts[i] = "lists.range(10000)"
+	}
+	expr := "${size([" + strings.Join(parts, ", ") + "])}"
+
+	e := NewEngine()
+	var err error
+	withWatchdog(t, func() {
+		_, err = e.Render(t.Context(), expr, emptyInputs())
+	})
+	if !errors.Is(err, ErrCostLimitExceeded) {
+		t.Fatalf("expected %d materialized ranges to breach the per-expression limit, got: %v", copies, err)
+	}
+}
+
+// refusalBound is what "quickly" means for a guard that charges after the fact: cel-go
+// meters distinct() only once it returns, so one quadratic pass over 10,000 elements always
+// completes before the breach can fire. That pass is ~150ms here and ~1.7s under -race, so
+// the bound follows watchdogTimeout's convention and budgets for the ~10x slowdown. It is
+// still two orders of magnitude below the ~30s an unmetered render of this template took.
+const refusalBound = 5 * time.Second
+
+// The volume form of the same attack. Each entry is one expression, so the per-expression
+// limit is what has to stop the first one; before the overloads were metered the whole render
+// completed successfully after ~30 seconds of CPU.
+func TestVolumeOfDistinctRangesIsRefusedQuickly(t *testing.T) {
+	const entries = 200
+	data := make(map[string]any, entries)
+	for i := range entries {
+		data[fmt.Sprintf("f%d", i)] = "${size(lists.range(10000).distinct())}"
+	}
+
+	e := NewEngine()
+	var err error
+	var elapsed time.Duration
+	withWatchdog(t, func() {
+		start := time.Now()
+		_, err = e.Render(t.Context(), data, emptyInputs())
+		elapsed = time.Since(start)
+	})
+	t.Logf("elapsed=%s err=%v", elapsed, err)
+
+	if !errors.Is(err, ErrCostLimitExceeded) && !errors.Is(err, ErrCostBudgetExceeded) {
+		t.Fatalf("expected %d distinct-over-10,000 entries to breach a cost guard, got: %v", entries, err)
+	}
+	if elapsed > refusalBound {
+		t.Errorf("expected the refusal within %s, took %s: only the first entry should evaluate",
+			refusalBound, elapsed)
+	}
+}
+
+// The trackers must not price ordinary template work out of existence: everything below is
+// the size a real template uses, and has to keep evaluating for a handful of units.
+func TestOrdinaryListAndStringOperationsStayCheap(t *testing.T) {
+	inputs := map[string]any{
+		"spec":    map[string]any{},
+		"payload": "a,b,c",
+	}
+	tests := []struct {
+		name string
+		expr string
+		want any
+	}{
+		{name: "lists.range", expr: "${size(lists.range(5))}", want: int64(5)},
+		{name: "sort", expr: "${[3,1,2].sort()}", want: []any{int64(1), int64(2), int64(3)}},
+		{name: "split", expr: `${"a,b".split(",")}`, want: []any{"a", "b"}},
+		{name: "split a bound string", expr: `${payload.split(",")}`, want: []any{"a", "b", "c"}},
+		{name: "join", expr: `${["a","b"].join("-")}`, want: "a-b"},
+		{name: "distinct", expr: "${[1,1,2].distinct()}", want: []any{int64(1), int64(2)}},
+		{name: "lowerAscii", expr: `${"AB".lowerAscii()}`, want: "ab"},
+	}
+
+	// Every fixture here is smaller than a hundred elements or bytes, so anything past a few
+	// hundred units would mean a formula that scales on something other than the input.
+	const ceiling uint64 = 200
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewEngine().Render(t.Context(), tt.expr, inputs)
+			if err != nil {
+				t.Fatalf("%s must still evaluate: %v", tt.expr, err)
+			}
+			if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", tt.want) {
+				t.Fatalf("%s = %v, want %v", tt.expr, got, tt.want)
+			}
+			if cost := observedCost(t, tt.expr, inputs); cost > ceiling {
+				t.Fatalf("%s cost %d units, above the %d ceiling for template-sized input", tt.expr, cost, ceiling)
+			}
+		})
+	}
+}
+
+// The tests above drive the estimator through real expressions, which is what proves the
+// trackers are wired to the same meter the limit bounds. These call it directly, to pin the
+// two things an expression cannot isolate: the formula for a quadratic overload, and the
+// dispatch that has to work when cel-go resolves no overload ID at all.
+func TestExtOverloadCostDispatch(t *testing.T) {
+	ints := func(n int) ref.Val {
+		items := make([]ref.Val, n)
+		for i := range items {
+			items[i] = types.Int(i)
+		}
+		return types.NewRefValList(types.DefaultTypeAdapter, items)
+	}
+	strs := func(n int) ref.Val {
+		items := make([]ref.Val, n)
+		for i := range items {
+			items[i] = types.String("x")
+		}
+		return types.NewRefValList(types.DefaultTypeAdapter, items)
+	}
+
+	// An n-element self-compare is charged n^2 at cel-go's factor of two per comparison, plus
+	// one for the dispatch and ten for allocating the result.
+	const selfCompare100 uint64 = 100*100*2 + 1 + 10
+
+	tests := []struct {
+		name       string
+		function   string
+		overloadID string
+		args       []ref.Val
+		result     ref.Val
+		want       uint64
+	}{
+		{
+			name:     "distinct is quadratic in its input",
+			function: "distinct", overloadID: "list_distinct",
+			args: []ref.Val{ints(100)}, result: ints(100),
+			want: selfCompare100,
+		},
+		{
+			name:     "sort resolved to a typed overload",
+			function: "sort", overloadID: "list_int_sort",
+			args: []ref.Val{ints(100)}, result: ints(100),
+			want: selfCompare100,
+		},
+		{
+			name:     "sort left unresolved by a dyn argument",
+			function: "sort", overloadID: "",
+			args: []ref.Val{ints(100)}, result: ints(100),
+			want: selfCompare100,
+		},
+		{
+			name:     "comparing strings costs their contents too",
+			function: "sort", overloadID: "",
+			args: []ref.Val{strs(100)}, result: strs(100),
+			// 2.0 + StringTraversalCostFactor per comparison.
+			want: 100*100*21/10 + 1 + 10,
+		},
+		{
+			name:     "sortBy is charged over the key list, not the sorted list",
+			function: "@sortByAssociatedKeys", overloadID: "",
+			args: []ref.Val{ints(1), ints(100)}, result: ints(1),
+			want: selfCompare100,
+		},
+		{
+			name:     "reverse over an unresolved list uses the list formula",
+			function: "reverse", overloadID: "",
+			args: []ref.Val{ints(100)}, result: ints(100),
+			want: 100 + 1 + 10,
+		},
+		{
+			name:     "reverse over an unresolved string uses the string formula",
+			function: "reverse", overloadID: "",
+			args: []ref.Val{types.String(strings.Repeat("a", 100))}, result: types.String(strings.Repeat("a", 100)),
+			// ceil(100 x 0.1) read, plus dispatch, plus the 100 bytes written.
+			want: 10 + 1 + 100,
+		},
+		{
+			name:     "an empty list still costs the dispatch and the allocation",
+			function: "distinct", overloadID: "list_distinct",
+			args: []ref.Val{ints(0)}, result: ints(0),
+			want: 0 + 1 + 10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extOverloadCost(tt.function, tt.overloadID, tt.args, tt.result)
+			if got == nil {
+				t.Fatalf("%s/%q was left unmetered", tt.function, tt.overloadID)
+			}
+			if *got != tt.want {
+				t.Fatalf("%s/%q cost = %d, want %d", tt.function, tt.overloadID, *got, tt.want)
+			}
+		})
+	}
+}
+
+// Anything the trackers do not recognize has to fall through to cel-go's own accounting.
+// Returning a cost instead would replace the built-in formula for that overload with this
+// one, and returning zero would silently unmeter it.
+func TestExtOverloadCostLeavesUnknownCallsToCELGo(t *testing.T) {
+	for _, tt := range []struct{ function, overloadID string }{
+		{"startsWith", "starts_with_string"},
+		{"_+_", "add_string"},
+		{"format", "string_format"},
+		{"sets.contains", "list_sets_contains_list"},
+		{"math.abs", "math_abs_int"},
+		{"oc_omit", "oc_omit"},
+	} {
+		if got := extOverloadCost(tt.function, tt.overloadID, []ref.Val{types.String("a")}, types.String("a")); got != nil {
+			t.Errorf("%s/%s must be left to cel-go, got a cost of %d", tt.function, tt.overloadID, *got)
+		}
+	}
+}
+
+// A quadratic term over a list that reports an implausible size must saturate rather than
+// wrap. A wrapped product reads as a tiny cost and would fund the very evaluation the guard
+// exists to refuse.
+func TestExtOverloadCostSaturates(t *testing.T) {
+	if got := saturatingMul(math.MaxUint64/2, 4); got != math.MaxUint64 {
+		t.Fatalf("saturatingMul wrapped: got %d", got)
+	}
+	if got := scaledCost(math.MaxUint64, 1000); got != math.MaxUint64 {
+		t.Fatalf("scaledCost wrapped: got %d", got)
+	}
+	if got := allocatingListCost(2, math.MaxUint64); got != math.MaxUint64 {
+		t.Fatalf("allocatingListCost wrapped: got %d", got)
+	}
+}
+
+// The trackers run inside cel-go's cost observer, where a panic takes down the reconcile
+// rather than failing the render. Arity is cel-go's to choose, so nothing here may index an
+// argument it was not handed.
+func TestExtOverloadCostToleratesUnexpectedArity(t *testing.T) {
+	for _, tt := range []struct {
+		function, overloadID string
+		args                 []ref.Val
+	}{
+		{"distinct", "list_distinct", nil},
+		{"sort", "", nil},
+		{"@sortByAssociatedKeys", "", []ref.Val{types.NewRefValList(types.DefaultTypeAdapter, nil)}},
+		{"reverse", "", nil},
+		{"replace", "string_replace_string_string", []ref.Val{types.String("a")}},
+		{"indexOf", "string_index_of_string", nil},
+		{"flatten", "list_flatten_int", nil},
+		{"base64.encode", "base64_encode_bytes", nil},
+	} {
+		if got := extOverloadCost(tt.function, tt.overloadID, tt.args, types.String("")); got == nil {
+			t.Errorf("%s/%s returned no cost", tt.function, tt.overloadID)
+		}
+	}
+}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
> Backport of 30986766 (#4567) to release-v1.0. Template rendering ran cel-go with no cost limit and no interrupt, so a tenant-authored ComponentType, Trait or Workflow template could burn unbounded CPU in the controller on every reconcile.

> Deliberately not backported: the render timeout (--render-timeout / RENDER_TIMEOUT). The cost guards are the primary bound and it ships disabled by default upstream.

## Approach
> Summarize the solution and implementation details.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
