### PR TITLE
fix: correct delivery event emission, commit provenance and rollout identity

### DIFF
--- a/internal/controller/releasebinding/controller.go
+++ b/internal/controller/releasebinding/controller.go
@@ -756,10 +756,7 @@ func (r *Reconciler) reconcileRelease(ctx context.Context, releaseBinding *openc
 		applyCond.ObservedGeneration == dataPlaneRelease.Generation {
 		controller.MarkFalseCondition(releaseBinding, ConditionResourcesReady,
 			ReasonResourceApplyFailed, applyCond.Message)
-		if err := r.reconcileDelivery(
-			ctx, releaseBinding, componentRelease, dataPlaneRelease, dataPlaneResources, true); err != nil {
-			return ctrl.Result{}, err
-		}
+		r.reconcileDelivery(ctx, releaseBinding, componentRelease, dataPlaneRelease, dataPlaneResources, true)
 		return ctrl.Result{}, nil
 	}
 
@@ -780,10 +777,7 @@ func (r *Reconciler) reconcileRelease(ctx context.Context, releaseBinding *openc
 		return ctrl.Result{}, fmt.Errorf("failed to set resources ready status: %w", err)
 	}
 
-	if err := r.reconcileDelivery(
-		ctx, releaseBinding, componentRelease, dataPlaneRelease, dataPlaneResources, false); err != nil {
-		return ctrl.Result{}, err
-	}
+	r.reconcileDelivery(ctx, releaseBinding, componentRelease, dataPlaneRelease, dataPlaneResources, false)
 
 	return ctrl.Result{}, nil
 }

--- a/internal/controller/releasebinding/delivery_events.go
+++ b/internal/controller/releasebinding/delivery_events.go
@@ -10,10 +10,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -22,6 +24,7 @@ import (
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
 	"github.com/openchoreo/openchoreo/internal/controller"
+	"github.com/openchoreo/openchoreo/internal/controller/renderedrelease"
 	"github.com/openchoreo/openchoreo/internal/labels"
 )
 
@@ -63,7 +66,13 @@ const (
 // aggregator gets release and scope identity independent of collector
 // enrichment (Kubernetes Events do not inherit the involved object's labels).
 type deliveryEventPayload struct {
-	RenderedReleaseUID   string `json:"renderedReleaseUid"`
+	// RolloutID identifies one rollout as
+	// "<componentReleaseUID>.<renderedReleaseUID>.<renderedReleaseGeneration>".
+	// It is not a RenderedRelease UID on its own: the same RenderedRelease is
+	// reused across ComponentReleases, so neither UID distinguishes a rollout
+	// alone. The generation is what distinguishes redeployments of a spec that has
+	// been deployed before -- see deliveryContext.rolloutID.
+	RolloutID            string `json:"rolloutId"`
 	ComponentReleaseName string `json:"componentReleaseName"`
 	// NamespaceName is the OpenChoreo namespace the rollout belongs to -- the
 	// control-plane namespace, not the data-plane namespace the involved object
@@ -84,17 +93,30 @@ type deliveryEventPayload struct {
 	// merges them, and the merged duration then spans the healthy interval between
 	// them. Carried on Failed and Recovered; zero on Started and Succeeded.
 	FailureEpisode int32 `json:"failureEpisode,omitempty"`
+	// Commit is the VCS commit the running image was built from, and
+	// CommitAuthoredAt is when that commit was authored, in RFC 3339. Both are
+	// carried on every phase, not just the terminal one: the consumer has no route
+	// back to the ComponentRelease to look them up. Empty when the workload records
+	// no source.
+	Commit           string `json:"commit,omitempty"`
+	CommitAuthoredAt string `json:"commitAuthoredAt,omitempty"`
 }
 
 // deliveryContext is everything needed to emit delivery events for one
 // reconcile, resolved once up front. It exists only for component-owned
 // data-plane releases that render a primary workload resource.
 type deliveryContext struct {
-	// rolloutID is the per-rollout identity: the immutable ComponentRelease UID
-	// joined with the RenderedRelease UID. The RenderedRelease object is reused
-	// across rollouts (named {component}-{environment}), so its UID alone cannot
-	// identify a rollout; the ComponentRelease UID alone is shared by every
-	// environment the release is bound to. The pair is unique and stable.
+	// rolloutID is the per-rollout identity: the ComponentRelease UID, the
+	// RenderedRelease UID, and the RenderedRelease generation. Neither UID alone is
+	// enough -- the RenderedRelease is reused across rollouts, and the
+	// ComponentRelease UID is shared by every environment it is bound to -- and the
+	// generation separates redeployments of a spec that ran before, since
+	// ComponentReleases are content-addressed and a rollback resolves to the same
+	// one. It is stable while a rollout converges, so every phase shares an identity.
+	//
+	// A restart does not advance it: openchoreo.dev/restartedAt is an annotation that
+	// never enters the spec, so a restart records no deployment -- intended, since it
+	// ships no change.
 	rolloutID            string
 	componentReleaseName string
 	// namespaceName is the OpenChoreo namespace the rollout belongs to, taken from
@@ -105,6 +127,11 @@ type deliveryContext struct {
 	// then drops from the payload entirely. The object's own namespace is the same
 	// value and always set.
 	namespaceName string
+	// commit and commitAuthoredAt carry the source provenance of the image being
+	// rolled out, read from the ComponentRelease's frozen workload copy. Empty
+	// when the workload records no source.
+	commit           string
+	commitAuthoredAt string
 	// primary is the desired primary workload resource (Deployment, StatefulSet,
 	// or CronJob) the events anchor to as involvedObject.
 	primary *unstructured.Unstructured
@@ -123,11 +150,17 @@ var primaryWorkloadGVKs = map[schema.GroupVersionKind]bool{
 // deliveryContextFor).
 //
 // Health comes from the RenderedRelease this binding owns. Because the binding
-// Owns() that object, a status change there reconciles the binding, so this runs
-// against the freshly observed evaluation rather than having to watch the data
-// plane itself. Markers are set on the binding's own status and persisted by the
-// deferred status update in Reconcile, so an event and the record that it was
-// emitted are written together.
+// Owns() that object, a status change there reconciles the binding, so health
+// changes reach this without having to watch the data plane itself. Markers are
+// set on the binding's own status and persisted by the deferred status update in
+// Reconcile, so an event and the record that it was emitted are written together.
+//
+// A status change is not the only thing that reconciles the binding, though, so
+// this cannot assume the health it reads describes the rollout it is reporting on
+// -- see deliveryHealthIsCurrent.
+//
+// It returns nothing: every failure here is a lost metric, never a lost rollout,
+// so there is no outcome for the caller to act on.
 func (r *Reconciler) reconcileDelivery(
 	ctx context.Context,
 	releaseBinding *openchoreov1alpha1.ReleaseBinding,
@@ -135,10 +168,10 @@ func (r *Reconciler) reconcileDelivery(
 	renderedRelease *openchoreov1alpha1.RenderedRelease,
 	resources []map[string]any,
 	applyFailed bool,
-) error {
+) {
 	dc := deliveryContextFor(releaseBinding, componentRelease, renderedRelease, asUnstructured(resources))
 	if dc == nil {
-		return nil
+		return
 	}
 
 	planeClient, err := r.getDPClient(ctx, releaseBinding.Namespace, releaseBinding.Spec.Environment)
@@ -149,17 +182,62 @@ func (r *Reconciler) reconcileDelivery(
 		// fail the rollout. Nothing is recorded, so the next reconcile retries.
 		log.FromContext(ctx).V(1).Info("Skipping delivery events: no data plane client",
 			"environment", releaseBinding.Spec.Environment, "error", err.Error())
-		return nil
+		return
 	}
 
 	// An apply failure means the rollout never reached the plane, so there is no
 	// resource health to summarize -- report the failure directly.
 	if applyFailed {
 		r.markDeliveryApplyFailure(ctx, planeClient, releaseBinding, dc)
-		return nil
+		return
 	}
 
-	return r.emitDeliveryEvents(ctx, planeClient, releaseBinding, dc, renderedRelease.Status.Resources)
+	if !deliveryHealthIsCurrent(renderedRelease) {
+		// Reporting the previous revision's health as this rollout's outcome would
+		// emit DeploymentSucceeded before the rollout had begun. Nothing is
+		// recorded, so the reconcile that observes this generation reports it.
+		log.FromContext(ctx).V(1).Info("Deferring delivery events: resource health not yet observed for this generation",
+			"rolloutID", dc.rolloutID, "generation", renderedRelease.Generation)
+		return
+	}
+
+	if err := r.emitDeliveryEvents(ctx, planeClient, releaseBinding, dc, renderedRelease.Status.Resources); err != nil {
+		// Delivery events are a metric, for the same reason the plane client above
+		// is not fatal: a plane that refuses the write -- an agent without RBAC to
+		// create events, say -- must not put every binding into permanent reconcile
+		// failure. Logged rather than returned, and whatever phases did get emitted
+		// are still recorded, so the next reconcile continues from there.
+		log.FromContext(ctx).Error(err, "Failed to emit delivery events", "rolloutID", dc.rolloutID)
+	}
+}
+
+// deliveryHealthIsCurrent reports whether Status.Resources describes the spec the
+// rollout being reported on rendered.
+//
+// The rollout identity advances as soon as a new ComponentRelease is rendered,
+// but the resource health it is compared against is written asynchronously by the
+// renderedrelease controller. On the first reconcile after a re-render that status
+// still summarizes the revision being replaced -- which is healthy, having been
+// running until now -- so evaluating it would emit DeploymentSucceeded for a
+// rollout whose pods do not exist yet. That is not a cosmetic ordering problem:
+// succeededAt is what Lead Time for Changes measures to, so it would exclude the
+// rollout it is supposed to be timing.
+//
+// The applied condition is the marker for this: the renderedrelease controller
+// builds Status.Resources and sets the condition in the same reconcile, so a
+// successful condition reporting this generation means the health beside it
+// describes this spec.
+//
+// The status is checked as well as the generation, so this does not depend on
+// the caller having intercepted an apply failure first: a rollout whose apply
+// failed for this generation is reported through markDeliveryApplyFailure, and
+// there is no resource health to summarize for it either way.
+func deliveryHealthIsCurrent(renderedRelease *openchoreov1alpha1.RenderedRelease) bool {
+	applied := apimeta.FindStatusCondition(renderedRelease.Status.Conditions,
+		renderedrelease.ConditionResourcesApplied)
+	return applied != nil &&
+		applied.Status == metav1.ConditionTrue &&
+		applied.ObservedGeneration == renderedRelease.Generation
 }
 
 // asUnstructured views the rendered resource maps as unstructured objects, which
@@ -228,12 +306,36 @@ func deliveryContextFor(
 		return nil
 	}
 
+	commit, authoredAt := deliveryProvenance(componentRelease)
+
 	return &deliveryContext{
-		rolloutID:            fmt.Sprintf("%s.%s", componentRelease.UID, renderedRelease.UID),
+		rolloutID: fmt.Sprintf("%s.%s.%d",
+			componentRelease.UID, renderedRelease.UID, renderedRelease.Generation),
 		componentReleaseName: componentRelease.Name,
 		namespaceName:        releaseBinding.Namespace,
+		commit:               commit,
+		commitAuthoredAt:     authoredAt,
 		primary:              primary,
 	}
+}
+
+// deliveryProvenance reads the source commit and its authoring time off the
+// ComponentRelease's frozen workload copy, formatted for the payload.
+//
+// The ComponentRelease is the right source for this rather than the live
+// Workload: it is the immutable snapshot the rollout was rendered from, so the
+// provenance stays the provenance of what actually shipped even after the
+// Workload moves on. Returns empty strings when no source was recorded, which
+// `omitempty` then keeps out of the payload entirely.
+func deliveryProvenance(componentRelease *openchoreov1alpha1.ComponentRelease) (commit, authoredAt string) {
+	source := componentRelease.Spec.Workload.Source
+	if source == nil {
+		return "", ""
+	}
+	if source.AuthoredAt != nil {
+		authoredAt = source.AuthoredAt.UTC().Format(time.RFC3339)
+	}
+	return source.Commit, authoredAt
 }
 
 // deliveryState returns the binding's delivery markers for the current rollout,
@@ -271,9 +373,11 @@ func (r *Reconciler) emitDeliveryEvents(
 		return nil
 	}
 	if err := r.reconcileDeliveryEvents(ctx, planeClient, releaseBinding, dc, resourceStatuses); err != nil {
-		// Wrapped rather than logged here: controller-runtime already reports the
-		// error at the reconcile boundary, so logging it too would report the same
-		// failure twice. The rollout identity is what that report otherwise lacks.
+		// Wrapped rather than logged here, because the caller decides what to do
+		// with it -- and since this no longer reaches the reconcile boundary, the
+		// caller is what logs it. The wrap is what carries the rollout identity and
+		// the deferral in the message itself, so the error read on its own says
+		// which rollout stopped and that the remaining phases retry.
 		return fmt.Errorf("failed to emit delivery lifecycle events for rollout %s, "+
 			"remaining phases deferred: %w", dc.rolloutID, err)
 	}
@@ -548,7 +652,7 @@ func (r *Reconciler) emitDeliveryEvent(
 	}
 
 	payload := deliveryEventPayload{
-		RenderedReleaseUID:   dc.rolloutID,
+		RolloutID:            dc.rolloutID,
 		ComponentReleaseName: dc.componentReleaseName,
 		NamespaceName:        dc.namespaceName,
 		ProjectUID:           dc.primary.GetLabels()[labels.LabelKeyProjectUID],
@@ -557,6 +661,8 @@ func (r *Reconciler) emitDeliveryEvent(
 		Phase:                strings.TrimPrefix(reason, "Deployment"),
 		FailureReason:        failureReason,
 		FailureEpisode:       episode,
+		Commit:               dc.commit,
+		CommitAuthoredAt:     dc.commitAuthoredAt,
 	}
 	message, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/controller/releasebinding/delivery_events_unit_test.go
+++ b/internal/controller/releasebinding/delivery_events_unit_test.go
@@ -9,18 +9,22 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	openchoreov1alpha1 "github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/controller/renderedrelease"
 	"github.com/openchoreo/openchoreo/internal/labels"
 )
 
@@ -47,12 +51,33 @@ func makeDeliveryBinding() *openchoreov1alpha1.ReleaseBinding {
 	}
 }
 
+// testCommit and testAuthoredAt are the source provenance the ComponentRelease
+// snapshot carries, which delivery events forward for Lead Time for Changes.
+const (
+	testCommit     = "9f2c1ab3d4e5f60718293a4b5c6d7e8f90123456"
+	testAuthoredAt = "2026-09-01T10:30:00Z"
+)
+
 func makeDeliveryComponentRelease() *openchoreov1alpha1.ComponentRelease {
+	authored, err := time.Parse(time.RFC3339, testAuthoredAt)
+	if err != nil {
+		panic(err)
+	}
 	return &openchoreov1alpha1.ComponentRelease{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testComponentReleaseName,
 			Namespace: "acme",
 			UID:       types.UID(testComponentReleaseUID),
+		},
+		Spec: openchoreov1alpha1.ComponentReleaseSpec{
+			Workload: openchoreov1alpha1.WorkloadTemplateSpec{
+				Source: &openchoreov1alpha1.WorkloadSource{
+					Commit:     testCommit,
+					Branch:     "main",
+					Repository: "https://github.com/acme/checkout-service",
+					AuthoredAt: &metav1.Time{Time: authored},
+				},
+			},
 		},
 	}
 }
@@ -60,9 +85,10 @@ func makeDeliveryComponentRelease() *openchoreov1alpha1.ComponentRelease {
 func makeDeliveryRelease() *openchoreov1alpha1.RenderedRelease {
 	return &openchoreov1alpha1.RenderedRelease{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "checkout-service-dev",
-			Namespace: "acme",
-			UID:       types.UID("rr-uid-1"),
+			Name:       "checkout-service-dev",
+			Namespace:  "acme",
+			UID:        types.UID("rr-uid-1"),
+			Generation: 4,
 		},
 		Spec: openchoreov1alpha1.RenderedReleaseSpec{
 			Owner: openchoreov1alpha1.RenderedReleaseOwner{
@@ -136,10 +162,11 @@ func TestDeliveryContextFor(t *testing.T) {
 		if dc == nil {
 			t.Fatal("expected delivery context, got nil")
 		}
-		// The rollout identity pairs the immutable ComponentRelease UID with the
-		// RenderedRelease UID: neither alone identifies one rollout of one
-		// component into one environment.
-		wantRollout := testComponentReleaseUID + ".rr-uid-1"
+		// The rollout identity joins the immutable ComponentRelease UID, the
+		// RenderedRelease UID and its generation: neither UID alone identifies one
+		// rollout of one component into one environment, and without the generation
+		// a redeployment of a spec that ran before repeats the identity.
+		wantRollout := testComponentReleaseUID + ".rr-uid-1.4"
 		if dc.rolloutID != wantRollout {
 			t.Errorf("rolloutID = %q, want %q", dc.rolloutID, wantRollout)
 		}
@@ -274,8 +301,8 @@ func TestReconcileDeliveryEvents(t *testing.T) {
 		if err := json.Unmarshal([]byte(started.Message), &payload); err != nil {
 			t.Fatalf("unmarshal payload: %v", err)
 		}
-		if payload.RenderedReleaseUID != dc.rolloutID {
-			t.Errorf("payload renderedReleaseUid = %q, want %q", payload.RenderedReleaseUID, dc.rolloutID)
+		if payload.RolloutID != dc.rolloutID {
+			t.Errorf("payload rolloutId = %q, want %q", payload.RolloutID, dc.rolloutID)
 		}
 		if payload.ComponentReleaseName != testComponentReleaseName {
 			t.Errorf("payload componentReleaseName = %q, want %q", payload.ComponentReleaseName, testComponentReleaseName)
@@ -287,6 +314,14 @@ func TestReconcileDeliveryEvents(t *testing.T) {
 		}
 		if payload.Phase != "Started" {
 			t.Errorf("payload phase = %q, want Started", payload.Phase)
+		}
+		// Provenance travels on every phase: the aggregator reads a log store, not
+		// the control plane, so it cannot resolve the ComponentRelease itself.
+		if payload.Commit != testCommit {
+			t.Errorf("payload commit = %q, want %q", payload.Commit, testCommit)
+		}
+		if payload.CommitAuthoredAt != testAuthoredAt {
+			t.Errorf("payload commitAuthoredAt = %q, want %q", payload.CommitAuthoredAt, testAuthoredAt)
 		}
 
 		if binding.Status.Delivery == nil || binding.Status.Delivery.StartedAt == nil {
@@ -405,8 +440,8 @@ func TestReconcileDeliveryEventsEpisodes(t *testing.T) {
 		dc2 := deliveryContextFor(binding, nextRelease, release, desired)
 		mustReconcileDelivery(t, r, ctx, cl, binding, dc2, healthy)
 
-		if binding.Status.Delivery.RolloutID != "cr-uid-8.rr-uid-1" {
-			t.Errorf("RolloutID = %q, want cr-uid-8.rr-uid-1", binding.Status.Delivery.RolloutID)
+		if binding.Status.Delivery.RolloutID != "cr-uid-8.rr-uid-1.4" {
+			t.Errorf("RolloutID = %q, want cr-uid-8.rr-uid-1.4", binding.Status.Delivery.RolloutID)
 		}
 		events := listDeliveryEvents(t, cl)
 		if len(events) != 4 {
@@ -1021,6 +1056,344 @@ func TestDeliveryReachesAFixedPoint(t *testing.T) {
 		}
 		if n := countEventsByReason(listDeliveryEvents(t, cl), reasonDeploymentFailed); n != 1 {
 			t.Errorf("emitted %d DeploymentFailed for one open episode, want 1", n)
+		}
+	})
+}
+
+// ─────────────────────────────────────────────────────────────
+// reconcileDelivery: health currency and non-fatal emission
+// ─────────────────────────────────────────────────────────────
+
+// deliveryPlaneProvider hands out one client for every plane, so a delivery
+// reconcile can be driven end to end. Only the data plane methods are reached.
+type deliveryPlaneProvider struct{ cl client.Client }
+
+func (p *deliveryPlaneProvider) DataPlaneClient(*openchoreov1alpha1.DataPlane) (client.Client, error) {
+	return p.cl, nil
+}
+
+func (p *deliveryPlaneProvider) ClusterDataPlaneClient(*openchoreov1alpha1.ClusterDataPlane) (client.Client, error) {
+	return p.cl, nil
+}
+
+func (p *deliveryPlaneProvider) ObservabilityPlaneClient(*openchoreov1alpha1.ObservabilityPlane) (client.Client, error) {
+	return p.cl, nil
+}
+
+func (p *deliveryPlaneProvider) ClusterObservabilityPlaneClient(
+	*openchoreov1alpha1.ClusterObservabilityPlane,
+) (client.Client, error) {
+	return p.cl, nil
+}
+
+func (p *deliveryPlaneProvider) WorkflowPlaneClient(*openchoreov1alpha1.WorkflowPlane) (client.Client, error) {
+	return p.cl, nil
+}
+
+func (p *deliveryPlaneProvider) ClusterWorkflowPlaneClient(
+	*openchoreov1alpha1.ClusterWorkflowPlane,
+) (client.Client, error) {
+	return p.cl, nil
+}
+
+// appliedCondition builds the condition the renderedrelease controller sets
+// alongside Status.Resources, observed at the given generation.
+func appliedCondition(observedGeneration int64) metav1.Condition {
+	return metav1.Condition{
+		Type:               renderedrelease.ConditionResourcesApplied,
+		Status:             metav1.ConditionTrue,
+		Reason:             "ApplySucceeded",
+		ObservedGeneration: observedGeneration,
+		LastTransitionTime: metav1.Now(),
+	}
+}
+
+// newDeliveryReconcile wires a Reconciler whose control-plane client can resolve
+// the environment's data plane, and whose data-plane client is dpClient.
+func newDeliveryReconcile(t *testing.T, dpClient client.Client) (*Reconciler, *openchoreov1alpha1.ReleaseBinding) {
+	t.Helper()
+	binding := makeDeliveryBinding()
+
+	env := &openchoreov1alpha1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: binding.Spec.Environment, Namespace: binding.Namespace},
+		Spec: openchoreov1alpha1.EnvironmentSpec{
+			DataPlaneRef: &openchoreov1alpha1.DataPlaneRef{
+				Kind: openchoreov1alpha1.DataPlaneRefKindDataPlane,
+				Name: "dp-1",
+			},
+		},
+	}
+	dp := &openchoreov1alpha1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "dp-1", Namespace: binding.Namespace},
+	}
+
+	scheme := runtime.NewScheme()
+	if err := openchoreov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add openchoreo scheme: %v", err)
+	}
+	cpClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(env, dp).Build()
+
+	return &Reconciler{
+		Client:              cpClient,
+		PlaneClientProvider: &deliveryPlaneProvider{cl: dpClient},
+	}, binding
+}
+
+// TestDeliveryWaitsForHealthOfThisGeneration pins the ordering that makes
+// succeededAt meaningful.
+//
+// The rollout identity advances as soon as a new ComponentRelease is rendered,
+// but Status.Resources is written asynchronously by the renderedrelease
+// controller. On the first reconcile after a re-render that status still
+// summarizes the revision being replaced, which is healthy because it has been
+// running all along. Emitting on it reports DeploymentSucceeded for a rollout
+// whose pods do not exist yet -- and succeededAt is what Lead Time for Changes
+// measures to, so it would exclude the very rollout it is timing.
+//
+// Verified against the unguarded behavior: without the generation check the
+// stale case emits Started and Succeeded immediately.
+func TestDeliveryWaitsForHealthOfThisGeneration(t *testing.T) {
+	ctx := context.Background()
+	deployment := makeDeliveryDeployment()
+	resources := []map[string]any{deployment.Object}
+	componentRelease := makeDeliveryComponentRelease()
+
+	// The previous revision, still healthy -- what a stale status reports.
+	healthy := []openchoreov1alpha1.RenderedManifestStatus{
+		manifestStatus("deployment", openchoreov1alpha1.HealthStatusHealthy),
+	}
+
+	t.Run("status from an older generation emits nothing", func(t *testing.T) {
+		dpClient := fake.NewClientBuilder().Build()
+		r, binding := newDeliveryReconcile(t, dpClient)
+
+		release := makeDeliveryRelease()
+		release.Generation = 2
+		release.Status.Resources = healthy
+		release.Status.Conditions = []metav1.Condition{appliedCondition(1)}
+
+		r.reconcileDelivery(ctx, binding, componentRelease, release, resources, false)
+		if events := listDeliveryEvents(t, dpClient); len(events) != 0 {
+			t.Fatalf("expected no events while health is stale, got %d: %s",
+				len(events), events[0].Reason)
+		}
+		if binding.Status.Delivery != nil {
+			t.Errorf("expected no delivery markers, got %+v", binding.Status.Delivery)
+		}
+	})
+
+	t.Run("no applied condition at all emits nothing", func(t *testing.T) {
+		dpClient := fake.NewClientBuilder().Build()
+		r, binding := newDeliveryReconcile(t, dpClient)
+
+		release := makeDeliveryRelease()
+		release.Generation = 1
+		release.Status.Resources = healthy
+
+		r.reconcileDelivery(ctx, binding, componentRelease, release, resources, false)
+		if events := listDeliveryEvents(t, dpClient); len(events) != 0 {
+			t.Fatalf("expected no events without an applied condition, got %d", len(events))
+		}
+	})
+
+	t.Run("a failed apply at this generation emits nothing", func(t *testing.T) {
+		dpClient := fake.NewClientBuilder().Build()
+		r, binding := newDeliveryReconcile(t, dpClient)
+
+		release := makeDeliveryRelease()
+		release.Generation = 2
+		release.Status.Resources = healthy
+		failed := appliedCondition(2)
+		failed.Status = metav1.ConditionFalse
+		failed.Reason = "ApplyFailed"
+		release.Status.Conditions = []metav1.Condition{failed}
+
+		// reconcileRelease routes a current-generation apply failure to the
+		// applyFailed path instead, so arriving here with one means the health
+		// beside it is not this rollout's to report.
+		r.reconcileDelivery(ctx, binding, componentRelease, release, resources, false)
+		if events := listDeliveryEvents(t, dpClient); len(events) != 0 {
+			t.Fatalf("expected no events for a failed apply, got %d: %s", len(events), events[0].Reason)
+		}
+	})
+
+	t.Run("status observed at this generation emits", func(t *testing.T) {
+		dpClient := fake.NewClientBuilder().Build()
+		r, binding := newDeliveryReconcile(t, dpClient)
+
+		release := makeDeliveryRelease()
+		release.Generation = 2
+		release.Status.Resources = healthy
+		release.Status.Conditions = []metav1.Condition{appliedCondition(2)}
+
+		r.reconcileDelivery(ctx, binding, componentRelease, release, resources, false)
+		events := listDeliveryEvents(t, dpClient)
+		if len(events) != 2 {
+			t.Fatalf("expected Started and Succeeded once health is current, got %d", len(events))
+		}
+		if findEventByReason(events, reasonDeploymentStarted) == nil {
+			t.Error("missing DeploymentStarted")
+		}
+		if findEventByReason(events, reasonDeploymentSucceeded) == nil {
+			t.Error("missing DeploymentSucceeded")
+		}
+	})
+}
+
+// TestDeliveryEmissionFailureDoesNotFailReconcile pins that a plane which
+// refuses the write degrades the metric rather than the deployment.
+//
+// A data plane whose agent has no RBAC to create events returns Forbidden on
+// every attempt. Returning that to the reconcile boundary puts every
+// ReleaseBinding into permanent error backoff -- deployments still converge, but
+// no reconcile ever reports success. Delivery events are a metric, so this is
+// logged and swallowed, exactly as an unreachable plane client already is.
+//
+// Verified against the previous behavior: returning the error made this fail
+// with the Forbidden wrapped in "failed to emit delivery lifecycle events".
+func TestDeliveryEmissionFailureDoesNotFailReconcile(t *testing.T) {
+	ctx := context.Background()
+	resources := []map[string]any{makeDeliveryDeployment().Object}
+	componentRelease := makeDeliveryComponentRelease()
+
+	forbidden := apierrors.NewForbidden(
+		schema.GroupResource{Resource: "events"}, "",
+		errors.New(`User "system:serviceaccount:openchoreo-data-plane:cluster-agent-dataplane" cannot create resource "events"`))
+
+	dpClient := fake.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+		Create: func(ctx context.Context, cl client.WithWatch, obj client.Object,
+			opts ...client.CreateOption) error {
+			if _, ok := obj.(*corev1.Event); ok {
+				return forbidden
+			}
+			return cl.Create(ctx, obj, opts...)
+		},
+	}).Build()
+
+	r, binding := newDeliveryReconcile(t, dpClient)
+	release := makeDeliveryRelease()
+	release.Generation = 1
+	release.Status.Resources = []openchoreov1alpha1.RenderedManifestStatus{
+		manifestStatus("deployment", openchoreov1alpha1.HealthStatusHealthy),
+	}
+	release.Status.Conditions = []metav1.Condition{appliedCondition(1)}
+
+	// reconcileDelivery reports nothing back, so the contract is that this returns
+	// at all rather than propagating the Forbidden to the reconcile boundary. The
+	// call site in reconcileRelease has no error to return, which is what keeps a
+	// plane that refuses the write from wedging every binding.
+	r.reconcileDelivery(ctx, binding, componentRelease, release, resources, false)
+
+	if events := listDeliveryEvents(t, dpClient); len(events) != 0 {
+		t.Errorf("expected no events to be stored, got %d", len(events))
+	}
+	if binding.Status.Delivery == nil || binding.Status.Delivery.StartedAt != nil {
+		t.Error("a refused write must not record a StartedAt marker, or the phase would be skipped on retry")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────
+// Rollout identity and commit provenance
+// ─────────────────────────────────────────────────────────────
+
+// TestRolloutIDDistinguishesRedeployments pins that deploying a spec which ran
+// before is its own rollout.
+//
+// ComponentReleases are content-addressed, so rolling back to a previous spec --
+// or restarting -- resolves to the ComponentRelease that spec already had. With
+// only the two UIDs the identity repeated, and since the store keys deployment
+// facts by it, the redeployment folded into the earlier one: a rollback, which is
+// a deployment like any other, went uncounted in deployment frequency and left
+// the original deployment's timestamps in place.
+//
+// The RenderedRelease generation closes that, and must stay stable within one
+// rollout or Started and Succeeded would land under different identities.
+func TestRolloutIDDistinguishesRedeployments(t *testing.T) {
+	desired := []*unstructured.Unstructured{makeDeliveryDeployment()}
+	binding := makeDeliveryBinding()
+	componentRelease := makeDeliveryComponentRelease()
+
+	t.Run("the same spec at a later generation is a new rollout", func(t *testing.T) {
+		first := makeDeliveryRelease()
+		first.Generation = 4
+		rolledBack := makeDeliveryRelease()
+		rolledBack.Generation = 6
+
+		a := deliveryContextFor(binding, componentRelease, first, desired)
+		b := deliveryContextFor(binding, componentRelease, rolledBack, desired)
+		if a == nil || b == nil {
+			t.Fatal("expected delivery contexts")
+		}
+		if a.rolloutID == b.rolloutID {
+			t.Errorf("rolloutID %q repeated across generations; the redeployment would fold into the first",
+				a.rolloutID)
+		}
+	})
+
+	t.Run("the same generation is the same rollout", func(t *testing.T) {
+		a := deliveryContextFor(binding, componentRelease, makeDeliveryRelease(), desired)
+		b := deliveryContextFor(binding, componentRelease, makeDeliveryRelease(), desired)
+		if a.rolloutID != b.rolloutID {
+			t.Errorf("rolloutID is not stable within a rollout: %q then %q", a.rolloutID, b.rolloutID)
+		}
+	})
+}
+
+// TestDeliveryProvenance pins the source provenance the payload carries.
+//
+// Lead Time for Changes is authoring time to succeededAt, and the consumer folds
+// events out of a log store with no route back to the ComponentRelease, so the
+// commit and its authoring time have to travel in the message. When the emitter
+// moved packages this was dropped, and every deployment fact landed with an empty
+// commit and a null lead time while the aggregator went on parsing for it.
+func TestDeliveryProvenance(t *testing.T) {
+	t.Run("read from the ComponentRelease snapshot", func(t *testing.T) {
+		commit, authoredAt := deliveryProvenance(makeDeliveryComponentRelease())
+		if commit != testCommit {
+			t.Errorf("commit = %q, want %q", commit, testCommit)
+		}
+		if authoredAt != testAuthoredAt {
+			t.Errorf("authoredAt = %q, want %q (RFC 3339, which is what the consumer parses)",
+				authoredAt, testAuthoredAt)
+		}
+	})
+
+	t.Run("a workload with no source yields empty strings", func(t *testing.T) {
+		cr := makeDeliveryComponentRelease()
+		cr.Spec.Workload.Source = nil
+		commit, authoredAt := deliveryProvenance(cr)
+		if commit != "" || authoredAt != "" {
+			t.Errorf("commit/authoredAt = %q/%q, want empty for a workload without provenance",
+				commit, authoredAt)
+		}
+	})
+
+	t.Run("a source without an authoring time still yields the commit", func(t *testing.T) {
+		cr := makeDeliveryComponentRelease()
+		cr.Spec.Workload.Source.AuthoredAt = nil
+		commit, authoredAt := deliveryProvenance(cr)
+		if commit != testCommit || authoredAt != "" {
+			t.Errorf("commit/authoredAt = %q/%q, want the commit with no authoring time",
+				commit, authoredAt)
+		}
+	})
+
+	t.Run("an absent commit is omitted from the payload entirely", func(t *testing.T) {
+		cr := makeDeliveryComponentRelease()
+		cr.Spec.Workload.Source = nil
+		dc := deliveryContextFor(makeDeliveryBinding(), cr, makeDeliveryRelease(),
+			[]*unstructured.Unstructured{makeDeliveryDeployment()})
+		if dc == nil {
+			t.Fatal("expected a delivery context")
+		}
+		payload, err := json.Marshal(deliveryEventPayload{
+			RolloutID: dc.rolloutID, Commit: dc.commit, CommitAuthoredAt: dc.commitAuthoredAt,
+		})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if strings.Contains(string(payload), "commit") {
+			t.Errorf("payload %s carries an empty commit; omitempty must drop it", payload)
 		}
 	})
 }


### PR DESCRIPTION
## Fixes

1. `reconcileDelivery` waits for `ResourcesApplied` to report success for the
   generation it is reading health for, and defers rather than judging a
   RenderedRelease whose controller has not reconciled the new spec yet. The status is
   checked as well as the generation so the guard does not depend on the caller having
   intercepted an apply failure first.

2. `reconcileDelivery` returns nothing, so there is no error for the caller to
   propagate. A delivery event is a metric, never part of the rollout, so a plane that
   refuses the write must not put every binding into permanent reconcile failure. A
   failed write is logged with the rollout identity, and whatever phases were emitted
   stay recorded, so the next reconcile continues from there.

3. The payload field is renamed to `rolloutId`. The value was never a RenderedRelease
   UID: that object is reused across rollouts.

4. `deliveryProvenance` reads the commit and its authoring time off the
   ComponentRelease's frozen workload copy — the snapshot the rollout was rendered
   from, so the provenance stays that of what shipped even after the Workload moves
   on. Both travel on every phase, because the consumer folds these events out of a
   log store and has no route back to the ComponentRelease. Absent provenance stays
   absent: `omitempty` keeps empty fields out of the payload and lead time is simply
   not computed for that rollout.

5. The RenderedRelease generation joins the rollout identity, which becomes
   `<componentReleaseUID>.<renderedReleaseUID>.<generation>`. ComponentReleases are
   content-addressed, so a rollback resolves to the ComponentRelease that spec already
   had and the two-part identity repeated, folding the rollback into the original
   deployment. The generation advances on every change to the RenderedRelease spec, a
   rollback included, and is stable while one rollout converges, so Started and
   Succeeded still share an identity. Nothing parses the identity (the store treats it
   as an opaque key), so this needs no change on the consumer side.
