### PR TITLE
fix: scope the file-binding report to one workload

### DIFF
--- a/internal/occ/cmd/remote/connect.go
+++ b/internal/occ/cmd/remote/connect.go
@@ -222,10 +222,10 @@ func (d *Remote) Connect(ctx context.Context, p ConnectParams, out io.Writer) er
 			applyResourceBindings(overrides, out, resp, localAddrs)
 			// After the tunnels: a fetched value travels over one, so this cannot run
 			// before they are up.
-			fetchBindings(overrides, sensitive, out, resp, agentTunnels, files, localAddrs, p.NoSecrets)
+			materialized := fetchBindings(overrides, sensitive, out, resp, agentTunnels, files, localAddrs, p.NoSecrets)
 			// After both merges: an env var naming a mount path may have come from
 			// StaticEnv or from a fetch, so the repoint must see the finished map.
-			repointFilePaths(overrides, out, files)
+			repointFilePaths(overrides, out, files, materialized)
 			for _, u := range resp.Unconnectable {
 				fmt.Fprintf(out, "  ! %s: %s\n", u.Ref, u.Reason)
 			}

--- a/internal/occ/cmd/remote/fetch.go
+++ b/internal/occ/cmd/remote/fetch.go
@@ -119,7 +119,8 @@ func fetchBindings(
 	store *fileStore,
 	localAddrs map[string][]addrSwap,
 	noSecrets bool,
-) {
+) []string {
+	var materialized []string
 	for _, rb := range resp.Resources {
 		refKey := remoteconnect.ResourceRefKey(rb.Ref)
 
@@ -181,9 +182,11 @@ func fetchBindings(
 				fmt.Fprintf(out, "  ! %s: %s not provisioned (%v)\n", refKey, mountPath, werr)
 				continue
 			}
+			materialized = append(materialized, mountPath)
 			fmt.Fprintf(out, "  %-28s %s -> %s\n", refKey, mountPath, local)
 		}
 	}
+	return materialized
 }
 
 // fetchOne routes a fetch key to the agent the resolve designated for it. The key's
@@ -222,7 +225,7 @@ func tunnelForAgent(agentTunnels map[string]tunnel, agentID string) (tunnel, err
 // something that merely mentioned the path. Anything the exact rule cannot reach is
 // reported instead, so the developer points the app at the file themselves rather than
 // silently getting the cluster's path.
-func repointFilePaths(overrides map[string]string, out io.Writer, store *fileStore) {
+func repointFilePaths(overrides map[string]string, out io.Writer, store *fileStore, materialized []string) {
 	if len(store.paths) == 0 {
 		return
 	}
@@ -236,7 +239,9 @@ func repointFilePaths(overrides map[string]string, out io.Writer, store *fileSto
 		repointed[overrides[envVar]] = true
 		overrides[envVar] = local
 	}
-	for _, mountPath := range slices.Sorted(maps.Keys(store.paths)) {
+	paths := slices.Clone(materialized)
+	slices.Sort(paths)
+	for _, mountPath := range slices.Compact(paths) {
 		if repointed[mountPath] {
 			continue
 		}


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
`occ remote` prints file binding resolutions under each workload even if they're defined in a subset of the workload files.
This change fixes it

## Related Issues
https://github.com/openchoreo/openchoreo/issues/4215

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content