### PR TITLE
feat(helm): grant sre role resourcereleasebinding:update

### DIFF
--- a/install/helm/openchoreo-control-plane/values.yaml
+++ b/install/helm/openchoreo-control-plane/values.yaml
@@ -1484,6 +1484,7 @@ openchoreoApi:
                 - "resourcerelease:view"
                 - "projectrelease:view"
                 - "resourcereleasebinding:view"
+                - "resourcereleasebinding:update"
                 - "projectreleasebinding:view"
                 - "workflowrun:view"
                 - "workflowrun:create"


### PR DESCRIPTION
## Purpose
The SRE agent can diagnose Resource failures and recommend `ResourceReleaseBinding`
changes (#4081), but applying one from the portal fails with 403 for users holding the
`sre` role: it has `resourcereleasebinding:view` and no `:update`.

## Approach
Add `resourcereleasebinding:update` to the `sre` role in the control-plane values.
`developer` and `platform-engineer` already carry all four verbs, so only `sre` was
short. Not adding `:create`/`:delete` — quick fixes only mutate an existing binding.

## Related Issues
Part of https://github.com/openchoreo/openchoreo/issues/4631
Follow-up to https://github.com/openchoreo/openchoreo/pull/4081

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [X] This PR includes AI-generated code or content

## Remarks
The portal-side change lands separately in `openchoreo/backstage-plugins`; until both
are in, `ResourceReleaseBinding` quick fixes cannot be applied.
