### PR TITLE
fix(api): give the audit logger its own JSON handler

### DIFF
--- a/cmd/observer/main.go
+++ b/cmd/observer/main.go
@@ -266,7 +266,7 @@ func main() {
 	// One Emitter shared across all three surfaces, so one policy applies to
 	// every one of them. The middlewares that consume it are built inside the
 	// composers, mirroring openchoreo-api's OpenAPIMiddlewares.
-	auditEmitter, err := initAuditEmitter(cfg, logger)
+	auditEmitter, err := initAuditEmitter(cfg)
 	if err != nil {
 		logger.Error("Failed to initialize audit", "error", err)
 		os.Exit(1)
@@ -570,7 +570,7 @@ func initJWTMiddleware(cfg *config.Config, logger *slog.Logger) func(http.Handle
 // ports and silently never audited. Failing at startup matches how the
 // middleware composers treat a nil emitter or an unresolvable
 // RESTResourceParam.
-func initAuditEmitter(cfg *config.Config, logger *slog.Logger) (*audit.Emitter, error) {
+func initAuditEmitter(cfg *config.Config) (*audit.Emitter, error) {
 	publicSwagger, err := gen.GetSwagger()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load public OpenAPI spec: %w", err)
@@ -588,7 +588,7 @@ func initAuditEmitter(cfg *config.Config, logger *slog.Logger) (*audit.Emitter, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to build audit policy set: %w", err)
 	}
-	return audit.NewEmitter("observer", auditPolicies, audit.NewLogger(logger))
+	return audit.NewEmitter("observer", auditPolicies, audit.NewLogger(os.Stdout))
 }
 
 func initMCPMiddleware(logger *slog.Logger) func(http.Handler) http.Handler {

--- a/cmd/openchoreo-api/main.go
+++ b/cmd/openchoreo-api/main.go
@@ -210,7 +210,7 @@ func main() {
 		logger.Error("Failed to build audit policy set", slog.Any("error", err))
 		os.Exit(1)
 	}
-	auditEmitter, err := audit.NewEmitter("openchoreo-api", auditPolicies, audit.NewLogger(logger))
+	auditEmitter, err := audit.NewEmitter("openchoreo-api", auditPolicies, audit.NewLogger(os.Stdout))
 	if err != nil {
 		logger.Error("Failed to build audit emitter", slog.Any("error", err))
 		os.Exit(1)

--- a/internal/observer/api/handlers/audit_test_helpers_test.go
+++ b/internal/observer/api/handlers/audit_test_helpers_test.go
@@ -6,7 +6,6 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
-	"log/slog"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,12 +22,11 @@ func newAuditSink(t *testing.T) (*audit.Emitter, *bytes.Buffer) {
 	t.Helper()
 
 	var buf bytes.Buffer
-	sinkLogger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	policies, errs := audit.NewPolicySet(coreconfig.NewPath("audit"), audit.Settings{Publish: true}, nil)
 	require.Empty(t, errs, "default policy set must build cleanly")
 
-	emitter, err := audit.NewEmitter("observer-test", policies, audit.NewLogger(sinkLogger))
+	emitter, err := audit.NewEmitter("observer-test", policies, audit.NewLogger(&buf))
 	require.NoError(t, err)
 
 	return emitter, &buf

--- a/internal/openchoreo-api/api/handlers/audit_wiring_test.go
+++ b/internal/openchoreo-api/api/handlers/audit_wiring_test.go
@@ -83,7 +83,7 @@ func TestAuditMiddlewareWired(t *testing.T) {
 	fc := uidAssigningClient(t)
 	svc := projectsvc.NewServiceWithAuthz(fc, &allowAllPDP{}, logger)
 	services := &handlerservices.Services{ProjectService: svc}
-	handler := newTestHTTPHandlerWithLogger(t, services, logger)
+	handler := newTestHTTPHandlerWithLogger(t, services, logger, &buf)
 
 	body, _ := json.Marshal(gen.Project{
 		Metadata: gen.ObjectMeta{Name: "audit-test-proj"},
@@ -123,7 +123,7 @@ func TestAuditMiddlewareWired_ProjectCRUD(t *testing.T) {
 	fc := uidAssigningClient(t)
 	svc := projectsvc.NewServiceWithAuthz(fc, &allowAllPDP{}, logger)
 	services := &handlerservices.Services{ProjectService: svc}
-	handler := newTestHTTPHandlerWithLogger(t, services, logger)
+	handler := newTestHTTPHandlerWithLogger(t, services, logger, &buf)
 
 	createBody, _ := json.Marshal(gen.Project{
 		Metadata: gen.ObjectMeta{Name: "crud-test-proj"},
@@ -194,7 +194,7 @@ func TestAuditMiddlewareWired_TraitCRUD(t *testing.T) {
 	fc := uidAssigningClient(t)
 	svc := traitsvc.NewServiceWithAuthz(fc, &allowAllPDP{}, logger)
 	services := &handlerservices.Services{TraitService: svc}
-	handler := newTestHTTPHandlerWithLogger(t, services, logger)
+	handler := newTestHTTPHandlerWithLogger(t, services, logger, &buf)
 
 	createBody, _ := json.Marshal(gen.Trait{
 		Metadata: gen.ObjectMeta{Name: "crud-test-trait"},
@@ -291,7 +291,7 @@ func TestAuditMiddlewareWired_AllOperations(t *testing.T) {
 		DataPlaneService:   dataPlaneSvc,
 		EnvironmentService: envSvc,
 	}
-	handler := newTestHTTPHandlerWithLogger(t, services, logger)
+	handler := newTestHTTPHandlerWithLogger(t, services, logger, &buf)
 
 	type opRequest struct {
 		action string
@@ -345,7 +345,7 @@ func TestAuditMiddlewareWired_DeniedRequestCarriesResource(t *testing.T) {
 		Return(nil, services.ErrForbidden)
 
 	services := &handlerservices.Services{ProjectService: projectSvc}
-	handler := newTestHTTPHandlerWithLogger(t, services, logger)
+	handler := newTestHTTPHandlerWithLogger(t, services, logger, &buf)
 
 	body, _ := json.Marshal(gen.Project{Metadata: gen.ObjectMeta{Name: "denied-proj"}})
 	_, rec := doRequest(t, handler, http.MethodPut,
@@ -390,7 +390,7 @@ func TestAuditMiddlewareWired_UnauthenticatedRejection(t *testing.T) {
 	auditCfg := config.AuditDefaults()
 	policies, err := auditCfg.BuildPolicySet(auditconfig.Vocabulary{}, nil)
 	require.NoError(t, err)
-	emitter, err := audit.NewEmitter("openchoreo-api", policies, audit.NewLogger(logger))
+	emitter, err := audit.NewEmitter("openchoreo-api", policies, audit.NewLogger(&buf))
 	require.NoError(t, err)
 
 	h := &Handler{services: &handlerservices.Services{}, logger: logger}
@@ -433,7 +433,7 @@ func TestAuditMiddlewareWired_PanicOnAuthenticatedRouteEmitsExactlyOnce(t *testi
 		Run(func(context.Context, string, *openchoreov1alpha1.Project) { panic("handler blew up") })
 
 	services := &handlerservices.Services{ProjectService: projectSvc}
-	handler := newTestHTTPHandlerWithLogger(t, services, logger)
+	handler := newTestHTTPHandlerWithLogger(t, services, logger, &buf)
 
 	body, _ := json.Marshal(gen.Project{Metadata: gen.ObjectMeta{Name: "panic-proj"}})
 

--- a/internal/openchoreo-api/api/handlers/exec_wirelogs_audit_test.go
+++ b/internal/openchoreo-api/api/handlers/exec_wirelogs_audit_test.go
@@ -5,6 +5,7 @@ package handlers
 
 import (
 	"bytes"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -15,14 +16,14 @@ import (
 	"github.com/openchoreo/openchoreo/internal/server/middleware/audit"
 )
 
-func newTestAuditEmitter(t *testing.T, logger *slog.Logger) *audit.Emitter {
+func newTestAuditEmitter(t *testing.T, sink io.Writer) *audit.Emitter {
 	t.Helper()
 	auditCfg := config.AuditDefaults()
 	policies, err := auditCfg.BuildPolicySet(auditconfig.Vocabulary{}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error building policy set: %v", err)
 	}
-	emitter, err := audit.NewEmitter("openchoreo-api", policies, audit.NewLogger(logger))
+	emitter, err := audit.NewEmitter("openchoreo-api", policies, audit.NewLogger(sink))
 	if err != nil {
 		t.Fatalf("unexpected error building emitter: %v", err)
 	}
@@ -61,7 +62,7 @@ func TestExecWirelogsAuth401IsAudited(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			logger := slog.New(slog.NewJSONHandler(&buf, nil))
-			emitter := newTestAuditEmitter(t, logger)
+			emitter := newTestAuditEmitter(t, &buf)
 			mw, err := NewExecWirelogsAuditMiddleware(logger, emitter, true)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -107,7 +108,7 @@ func TestExecWirelogsAuth401IsAudited(t *testing.T) {
 func TestExecWirelogsAuthenticatedRequestEmitsExactlyOnce(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
-	emitter := newTestAuditEmitter(t, logger)
+	emitter := newTestAuditEmitter(t, &buf)
 	mw, err := NewExecWirelogsAuditMiddleware(logger, emitter, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -142,7 +143,7 @@ func TestExecWirelogsAuthenticatedRequestEmitsExactlyOnce(t *testing.T) {
 func TestFindFlusher_SeesThroughAuditWrapper(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
-	emitter := newTestAuditEmitter(t, logger)
+	emitter := newTestAuditEmitter(t, &buf)
 	mw, err := NewExecWirelogsAuditMiddleware(logger, emitter, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -176,7 +177,7 @@ func TestFindFlusher_SeesThroughAuditWrapper(t *testing.T) {
 func TestExecWirelogsAuditMiddleware_ResolvesBothRoutes(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
-	emitter := newTestAuditEmitter(t, logger)
+	emitter := newTestAuditEmitter(t, &buf)
 	mw, err := NewExecWirelogsAuditMiddleware(logger, emitter, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -230,7 +231,7 @@ func TestExecWirelogsAuditMiddleware_ResolvesBothRoutes(t *testing.T) {
 func TestExecHandler_SetsResourceNameFromParsedPath(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
-	emitter := newTestAuditEmitter(t, logger)
+	emitter := newTestAuditEmitter(t, &buf)
 	mw, err := NewExecWirelogsAuditMiddleware(logger, emitter, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -270,7 +271,7 @@ func TestExecHandler_SetsResourceNameFromParsedPath(t *testing.T) {
 func TestWirelogsHandler_SetsResourceNamespaceFromParsedPath(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
-	emitter := newTestAuditEmitter(t, logger)
+	emitter := newTestAuditEmitter(t, &buf)
 	mw, err := NewExecWirelogsAuditMiddleware(logger, emitter, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -317,7 +318,7 @@ func TestWirelogsHandler_SetsResourceNamespaceFromParsedPath(t *testing.T) {
 func TestWirelogsHandler_MalformedNamespaceNotAudited(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
-	emitter := newTestAuditEmitter(t, logger)
+	emitter := newTestAuditEmitter(t, &buf)
 	mw, err := NewExecWirelogsAuditMiddleware(logger, emitter, true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/openchoreo-api/api/handlers/http_test_helpers_test.go
+++ b/internal/openchoreo-api/api/handlers/http_test_helpers_test.go
@@ -31,7 +31,7 @@ import (
 // chain, and serialization — rather than calling handler methods directly.
 func newTestHTTPHandler(t *testing.T, services *handlerservices.Services) http.Handler {
 	t.Helper()
-	return newTestHTTPHandlerWithLogger(t, services, slog.Default())
+	return newTestHTTPHandlerWithLogger(t, services, slog.Default(), io.Discard)
 }
 
 // newTestHTTPHandlerWithLogger is like newTestHTTPHandler but lets the caller supply
@@ -40,12 +40,12 @@ func newTestHTTPHandler(t *testing.T, services *handlerservices.Services) http.H
 // Builds its chain via OpenAPIMiddlewares, the same constructor production uses,
 // so tests exercise the real middleware ordering rather than a hand-assembled
 // stand-in — do not rebuild the chain here instead (see #2588).
-func newTestHTTPHandlerWithLogger(t *testing.T, services *handlerservices.Services, logger *slog.Logger) http.Handler {
+func newTestHTTPHandlerWithLogger(t *testing.T, services *handlerservices.Services, logger *slog.Logger, auditSink io.Writer) http.Handler {
 	t.Helper()
 	auditCfg := config.AuditDefaults()
 	policies, err := auditCfg.BuildPolicySet(auditconfig.Vocabulary{}, nil)
 	require.NoError(t, err, "test audit defaults must build a valid PolicySet")
-	emitter, err := audit.NewEmitter("openchoreo-api", policies, audit.NewLogger(logger))
+	emitter, err := audit.NewEmitter("openchoreo-api", policies, audit.NewLogger(auditSink))
 	require.NoError(t, err, "test audit defaults must build a valid Emitter")
 
 	h := &Handler{services: services, logger: logger}

--- a/internal/server/middleware/audit/logger.go
+++ b/internal/server/middleware/audit/logger.go
@@ -5,9 +5,9 @@ package audit
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 )
 
@@ -19,46 +19,30 @@ type Logger struct {
 	slogger *slog.Logger
 }
 
-// forceLevelHandler wraps a slog.Handler so every record is treated as
-// enabled, regardless of the minimum level the wrapped handler was
-// constructed with. Audit events must not be silently dropped by the
-// application's log-level configuration (e.g. logging.level: warn), since
-// audit.enabled is meant to be the only kill switch for audit output.
-type forceLevelHandler struct {
-	slog.Handler
-}
-
-// Enabled always returns true so the wrapped handler's level filter never
-// suppresses an audit record.
-func (h *forceLevelHandler) Enabled(context.Context, slog.Level) bool {
-	return true
-}
-
-// WithAttrs and WithGroup re-wrap the result in a forceLevelHandler. Without
-// these, the embedded slog.Handler's own WithAttrs/WithGroup would return the
-// *inner* handler directly — silently dropping the always-enabled override on
-// any derived logger, the same silent-drop failure mode this handler exists
-// to close. Unreachable today (LogEvent never derives a logger via .With),
-// but left un-implemented it is a landmine for the next caller that does.
-func (h *forceLevelHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	return &forceLevelHandler{Handler: h.Handler.WithAttrs(attrs)}
-}
-
-func (h *forceLevelHandler) WithGroup(name string) slog.Handler {
-	return &forceLevelHandler{Handler: h.Handler.WithGroup(name)}
-}
-
-// NewLogger creates a new audit logger. It reuses the given logger's handler
-// (output stream, format, and any attrs already attached, e.g. "component")
-// but forces every record through regardless of the handler's configured
-// minimum level.
-func NewLogger(slogger *slog.Logger) *Logger {
-	return &Logger{slogger: slog.New(&forceLevelHandler{Handler: slogger.Handler()})}
+// NewLogger creates an audit logger writing newline-delimited JSON to w.
+//
+// The handler is this package's own rather than the application logger's: a
+// collector parses these records, so the format is a published contract, not a
+// logging preference. audit.enabled is therefore the only kill switch — no
+// application log level applies.
+//
+// Pass the same *os.File the application logger uses (os.Stdout). slog writes
+// each record in one Write and os.File serializes writes per descriptor, so
+// two handlers on one *os.File cannot interleave; wrapping either side in a
+// buffered or separately-opened writer loses that.
+func NewLogger(w io.Writer) *Logger {
+	return &Logger{slogger: slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))}
 }
 
 // LogEvent emits an audit log event using slog. The attrs are derived from
 // Event.MarshalJSON's output rather than built by hand, so the log stream and
 // a sink that marshals the same *Event cannot publish different shapes.
+//
+// The "AUDIT-LOG" message is the collector's routing key, separating these
+// records from the process's application logs, so it is stable across schema
+// minor versions.
 func (l *Logger) LogEvent(event *Event) {
 	payload, err := json.Marshal(event)
 	if err != nil {

--- a/internal/server/middleware/audit/logger_test.go
+++ b/internal/server/middleware/audit/logger_test.go
@@ -5,9 +5,9 @@ package audit
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"log/slog"
+	"strings"
 	"testing"
 )
 
@@ -17,7 +17,7 @@ import (
 // silently dropped both fields regardless of what Emit passed in.
 func TestLogEvent_IncludesOriginAndOperationID(t *testing.T) {
 	var buf bytes.Buffer
-	logger := NewLogger(slog.New(slog.NewJSONHandler(&buf, nil)))
+	logger := NewLogger(&buf)
 
 	logger.LogEvent(&Event{
 		Actor:       Actor{Type: "user", ID: "u1"},
@@ -47,7 +47,7 @@ func TestLogEvent_IncludesOriginAndOperationID(t *testing.T) {
 // omitted rather than rendered as an empty string.
 func TestLogEvent_OmitsEmptyOriginAndOperationID(t *testing.T) {
 	var buf bytes.Buffer
-	logger := NewLogger(slog.New(slog.NewJSONHandler(&buf, nil)))
+	logger := NewLogger(&buf)
 
 	logger.LogEvent(&Event{
 		Actor:    Actor{Type: "user", ID: "u1"},
@@ -77,7 +77,7 @@ func TestLogEvent_OmitsEmptyOriginAndOperationID(t *testing.T) {
 // there isn't one.
 func TestLogEvent_ResourceTypeIndependentOfResource(t *testing.T) {
 	var buf bytes.Buffer
-	logger := NewLogger(slog.New(slog.NewJSONHandler(&buf, nil)))
+	logger := NewLogger(&buf)
 
 	logger.LogEvent(&Event{
 		Actor:        Actor{Type: "user", ID: "u1"},
@@ -113,7 +113,7 @@ func TestLogEvent_ResourceTypeIndependentOfResource(t *testing.T) {
 // the "resource" group.
 func TestLogEvent_IncludesHierarchy(t *testing.T) {
 	var buf bytes.Buffer
-	logger := NewLogger(slog.New(slog.NewJSONHandler(&buf, nil)))
+	logger := NewLogger(&buf)
 
 	logger.LogEvent(&Event{
 		Actor:        Actor{Type: "user", ID: "u1"},
@@ -150,7 +150,7 @@ func TestLogEvent_IncludesHierarchy(t *testing.T) {
 // "project"/"component"/"resource" keys.
 func TestLogEvent_OmitsEmptyHierarchyFields(t *testing.T) {
 	var buf bytes.Buffer
-	logger := NewLogger(slog.New(slog.NewJSONHandler(&buf, nil)))
+	logger := NewLogger(&buf)
 
 	logger.LogEvent(&Event{
 		Actor:        Actor{Type: "user", ID: "u1"},
@@ -202,7 +202,7 @@ func TestRenderPaths_NamespaceFromHierarchyWithNilResource(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	NewLogger(slog.New(slog.NewJSONHandler(&buf, nil))).LogEvent(event)
+	NewLogger(&buf).LogEvent(event)
 	var loggerRecord map[string]any
 	if err := json.Unmarshal(buf.Bytes(), &loggerRecord); err != nil {
 		t.Fatalf("failed to unmarshal LogEvent output: %v", err)
@@ -255,7 +255,7 @@ func TestRenderPaths_ResourceNamespaceOverridesHierarchy(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	NewLogger(slog.New(slog.NewJSONHandler(&buf, nil))).LogEvent(event)
+	NewLogger(&buf).LogEvent(event)
 	var loggerRecord map[string]any
 	if err := json.Unmarshal(buf.Bytes(), &loggerRecord); err != nil {
 		t.Fatalf("failed to unmarshal LogEvent output: %v", err)
@@ -285,71 +285,37 @@ func TestRenderPaths_ResourceNamespaceOverridesHierarchy(t *testing.T) {
 	}
 }
 
-// TestForceLevelHandler_WithAttrsAndWithGroupPreserveForce guards against the
-// always-enabled override silently disappearing through .WithAttrs/.WithGroup
-// — slog.Handler's embedding means those methods, left unimplemented, would
-// return the *inner* handler directly, dropping the force. Unreachable via
-// LogEvent today (it never derives a logger), but a landmine for the next
-// caller that does.
-func TestForceLevelHandler_WithAttrsAndWithGroupPreserveForce(t *testing.T) {
-	newBase := func(buf *bytes.Buffer) slog.Handler {
-		return slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelError})
-	}
+// TestLogEvent_PublishesJSONRegardlessOfAppLogging pins what a collector
+// depends on: a JSON record carrying the AUDIT-LOG marker, whatever format or
+// level the application logger uses. The app logger here is a text handler at
+// LevelError — observer's LOG_LEVEL=debug shape.
+func TestLogEvent_PublishesJSONRegardlessOfAppLogging(t *testing.T) {
+	var appBuf, auditBuf bytes.Buffer
+	appLogger := slog.New(slog.NewTextHandler(&appBuf, &slog.HandlerOptions{Level: slog.LevelError}))
+	appLogger.Error("an application error")
 
-	t.Run("WithAttrs", func(t *testing.T) {
-		var buf bytes.Buffer
-		h := &forceLevelHandler{Handler: newBase(&buf)}
-		derived := h.WithAttrs([]slog.Attr{slog.String("k", "v")})
-
-		if !derived.Enabled(context.Background(), slog.LevelInfo) {
-			t.Fatal("expected the WithAttrs-derived handler to still report Enabled=true below the wrapped handler's minimum level")
-		}
-		slog.New(derived).Info("test message")
-		if buf.Len() == 0 {
-			t.Fatal("expected a record via the WithAttrs-derived handler despite LevelError, got none")
-		}
-	})
-
-	t.Run("WithGroup", func(t *testing.T) {
-		var buf bytes.Buffer
-		h := &forceLevelHandler{Handler: newBase(&buf)}
-		derived := h.WithGroup("g")
-
-		if !derived.Enabled(context.Background(), slog.LevelInfo) {
-			t.Fatal("expected the WithGroup-derived handler to still report Enabled=true below the wrapped handler's minimum level")
-		}
-		slog.New(derived).Info("test message")
-		if buf.Len() == 0 {
-			t.Fatal("expected a record via the WithGroup-derived handler despite LevelError, got none")
-		}
-	})
-}
-
-// TestLogEvent_NotGatedByAppLogLevel guards against audit events being
-// silently dropped when the application logger is configured with a level
-// above Info (e.g. logging.level: warn in Helm values). audit.enabled must be
-// the only kill switch for audit output.
-func TestLogEvent_NotGatedByAppLogLevel(t *testing.T) {
-	var buf bytes.Buffer
-	appLogger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError}))
-	logger := NewLogger(appLogger)
-
-	logger.LogEvent(&Event{
+	NewLogger(&auditBuf).LogEvent(&Event{
 		Actor:    Actor{Type: "user", ID: "u1"},
 		Action:   "create_project",
 		Category: CategoryManagement,
 		Result:   ResultSuccess,
 	})
 
-	if buf.Len() == 0 {
-		t.Fatal("expected audit record to be emitted despite app logger's LevelError filter, got no output")
+	if auditBuf.Len() == 0 {
+		t.Fatal("expected an audit record, got no output")
 	}
 
 	var record map[string]any
-	if err := json.Unmarshal(buf.Bytes(), &record); err != nil {
-		t.Fatalf("failed to unmarshal log line: %v", err)
+	if err := json.Unmarshal(auditBuf.Bytes(), &record); err != nil {
+		t.Fatalf("audit record is not JSON: %v\nline: %s", err, auditBuf.String())
+	}
+	if record["msg"] != "AUDIT-LOG" {
+		t.Errorf("msg = %v, want AUDIT-LOG — collectors route on this field", record["msg"])
 	}
 	if record["action"] != "create_project" {
 		t.Errorf("action = %v, want create_project", record["action"])
+	}
+	if strings.Contains(auditBuf.String(), "an application error") {
+		t.Error("audit output must not share a destination with the application logger")
 	}
 }

--- a/internal/server/middleware/audit/record_shape_test.go
+++ b/internal/server/middleware/audit/record_shape_test.go
@@ -6,7 +6,6 @@ package audit
 import (
 	"bytes"
 	"encoding/json"
-	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -19,18 +18,20 @@ var fixedTime = time.Date(2026, 9, 7, 12, 30, 45, 0, time.UTC)
 // logLinePrefix is what slog's JSONHandler puts before the event's own fields.
 const logLinePrefix = `{"level":"INFO","msg":"AUDIT-LOG",`
 
-// newRecordLogger returns a Logger writing to buf with slog's handler-stamped
-// "time" attr removed — it is the wall clock at emission, so it would defeat
-// any byte comparison. The event's own pinned "event_time" is the one asserted.
-func newRecordLogger(buf *bytes.Buffer) *Logger {
-	return NewLogger(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{
-		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
-			if len(groups) == 0 && a.Key == slog.TimeKey {
-				return slog.Attr{}
-			}
-			return a
-		},
-	})))
+// stripTimeAttr removes slog's handler-stamped "time" attr, the wall clock at
+// emission, which would defeat a byte comparison; the event's own pinned
+// "event_time" is the one asserted. Stripping here rather than with a
+// ReplaceAttr hook keeps NewLogger free of a test-only option.
+func stripTimeAttr(line string) string {
+	const timeKey = `{"time":"`
+	if !strings.HasPrefix(line, timeKey) {
+		return line
+	}
+	end := strings.Index(line, `","level":`)
+	if end < 0 {
+		return line
+	}
+	return "{" + line[end+2:]
 }
 
 type recordCase struct {
@@ -276,8 +277,8 @@ func TestPublishedRecordShape(t *testing.T) {
 	for _, tc := range recordCases() {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			newRecordLogger(&buf).LogEvent(tc.event)
-			if got := buf.String(); got != tc.want {
+			NewLogger(&buf).LogEvent(tc.event)
+			if got := stripTimeAttr(buf.String()); got != tc.want {
 				t.Errorf("published record changed:\n got: %s\nwant: %s", got, tc.want)
 			}
 		})
@@ -308,7 +309,7 @@ func TestPublishedRecordShape_MarshalJSONAgrees(t *testing.T) {
 // be marshaled still produces a record rather than vanishing.
 func TestLogEvent_RenderFailureIsReported(t *testing.T) {
 	var buf bytes.Buffer
-	newRecordLogger(&buf).LogEvent(&Event{
+	NewLogger(&buf).LogEvent(&Event{
 		EventID:  "01920000-0000-7000-8000-00000000000f",
 		Action:   "create_project",
 		Result:   ResultSuccess,

--- a/pkg/mcp/server_audit_test.go
+++ b/pkg/mcp/server_audit_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -160,13 +161,13 @@ func withTestSubject(next http.Handler) http.Handler {
 	})
 }
 
-func newAuditTestEmitter(t *testing.T, logger *slog.Logger) *audit.Emitter {
+func newAuditTestEmitter(t *testing.T, sink io.Writer) *audit.Emitter {
 	t.Helper()
 	policies, errs := audit.NewPolicySet(coreconfig.NewPath("audit"), audit.Settings{Publish: true}, nil)
 	if len(errs) != 0 {
 		t.Fatalf("unexpected policy validation errors: %v", errs)
 	}
-	emitter, err := audit.NewEmitter("openchoreo-api", policies, audit.NewLogger(logger))
+	emitter, err := audit.NewEmitter("openchoreo-api", policies, audit.NewLogger(sink))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -226,8 +227,7 @@ func auditRecordsFromLog(t *testing.T, buf *bytes.Buffer) []map[string]any {
 func TestNewHTTPServer_AuditWired(t *testing.T) {
 	t.Run("success emits one record with the handler's resource UID", func(t *testing.T) {
 		var buf bytes.Buffer
-		logger := slog.New(slog.NewJSONHandler(&buf, nil))
-		emitter := newAuditTestEmitter(t, logger)
+		emitter := newAuditTestEmitter(t, &buf)
 
 		toolsets := &tools.Toolsets{
 			ProjectToolset: &fakeCreateProjectWithUID{},
@@ -284,8 +284,7 @@ func TestNewHTTPServer_AuditWired(t *testing.T) {
 
 	t.Run("PDP denial emits result=denied, distinguishable from failure", func(t *testing.T) {
 		var buf bytes.Buffer
-		logger := slog.New(slog.NewJSONHandler(&buf, nil))
-		emitter := newAuditTestEmitter(t, logger)
+		emitter := newAuditTestEmitter(t, &buf)
 
 		toolsets := &tools.Toolsets{
 			ProjectToolset: &fakeProjectToolset{},
@@ -341,8 +340,7 @@ func TestNewHTTPServer_AuditWired(t *testing.T) {
 
 	t.Run("environment binding resolves independently of the project binding", func(t *testing.T) {
 		var buf bytes.Buffer
-		logger := slog.New(slog.NewJSONHandler(&buf, nil))
-		emitter := newAuditTestEmitter(t, logger)
+		emitter := newAuditTestEmitter(t, &buf)
 
 		toolsets := &tools.Toolsets{
 			PEToolset: &fakePEToolset{},
@@ -397,8 +395,7 @@ func TestNewHTTPServer_AuditWired(t *testing.T) {
 // bound tool call must still succeed but produce zero AUDIT-LOG records.
 func TestNewHTTPServer_AuditDisabled(t *testing.T) {
 	var buf bytes.Buffer
-	logger := slog.New(slog.NewJSONHandler(&buf, nil))
-	emitter := newAuditTestEmitter(t, logger)
+	emitter := newAuditTestEmitter(t, &buf)
 
 	toolsets := &tools.Toolsets{
 		ProjectToolset: &fakeCreateProjectWithUID{},


### PR DESCRIPTION
## Purpose

Audit records go to stdout alongside application logs, and the next phase of the epic has a log collector pick them out and route them to their own index. That only works if the records are reliably parseable.

They aren't. `NewLogger` reused the application logger's handler, so the audit format followed `logging.format`. Observer selects a text handler when `LOG_LEVEL=debug`, and in that mode it emits audit records no collector can parse — silently, since nothing downstream exists yet to notice.

## Approach

`NewLogger` takes an `io.Writer` and builds its own `slog.NewJSONHandler`. Both producers pass `os.Stdout`, the same file the application logger writes to.

`forceLevelHandler` is deleted. It existed to stop a borrowed handler's level filter suppressing audit records; an owned handler sets its own level, so `audit.enabled` remains the only kill switch with nothing left to compensate for.

Test helpers that previously passed a `*slog.Logger` now take the sink writer directly, which is usually the buffer the test was already asserting on.

## Behavioural changes

- Audit records are JSON whatever `logging.format` or `LOG_LEVEL` is set to. Application logs are unaffected.
- The `component` slog attr is no longer emitted. It came from `logging.NewWithComponent`, so it appeared on `openchoreo-api` records and never on observer's, and it duplicated `producer`, which is inside the event and consistent across both.

Both are slog envelope fields rather than part of event schema v1, so neither is a schema version bump. The seven golden `want` strings in `record_shape_test.go` are unchanged, so the published event itself is byte-identical.

## Related Issues

Part of #3343. Prerequisite for the collector-side audit routing that follows.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks

`make test` passes and `golangci-lint` reports 0 issues. `make code.gen` produces no drift — no generated file, Helm value or schema is touched.

`TestLogEvent_NotGatedByAppLogLevel` is replaced rather than deleted. With the handler owned there is no application logger in scope to be gated by, so the old assertion could no longer fail; `TestLogEvent_PublishesJSONRegardlessOfAppLogging` pins the property that replaces it — a JSON record carrying the `AUDIT-LOG` marker while the application logger is a text handler at `LevelError`.

Two things recorded in doc comments rather than enforced in code. The `AUDIT-LOG` message is the collector's routing key, so it is stable across schema minor versions. And the two handlers stay non-interleaving because they share one `*os.File`: slog writes each record in a single `Write`, and `os.File` serializes writes per descriptor. Wrapping either side in a buffered or separately-opened writer would quietly lose that, which is why it is stated at `NewLogger`.

The routing contract belongs in the generated audit schema reference, but `docs/audit/schema-reference.md` does not exist yet — it is still an open item from the schema-v1 phase. Until it lands, the contract lives in the `NewLogger` and `LogEvent` doc comments.
