### PR TITLE
fix(releasebinding): reconcile environment overrides

### DIFF
--- a/internal/controller/releasebinding/controller.go
+++ b/internal/controller/releasebinding/controller.go
@@ -1641,6 +1641,13 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.findReleaseBindingsForClusterDataPlane),
 			builder.WithPredicates(dataPlaneRenderInputsChangedPredicate()),
 		).
+		// Environment gateway settings override the DataPlane values in the render context.
+		// Watch their spec changes so an override is applied to every dependent binding.
+		Watches(
+			&openchoreov1alpha1.Environment{},
+			handler.EnqueueRequestsFromMapFunc(r.findReleaseBindingsForEnvironment),
+			builder.WithPredicates(dataPlaneRenderInputsChangedPredicate()),
+		).
 		Named("releasebinding").
 		Complete(r)
 }

--- a/internal/controller/releasebinding/controller_watch.go
+++ b/internal/controller/releasebinding/controller_watch.go
@@ -416,6 +416,35 @@ func (r *Reconciler) findReleaseBindingsForClusterDataPlane(ctx context.Context,
 	return r.releaseBindingsForDataPlaneRef(ctx, "", openchoreov1alpha1.DataPlaneRefKindClusterDataPlane, cdp.Name)
 }
 
+// findReleaseBindingsForEnvironment enqueues the bindings in an Environment's namespace
+// that render into that Environment. Environment gateway settings are render inputs and
+// take precedence over the DataPlane defaults, so an override change must not wait for an
+// unrelated ReleaseBinding update to be observed.
+func (r *Reconciler) findReleaseBindingsForEnvironment(ctx context.Context, obj client.Object) []reconcile.Request {
+	env, ok := obj.(*openchoreov1alpha1.Environment)
+	if !ok {
+		return nil
+	}
+
+	var bindings openchoreov1alpha1.ReleaseBindingList
+	if err := r.List(ctx, &bindings, client.InNamespace(env.Namespace)); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to list ReleaseBindings for Environment change", "environment", env.Name)
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0)
+	for i := range bindings.Items {
+		rb := &bindings.Items[i]
+		if rb.Spec.Environment != env.Name {
+			continue
+		}
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: rb.Name, Namespace: rb.Namespace},
+		})
+	}
+	return requests
+}
+
 // releaseBindingsForDataPlaneRef returns reconcile requests for the ReleaseBindings whose target
 // Environment references the given data plane (kind+name). When namespace is empty the
 // Environment scan is cluster-wide (used for ClusterDataPlane). Environments that resolve to a

--- a/internal/controller/releasebinding/controller_watch_dataplane_test.go
+++ b/internal/controller/releasebinding/controller_watch_dataplane_test.go
@@ -148,3 +148,20 @@ func TestFindReleaseBindingsForClusterDataPlane(t *testing.T) {
 		&openchoreov1alpha1.ClusterDataPlane{ObjectMeta: metav1.ObjectMeta{Name: "cdp"}})
 	assert.ElementsMatch(t, []string{"rb-1", "rb-2"}, requestNames(reqs))
 }
+
+// TestFindReleaseBindingsForEnvironment ensures an Environment override re-renders only the
+// ReleaseBindings targeted at that Environment, within the same namespace.
+func TestFindReleaseBindingsForEnvironment(t *testing.T) {
+	ctx := context.Background()
+	r := newReconcilerWith(t,
+		envRef("org", "production", openchoreov1alpha1.DataPlaneRefKindClusterDataPlane, "cdp"),
+		bindingFor("org", "rb-production-a", "production"),
+		bindingFor("org", "rb-production-b", "production"),
+		bindingFor("org", "rb-stage", "stage"),
+		bindingFor("other", "rb-other-namespace", "production"),
+	)
+
+	reqs := r.findReleaseBindingsForEnvironment(ctx,
+		&openchoreov1alpha1.Environment{ObjectMeta: metav1.ObjectMeta{Namespace: "org", Name: "production"}})
+	assert.ElementsMatch(t, []string{"rb-production-a", "rb-production-b"}, requestNames(reqs))
+}


### PR DESCRIPTION
Environment gateway settings override DataPlane gateway values during rendering, but changing an Environment did not enqueue its ReleaseBindings. This adds the Environment watch and a namespace-scoped mapper, with a regression test.