### PR TITLE
feat: support directory based workload file discovery for occ remote

### DIFF
--- a/internal/occ/cmd/remote/cmd.go
+++ b/internal/occ/cmd/remote/cmd.go
@@ -27,18 +27,23 @@ func NewRemoteCmd() *cobra.Command {
 		printEnv    bool
 		noSecrets   bool
 		showSecrets bool
+		dryRun      bool
 		localArgs   []string
 	)
 
 	cmd := &cobra.Command{
-		Use:   "remote <workload.yaml> [workload.yaml...]",
+		Use:   "remote <path> [path...]",
 		Short: "Tunnel one or more workloads' dependencies to your machine",
 		Long: "Resolve each workload's declared dependencies for an environment, open a local " +
 			"TCP listener for each remote one, and start a subshell whose environment points at " +
 			"those listeners — so the app runs locally against the environment's real upstreams.\n\n" +
-			"When multiple workload files are given and one declares an endpoint dependency on " +
-			"another workload's own component, that dependency is wired directly to a local " +
-			"host:port instead of being tunneled — see --local.\n\n" +
+			"Each argument is a path. A file contributes every Workload document it holds, and " +
+			"a directory contributes every Workload document beneath it, recursively, so " +
+			"`occ remote components/` is shorthand for naming each workload file in that tree. " +
+			"Use --dry-run to see what a path expands to.\n\n" +
+			"Every workload in the resolved set is treated as running on your machine. When one " +
+			"of them declares an endpoint dependency on another's own component, that dependency " +
+			"is wired directly to a local host:port instead of being tunneled — see --local.\n\n" +
 			"Values a dependency publishes through a Secret or ConfigMap are read in the data " +
 			"plane and returned over the tunnel, so they never pass through the control plane. " +
 			"They are placed in the subshell's environment (or, for file bindings, in a " +
@@ -46,18 +51,30 @@ func NewRemoteCmd() *cobra.Command {
 			"them with --print-env --show-secrets. Use --no-secrets to skip fetching them.",
 		Example: "  occ remote comp1/workload.yaml --env development\n" +
 			"  occ remote comp1/workload.yaml comp2/workload.yaml --env development\n" +
+			"  occ remote components/ --env development\n" +
+			"  occ remote components/ ../shared/gateway.yaml --env development\n" +
+			"  occ remote components/ --dry-run\n" +
 			"  occ remote comp1/workload.yaml comp2/workload.yaml --local comp2=127.0.0.1:9091 --env development",
-		Args:    cobra.MinimumNArgs(1),
-		PreRunE: auth.RequireLogin(),
+		Args: cobra.MinimumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// --dry-run reads local files only.
+			if dryRun {
+				return nil
+			}
+			return auth.RequireLogin()(cmd, args)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			overrides, err := parseLocalOverrides(localArgs)
 			if err != nil {
 				return err
 			}
 
-			resolver, err := newHTTPResolver()
-			if err != nil {
-				return err
+			// --dry-run reads local files only, so it must not need a control plane.
+			var resolver Resolver
+			if !dryRun {
+				if resolver, err = newHTTPResolver(); err != nil {
+					return err
+				}
 			}
 			// Tunnels live for the session; Ctrl-C / SIGTERM tears everything down.
 			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -71,6 +88,7 @@ func NewRemoteCmd() *cobra.Command {
 				PrintEnv:       printEnv,
 				ShowSecrets:    showSecrets,
 				NoSecrets:      noSecrets,
+				DryRun:         dryRun,
 			}, cmd.OutOrStdout())
 		},
 	}
@@ -83,12 +101,16 @@ func NewRemoteCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&noSecrets, "no-secrets", false,
 		"Do not fetch secret- or configmap-backed dependency values; report them as "+
 			"unresolved instead, so no credential enters the local process")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
+		"Print the workloads the given paths expand to and exit, without resolving "+
+			"dependencies or contacting the control plane")
 	cmd.Flags().StringArrayVar(&localArgs, "local", nil,
 		"Override the local host:port for a cross-linked dependency's provider component "+
 			"(component=host:port), e.g. --local comp2=127.0.0.1:9091. Repeatable. Defaults to "+
 			"127.0.0.1:<the provider's declared endpoint port> when not given.")
 	// --no-secrets fetches nothing, so there is nothing for --show-secrets to print.
 	cmd.MarkFlagsMutuallyExclusive("show-secrets", "no-secrets")
+	cmd.MarkFlagsMutuallyExclusive("dry-run", "print-env")
 	flags.AddNamespace(cmd)
 	flags.AddEnvironment(cmd)
 	return cmd

--- a/internal/occ/cmd/remote/connect.go
+++ b/internal/occ/cmd/remote/connect.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -114,144 +115,252 @@ func (d *Remote) Connect(ctx context.Context, p ConnectParams, out io.Writer) er
 	if len(p.WorkloadPaths) == 0 {
 		return fmt.Errorf("at least one workload is required")
 	}
-	if p.Environment == "" {
+	// --dry-run resolves nothing, so it needs no environment.
+	if p.Environment == "" && !p.DryRun {
 		return fmt.Errorf("--env is required")
 	}
 
-	workloads := make([]*v1alpha1.Workload, 0, len(p.WorkloadPaths))
-	byIdentity := make(map[workloadIdentity]*v1alpha1.Workload, len(p.WorkloadPaths))
-	for _, path := range p.WorkloadPaths {
-		wl, err := loadWorkloadFromFile(path)
-		if err != nil {
-			return err
+	disc, err := discoverWorkloads(p.WorkloadPaths)
+	if err != nil {
+		return err
+	}
+	if err := reportDiscovery(out, disc); err != nil {
+		return err
+	}
+	found := disc.workloads
+
+	if err := assignIdentities(found, p.Namespace); err != nil {
+		return err
+	}
+	// A collision is what --dry-run is most often reached for, so print the expansion
+	// before reporting it.
+	byIdentity, dupErr := indexByIdentity(found)
+	if p.DryRun {
+		printDiscovered(out, disc.sources, found)
+		// byIdentity is nil on a collision, which would understate the links.
+		if dupErr == nil {
+			printPlannedLinks(out, found, byIdentity, p.LocalOverrides)
+			printBindingCollisions(out, found)
 		}
-		namespace, err := workloadNamespace(wl, p.Namespace)
-		if err != nil {
-			return err
-		}
-		id := workloadIdentity{namespace: namespace, project: wl.Spec.Owner.ProjectName, component: wl.Spec.Owner.ComponentName}
-		if existing, dup := byIdentity[id]; dup {
-			return fmt.Errorf("duplicate workload for %s/%s/%s: %s and %s",
-				namespace, id.project, id.component, existing.Spec.Owner.ComponentName, path)
-		}
-		byIdentity[id] = wl
-		workloads = append(workloads, wl)
+		return dupErr
+	}
+	if dupErr != nil {
+		return dupErr
+	}
+	// Announce a set a directory chose; the whole set is treated as running locally.
+	if disc.fromDir {
+		fmt.Fprintf(out, "%s from %s, all treated as running locally\n",
+			countWorkloads(len(found)), strings.Join(disc.sources, ", "))
 	}
 
-	overrides := map[string]string{}
-	// Names of env vars whose values were fetched from the data plane. Tracked so
-	// --print-env can redact them rather than writing credentials to the terminal.
-	sensitive := map[string]bool{}
-	var listeners []net.Listener
-	var tunnels []tunnel
-	// Fetched file bindings live here for the life of the session. The cleanup below
-	// runs on every return path — including the ctx-cancelled one that Ctrl-C takes —
-	// so credentials written to disk do not outlive the tunnels that fetched them.
-	files := newFileStore()
+	s := &session{
+		overrides: map[string]string{},
+		sensitive: map[string]bool{},
+		files:     newFileStore(),
+	}
+	// This cleanup runs on every return path — including the ctx-cancelled one that
+	// Ctrl-C takes — so credentials written to disk do not outlive the tunnels that
+	// fetched them.
 	defer func() {
-		for _, ln := range listeners {
+		for _, ln := range s.listeners {
 			_ = ln.Close()
 		}
-		for _, tn := range tunnels {
+		for _, tn := range s.tunnels {
 			_ = tn.Close()
 		}
-		files.cleanup()
+		s.files.cleanup()
 	}()
 
-	for _, wl := range workloads {
-		namespace, err := workloadNamespace(wl, p.Namespace)
-		if err != nil {
-			return err
+	failures := 0
+	var firstErr error
+	var firstID workloadIdentity
+	for _, f := range found {
+		werr := d.connectWorkload(ctx, p, f, byIdentity, s, out)
+		if werr == nil {
+			continue
 		}
-		componentName := wl.Spec.Owner.ComponentName
-		remoteEndpoints, links := splitDependencies(wl, namespace, byIdentity)
-
-		fmt.Fprintf(out, "Connecting to %s/%s (%s)...\n", wl.Spec.Owner.ProjectName, componentName, p.Environment)
-
-		hasResources := wl.Spec.Dependencies != nil && len(wl.Spec.Dependencies.Resources) > 0
-		if len(remoteEndpoints) > 0 || hasResources {
-			req := buildResolveRequest(wl, namespace, p.Environment, remoteEndpoints)
-			resp, err := d.resolver.Resolve(ctx, req)
-			if err != nil {
-				return err
-			}
-
-			// Per resource, the in-cluster address each of its addresses resolved to and
-			// the local listener that now stands in for it.
-			localAddrs := map[string][]addrSwap{}
-			// Hoisted out of the target loop: fetching values needs the same tunnels the
-			// listeners use, and a resource with no address at all still needs one.
-			agentTunnels := make(map[string]tunnel, len(resp.Agents))
-			for id, agent := range resp.Agents {
-				tn, terr := d.dialTunnel(ctx, agent, resp.Capability)
-				if terr != nil {
-					return terr
-				}
-				tunnels = append(tunnels, tn)
-				agentTunnels[id] = tn
-			}
-			if len(resp.Targets) > 0 {
-				// Route each target's streams to its own agent; same-namespace
-				// dependencies share a tunnel.
-				reporter := newStreamErrorReporter(out, resp.Capability)
-				for _, t := range resp.Targets {
-					tn, ok := agentTunnels[t.AgentID]
-					if !ok {
-						return fmt.Errorf("resolve returned no remote-agent %q for target %s", t.AgentID, t.Key)
-					}
-
-					ln, lerr := net.Listen("tcp", net.JoinHostPort(localHost, "0"))
-					if lerr != nil {
-						return fmt.Errorf("open local listener for %s: %w", t.Key, lerr)
-					}
-					listeners = append(listeners, ln)
-					port := ln.Addr().(*net.TCPAddr).Port
-
-					key := t.Key
-					open := func() (net.Conn, error) { return tn.OpenStream(key) }
-					go forward(ln, key, open, reporter.report)
-
-					mergeOverrides(overrides, out, remoteconnect.RenderEnv(t, localHost, port))
-					if t.Resource != nil && t.Resource.RemoteAddr != "" {
-						localAddrs[t.Resource.Ref] = append(localAddrs[t.Resource.Ref],
-							newAddrSwap(t.Resource.RemoteAddr, strconv.Itoa(port)))
-					}
-					fmt.Fprintf(out, "  %-28s -> %s:%d  (%s)\n", t.Key, localHost, port, targetKind(t))
-				}
-			}
-			applyResourceBindings(overrides, out, resp, localAddrs)
-			// After the tunnels: a fetched value travels over one, so this cannot run
-			// before they are up.
-			materialized := fetchBindings(overrides, sensitive, out, resp, agentTunnels, files, localAddrs, p.NoSecrets)
-			// After both merges: an env var naming a mount path may have come from
-			// StaticEnv or from a fetch, so the repoint must see the finished map.
-			repointFilePaths(overrides, out, files, materialized)
-			for _, u := range resp.Unconnectable {
-				fmt.Fprintf(out, "  ! %s: %s\n", u.Ref, u.Reason)
-			}
+		// With a single workload the returned error is the whole report.
+		if len(found) > 1 {
+			fmt.Fprintf(out, "  ! could not connect %s/%s (%s): %v\n",
+				f.id.project, f.id.component, f.path, werr)
 		}
-
-		for _, link := range links {
-			host, port := link.target(p.LocalOverrides)
-			mergeOverrides(overrides, out, remoteconnect.RenderEnv(link.resolvedTarget(), host, port))
-			fmt.Fprintf(out, "  %-28s -> %s:%d  (local)\n", link.key, host, port)
+		failures++
+		if firstErr == nil {
+			firstErr, firstID = werr, f.id
 		}
+	}
+	if failures == len(found) {
+		if len(found) == 1 {
+			return firstErr
+		}
+		return fmt.Errorf("none of the %d workloads could be connected; first failure: %s/%s: %w",
+			len(found), firstID.project, firstID.component, firstErr)
+	}
+	if failures > 0 {
+		fmt.Fprintf(out, "! %d of %d workloads could not be connected; their dependencies are missing from this session\n",
+			failures, len(found))
 	}
 
 	if p.PrintEnv {
 		// Explicit --show-secrets needs no prompt; without it, ask rather than leaving
 		// the developer to guess why a resolved binding has no value.
 		show := p.ShowSecrets
-		if names := sortedKeys(sensitive); !show && len(names) > 0 {
+		if names := sortedKeys(s.sensitive); !show && len(names) > 0 {
 			show = d.confirmSecrets(out, names)
 		}
-		printEnvBindings(out, overrides, sensitive, show)
+		printEnvBindings(out, s.overrides, s.sensitive, show)
 		fmt.Fprintln(out, "\nTunnels open. Press Ctrl-C to disconnect.")
 		<-ctx.Done()
 		return nil
 	}
 
-	return d.runShell(ctx, mergeEnv(os.Environ(), overrides))
+	return d.runShell(ctx, mergeEnv(os.Environ(), s.overrides))
+}
+
+// session is the mutable state one invocation accumulates across its workloads.
+type session struct {
+	overrides map[string]string
+	// sensitive names the env vars whose values were fetched from the data plane, so
+	// --print-env can redact them rather than writing credentials to the terminal.
+	sensitive map[string]bool
+	listeners []net.Listener
+	tunnels   []tunnel
+	files     *fileStore
+}
+
+// connectWorkload wires one workload's dependencies into s. A failure here is confined
+// to this workload: the caller reports it and moves on to the next.
+func (d *Remote) connectWorkload(ctx context.Context, p ConnectParams, f discovered,
+	byIdentity map[workloadIdentity]*v1alpha1.Workload, s *session, out io.Writer) error {
+	remoteEndpoints, links := splitDependencies(f.wl, f.id.namespace, byIdentity)
+	fmt.Fprintf(out, "Connecting to %s/%s (%s)...\n", f.id.project, f.id.component, p.Environment)
+
+	err := d.connectRemote(ctx, p, f, remoteEndpoints, s, out)
+	// Local links need no control plane, so they hold even when the remote half failed.
+	for _, link := range links {
+		host, port := link.target(p.LocalOverrides)
+		mergeOverrides(s.overrides, out, remoteconnect.RenderEnv(link.resolvedTarget(), host, port))
+		fmt.Fprintf(out, "  %-28s -> %s:%d  (local)\n", link.key, host, port)
+	}
+	return err
+}
+
+// connectRemote resolves the workload's remaining dependencies and opens a local
+// listener for each tunnellable target.
+func (d *Remote) connectRemote(ctx context.Context, p ConnectParams, f discovered,
+	remoteEndpoints []v1alpha1.WorkloadConnection, s *session, out io.Writer) error {
+	wl := f.wl
+	hasResources := wl.Spec.Dependencies != nil && len(wl.Spec.Dependencies.Resources) > 0
+	if len(remoteEndpoints) == 0 && !hasResources {
+		return nil
+	}
+	req := buildResolveRequest(wl, f.id.namespace, p.Environment, remoteEndpoints)
+	resp, err := d.resolver.Resolve(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	// Staged until the whole workload is up, so one counted as failed contributes
+	// nothing and can never overwrite a healthy workload's binding.
+	staged := map[string]string{}
+	stagedSensitive := map[string]bool{}
+
+	// Per resource, the in-cluster address each of its addresses resolved to and
+	// the local listener that now stands in for it.
+	localAddrs := map[string][]addrSwap{}
+	// Hoisted out of the target loop: fetching values needs the same tunnels the
+	// listeners use, and a resource with no address at all still needs one.
+	agentTunnels := make(map[string]tunnel, len(resp.Agents))
+	for id, agent := range resp.Agents {
+		tn, terr := d.dialTunnel(ctx, agent, resp.Capability)
+		if terr != nil {
+			return terr
+		}
+		s.tunnels = append(s.tunnels, tn)
+		agentTunnels[id] = tn
+	}
+	if len(resp.Targets) > 0 {
+		// Route each target's streams to its own agent; same-namespace
+		// dependencies share a tunnel.
+		reporter := newStreamErrorReporter(out, resp.Capability)
+		for _, t := range resp.Targets {
+			tn, ok := agentTunnels[t.AgentID]
+			if !ok {
+				return fmt.Errorf("resolve returned no remote-agent %q for target %s", t.AgentID, t.Key)
+			}
+
+			ln, lerr := net.Listen("tcp", net.JoinHostPort(localHost, "0"))
+			if lerr != nil {
+				return fmt.Errorf("open local listener for %s: %w", t.Key, lerr)
+			}
+			s.listeners = append(s.listeners, ln)
+			port := ln.Addr().(*net.TCPAddr).Port
+
+			key := t.Key
+			open := func() (net.Conn, error) { return tn.OpenStream(key) }
+			go forward(ln, key, open, reporter.report)
+
+			mergeOverrides(staged, out, remoteconnect.RenderEnv(t, localHost, port))
+			if t.Resource != nil && t.Resource.RemoteAddr != "" {
+				localAddrs[t.Resource.Ref] = append(localAddrs[t.Resource.Ref],
+					newAddrSwap(t.Resource.RemoteAddr, strconv.Itoa(port)))
+			}
+			fmt.Fprintf(out, "  %-28s -> %s:%d  (%s)\n", t.Key, localHost, port, targetKind(t))
+		}
+	}
+	applyResourceBindings(staged, out, resp, localAddrs)
+	// After the tunnels: a fetched value travels over one, so this cannot run
+	// before they are up.
+	materialized := fetchBindings(staged, stagedSensitive, out, resp, agentTunnels, s.files, localAddrs, p.NoSecrets)
+	// After both merges: an env var naming a mount path may have come from
+	// StaticEnv or from a fetch, so the repoint must see the finished map.
+	repointFilePaths(staged, out, s.files, materialized)
+	for _, u := range resp.Unconnectable {
+		fmt.Fprintf(out, "  ! %s: %s\n", u.Ref, u.Reason)
+	}
+
+	mergeOverrides(s.overrides, out, staged)
+	for name := range stagedSensitive {
+		s.sensitive[name] = true
+	}
+	return nil
+}
+
+// assignIdentities fills in each discovered workload's identity.
+func assignIdentities(found []discovered, fallbackNamespace string) error {
+	for i := range found {
+		wl := found[i].wl
+		namespace, err := workloadNamespace(wl, fallbackNamespace)
+		if err != nil {
+			return fmt.Errorf("%s: %w", found[i].path, err)
+		}
+		found[i].id = workloadIdentity{
+			namespace: namespace,
+			project:   wl.Spec.Owner.ProjectName,
+			component: wl.Spec.Owner.ComponentName,
+		}
+	}
+	return nil
+}
+
+// indexByIdentity indexes the discovered workloads for cross-workload dependency
+// matching, rejecting two workloads that claim the same component.
+func indexByIdentity(found []discovered) (map[workloadIdentity]*v1alpha1.Workload, error) {
+	byIdentity := make(map[workloadIdentity]*v1alpha1.Workload, len(found))
+	paths := make(map[workloadIdentity]string, len(found))
+	for _, f := range found {
+		if existing, dup := paths[f.id]; dup {
+			where := fmt.Sprintf("%s and %s", existing, f.path)
+			if existing == f.path {
+				where = fmt.Sprintf("%s declares it twice", f.path)
+			}
+			return nil, fmt.Errorf("duplicate workload for %s/%s/%s: %s",
+				f.id.namespace, f.id.project, f.id.component, where)
+		}
+		paths[f.id] = f.path
+		byIdentity[f.id] = f.wl
+	}
+	return byIdentity, nil
 }
 
 // workloadNamespace resolves a workload's effective namespace: its own
@@ -588,29 +697,89 @@ func isAddrChar(s string, i int) bool {
 		('0' <= c && c <= '9') || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')
 }
 
-// loadWorkloadFromFile reads a YAML file and returns its Workload document.
-func loadWorkloadFromFile(path string) (*v1alpha1.Workload, error) {
+// loadedFile is what one YAML file yielded. problems describes documents that mean to
+// be OpenChoreo Workloads but cannot be used; their siblings in the same file are still
+// returned.
+type loadedFile struct {
+	workloads []*v1alpha1.Workload
+	problems  []string
+}
+
+// loadWorkloadsFromFile returns every usable OpenChoreo Workload document in a YAML
+// file. A document belonging to another API group, or none at all, is not ours and is
+// passed over in silence. When the file yields no usable Workload the error either
+// names the problems found or is errNoWorkloadDoc.
+func loadWorkloadsFromFile(path string) (loadedFile, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("read workload file: %w", err)
+		return loadedFile{}, reasonOnly(err)
 	}
+	var lf loadedFile
 	for _, doc := range splitYAMLDocs(data) {
 		var probe struct {
-			Kind string `json:"kind"`
+			APIVersion string `json:"apiVersion"`
+			Kind       string `json:"kind"`
 		}
 		if err := k8syaml.Unmarshal(doc, &probe); err != nil {
+			// Unparseable, so its kind is unknown. Reported only when the text means to
+			// be a Workload, which keeps templated YAML from filling the output.
+			if bytes.Contains(doc, []byte("kind: Workload")) {
+				lf.problems = append(lf.problems, fmt.Sprintf("a document does not parse: %v", err))
+			}
 			continue
 		}
 		if probe.Kind != "Workload" {
 			continue
 		}
+		switch group, version, qualified := strings.Cut(probe.APIVersion, "/"); {
+		case probe.APIVersion == "":
+			lf.problems = append(lf.problems, fmt.Sprintf("Workload %q has no apiVersion", docName(doc)))
+			continue
+		case !qualified:
+			lf.problems = append(lf.problems, fmt.Sprintf("Workload %q has unsupported apiVersion %s",
+				docName(doc), probe.APIVersion))
+			continue
+		case group != v1alpha1.GroupVersion.Group:
+			// Several other ecosystems define a Workload kind; theirs are not ours.
+			continue
+		case version != v1alpha1.GroupVersion.Version:
+			lf.problems = append(lf.problems, fmt.Sprintf("Workload %q has unsupported apiVersion %s",
+				docName(doc), probe.APIVersion))
+			continue
+		}
 		var wl v1alpha1.Workload
 		if err := k8syaml.Unmarshal(doc, &wl); err != nil {
-			return nil, fmt.Errorf("parse Workload: %w", err)
+			lf.problems = append(lf.problems, fmt.Sprintf("Workload %q does not parse: %v", docName(doc), err))
+			continue
 		}
-		return &wl, nil
+		if wl.Spec.Owner.ProjectName == "" || wl.Spec.Owner.ComponentName == "" {
+			lf.problems = append(lf.problems,
+				fmt.Sprintf("Workload %q has no spec.owner.projectName or spec.owner.componentName", wl.Name))
+			continue
+		}
+		lf.workloads = append(lf.workloads, &wl)
 	}
-	return nil, fmt.Errorf("no Workload document found in %s", path)
+	if len(lf.workloads) == 0 {
+		if len(lf.problems) > 0 {
+			return loadedFile{}, errors.New(strings.Join(lf.problems, "; "))
+		}
+		return loadedFile{}, errNoWorkloadDoc
+	}
+	return lf, nil
+}
+
+// docName reads a document's metadata.name for a problem report, since a document that
+// does not parse into a Workload still usually names itself.
+func docName(doc []byte) string {
+	var probe struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+	}
+	if err := k8syaml.Unmarshal(doc, &probe); err == nil && probe.Metadata.Name != "" {
+		return probe.Metadata.Name
+	}
+	return "(unnamed)"
 }
 
 // splitYAMLDocs splits a multi-document YAML byte slice on `---` separators.

--- a/internal/occ/cmd/remote/connect_test.go
+++ b/internal/occ/cmd/remote/connect_test.go
@@ -351,11 +351,14 @@ func TestConnectMultiWorkloadLocalLinkOverride(t *testing.T) {
 }
 
 func TestBuildResolveRequestFromWorkloadFile(t *testing.T) {
-	wl, err := loadWorkloadFromFile(writeWorkloadFile(t))
+	wls, err := loadWorkloadsFromFile(writeWorkloadFile(t))
 	if err != nil {
 		t.Fatal(err)
 	}
-	req := buildResolveRequest(wl, "default", "development", nil)
+	if len(wls.workloads) != 1 {
+		t.Fatalf("got %d workloads, want 1", len(wls.workloads))
+	}
+	req := buildResolveRequest(wls.workloads[0], "default", "development", nil)
 	if req.Namespace != "default" || req.Project != "doclet" || req.Component != "doclet-document" || req.Environment != "development" {
 		t.Fatalf("unexpected identity: %+v", req)
 	}
@@ -705,10 +708,14 @@ func TestConnectEndToEndEndpointDependency(t *testing.T) {
 }
 
 func TestBuildResolveRequestIncludesEndpointDependencies(t *testing.T) {
-	wl, err := loadWorkloadFromFile(writeWorkloadFileContent(t, "workload.yaml", testEndpointWorkloadYAML))
+	wls, err := loadWorkloadsFromFile(writeWorkloadFileContent(t, "workload.yaml", testEndpointWorkloadYAML))
 	if err != nil {
 		t.Fatal(err)
 	}
+	if len(wls.workloads) != 1 {
+		t.Fatalf("got %d workloads, want 1", len(wls.workloads))
+	}
+	wl := wls.workloads[0]
 	req := buildResolveRequest(wl, "default", "development", wl.Spec.Dependencies.Endpoints)
 	if len(req.Endpoints) != 1 {
 		t.Fatalf("unexpected endpoints: %+v", req.Endpoints)

--- a/internal/occ/cmd/remote/discover.go
+++ b/internal/occ/cmd/remote/discover.go
@@ -1,0 +1,419 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package remote
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/openchoreo/openchoreo/api/v1alpha1"
+	"github.com/openchoreo/openchoreo/internal/remoteconnect"
+	"github.com/openchoreo/openchoreo/pkg/fsindex/scanner"
+)
+
+// errNoWorkloadDoc marks a YAML file with no Workload document: an error for a file the
+// developer named, a skip for one a directory walk turned up.
+var errNoWorkloadDoc = errors.New("no Workload document found")
+
+// discovered is one Workload document and the file it came from.
+type discovered struct {
+	path string
+	wl   *v1alpha1.Workload
+	id   workloadIdentity // set by the caller, which resolves the effective namespace
+}
+
+// skippedPath is a path a directory walk could not use.
+type skippedPath struct {
+	path   string
+	reason string
+}
+
+// discovery is what the command's path arguments expanded to.
+type discovery struct {
+	workloads  []discovered
+	fromDir    bool     // whether any argument was a directory
+	sources    []string // path arguments that contributed a Workload to the set
+	sourceKeys map[string]bool
+	emptyDirs  []string      // directory arguments holding no Workload document
+	skipped    []skippedPath // paths a walk could not read or parse
+}
+
+func (d *discovery) note(path, reason string) {
+	d.skipped = append(d.skipped, skippedPath{path: path, reason: reason})
+}
+
+func (d *discovery) addSource(path string) {
+	key := fileKey(path)
+	if d.sourceKeys == nil {
+		d.sourceKeys = map[string]bool{}
+	}
+	if d.sourceKeys[key] {
+		return
+	}
+	d.sourceKeys[key] = true
+	d.sources = append(d.sources, path)
+}
+
+func (d *discovery) noteProblems(path string, problems []string) {
+	for _, problem := range problems {
+		d.note(path, problem)
+	}
+}
+
+func (d *discovery) addEmptyDir(path string) {
+	if !slices.Contains(d.emptyDirs, path) {
+		d.emptyDirs = append(d.emptyDirs, path)
+	}
+}
+
+// discoverWorkloads expands paths into the Workload documents they name: a file
+// contributes every Workload document it holds, a directory every one beneath it. A
+// file the developer named must yield a Workload; inside a directory an unusable file
+// is recorded and the walk continues.
+func discoverWorkloads(paths []string) (discovery, error) {
+	var d discovery
+	seen := make(map[string]bool, len(paths))
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return discovery{}, fmt.Errorf("path %s does not exist", path)
+			}
+			return discovery{}, fmt.Errorf("access path %s: %w", path, err)
+		}
+
+		if !info.IsDir() {
+			lf, err := loadWorkloadsFromFile(path)
+			if err != nil {
+				return discovery{}, fmt.Errorf("%s: %w", path, err)
+			}
+			d.noteProblems(path, lf.problems)
+			if d.appendUnseen(seen, path, lf.workloads) {
+				d.addSource(path)
+			}
+			continue
+		}
+
+		withWorkloads := 0
+		added := false
+		for _, file := range walkYAMLFiles(path, &d) {
+			lf, err := loadWorkloadsFromFile(file)
+			if err != nil {
+				if !errors.Is(err, errNoWorkloadDoc) {
+					d.note(file, err.Error())
+				}
+				continue
+			}
+			d.noteProblems(file, lf.problems)
+			withWorkloads++
+			if d.appendUnseen(seen, file, lf.workloads) {
+				added = true
+			}
+		}
+		if withWorkloads == 0 {
+			d.addEmptyDir(path)
+			continue
+		}
+		if added {
+			// Only a directory that chose part of the set makes it differ from what the
+			// developer typed.
+			d.fromDir = true
+			d.addSource(path)
+		}
+	}
+	return d, nil
+}
+
+// appendUnseen appends path's workloads unless an earlier argument already named the
+// same file, and reports whether it appended any.
+func (d *discovery) appendUnseen(seen map[string]bool, path string, wls []*v1alpha1.Workload) bool {
+	key := fileKey(path)
+	if seen[key] || len(wls) == 0 {
+		return false
+	}
+	seen[key] = true
+	for _, wl := range wls {
+		d.workloads = append(d.workloads, discovered{path: path, wl: wl})
+	}
+	return true
+}
+
+// reasonOnly strips the path a filesystem error repeats, since every caller prints the
+// path itself.
+func reasonOnly(err error) error {
+	var pe *os.PathError
+	if errors.As(err, &pe) {
+		return fmt.Errorf("cannot %s: %w", pe.Op, pe.Err)
+	}
+	return err
+}
+
+// fileKey identifies a file by its resolved absolute path, so two names for one file
+// are the same file.
+func fileKey(path string) string {
+	resolved := path
+	if real, err := filepath.EvalSymlinks(path); err == nil {
+		resolved = real
+	}
+	if abs, err := filepath.Abs(resolved); err == nil {
+		return abs
+	}
+	return resolved
+}
+
+// walkYAMLFiles returns every regular YAML file under root in lexical order, skipping
+// the directories the repo's GitOps scanner excludes. A symlinked root is followed
+// because the developer named it, but a symlinked directory below it may not lead
+// outside that root. A directory reached twice is walked once, so a cycle terminates.
+// Paths it cannot read are recorded in d instead of failing the walk.
+func walkYAMLFiles(root string, d *discovery) []string {
+	filter := scanner.DefaultFilter()
+	realRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		d.note(root, reasonOnly(err).Error())
+		return nil
+	}
+	visited := map[string]bool{}
+	var files []string
+
+	var walk func(dir, realDir string)
+	walk = func(dir, realDir string) {
+		if visited[realDir] {
+			return
+		}
+		visited[realDir] = true
+
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			d.note(dir, reasonOnly(err).Error())
+			return
+		}
+		for _, entry := range entries {
+			path := filepath.Join(dir, entry.Name())
+			mode := entry.Type()
+			linked := mode&fs.ModeSymlink != 0
+			if linked {
+				info, serr := os.Stat(path)
+				if serr != nil {
+					if scanner.IsYAMLFile(path) {
+						d.note(path, reasonOnly(serr).Error())
+					}
+					continue
+				}
+				mode = info.Mode().Type()
+			}
+			switch {
+			case mode.IsDir():
+				if !filter.ShouldDescendIntoDir(entry.Name()) {
+					continue
+				}
+				realChild := filepath.Join(realDir, entry.Name())
+				if linked {
+					if realChild, err = filepath.EvalSymlinks(path); err != nil {
+						d.note(path, err.Error())
+						continue
+					}
+					if !within(realRoot, realChild) {
+						d.note(path, "directory symlink leads outside "+root)
+						continue
+					}
+				}
+				walk(path, realChild)
+			case mode.IsRegular():
+				if scanner.IsYAMLFile(path) {
+					files = append(files, path)
+				}
+			default:
+				// A FIFO or device named *.yaml would block or never end on read.
+				if scanner.IsYAMLFile(path) {
+					d.note(path, "not a regular file")
+				}
+			}
+		}
+	}
+	walk(root, realRoot)
+	slices.Sort(files)
+	return files
+}
+
+// within reports whether path is root or sits beneath it.
+func within(root, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+// reportDiscovery prints what the expansion could not use, and reports whether it
+// found anything at all.
+func reportDiscovery(out io.Writer, d discovery) error {
+	for _, s := range d.skipped {
+		fmt.Fprintf(out, "! skipped %s: %s\n", s.path, s.reason)
+	}
+	if len(d.workloads) == 0 {
+		return fmt.Errorf("no Workload documents found under %s", strings.Join(d.emptyDirs, ", "))
+	}
+	for _, dir := range d.emptyDirs {
+		fmt.Fprintf(out, "! no Workload documents found under %s\n", dir)
+	}
+	return nil
+}
+
+// printDiscovered reports what sources expanded to, for --dry-run. A namespace every
+// workload shares is stated once in the summary instead of repeated per row.
+func printDiscovered(out io.Writer, sources []string, found []discovered) {
+	namespace, shared := commonNamespace(found)
+	summary := fmt.Sprintf("%s from %s", countWorkloads(len(found)), strings.Join(sources, ", "))
+	if shared {
+		summary += fmt.Sprintf(" (namespace %s)", namespace)
+	}
+	fmt.Fprintf(out, "%s:\n", summary)
+
+	heads := []string{"PATH", "PROJECT", "COMPONENT"}
+	cells := func(f discovered) []string { return []string{f.path, f.id.project, f.id.component} }
+	if !shared {
+		heads = []string{"PATH", "NAMESPACE", "PROJECT", "COMPONENT"}
+		cells = func(f discovered) []string {
+			return []string{f.path, f.id.namespace, f.id.project, f.id.component}
+		}
+	}
+
+	w := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
+	fmt.Fprintf(w, "  %s\n", strings.Join(heads, "\t"))
+	for _, f := range found {
+		fmt.Fprintf(w, "  %s\n", strings.Join(cells(f), "\t"))
+	}
+	_ = w.Flush()
+}
+
+// printPlannedLinks reports, for --dry-run, the dependencies the discovered set wires
+// to this machine and how many would be tunneled instead.
+func printPlannedLinks(out io.Writer, found []discovered,
+	byIdentity map[workloadIdentity]*v1alpha1.Workload, overrides map[string]LocalTarget) {
+	rows := make([][]string, 0, len(found))
+	tunneled := 0
+	for _, f := range found {
+		remoteEndpoints, links := splitDependencies(f.wl, f.id.namespace, byIdentity)
+		tunneled += len(remoteEndpoints)
+		if f.wl.Spec.Dependencies != nil {
+			tunneled += len(f.wl.Spec.Dependencies.Resources)
+		}
+		for _, link := range links {
+			host, port := link.target(overrides)
+			rows = append(rows, []string{
+				f.id.component,
+				strings.TrimPrefix(link.key, "ep/"),
+				net.JoinHostPort(host, strconv.Itoa(port)),
+				strings.Join(bindingNames(link.envBindings), ", "),
+			})
+		}
+	}
+
+	if len(rows) > 0 {
+		fmt.Fprintf(out, "\n%s wired to your machine instead of the environment:\n", countDependencies(len(rows)))
+		w := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
+		fmt.Fprintln(w, "  FROM\tTO\tLOCAL ADDRESS\tBINDS")
+		for _, r := range rows {
+			fmt.Fprintf(w, "  %s\n", strings.Join(r, "\t"))
+		}
+		_ = w.Flush()
+	}
+	if tunneled > 0 {
+		fmt.Fprintf(out, "\n%s would be tunneled from the environment.\n", countDependencies(tunneled))
+	}
+}
+
+// printBindingCollisions warns, for --dry-run, about env vars more than one workload
+// binds. The bindings merge into one flat map where the last writer wins, so a
+// collision silently decides which upstream an app reaches.
+func printBindingCollisions(out io.Writer, found []discovered) {
+	owners := map[string][]string{}
+	for _, f := range found {
+		for _, name := range declaredEnvNames(f.wl) {
+			if !slices.Contains(owners[name], f.id.component) {
+				owners[name] = append(owners[name], f.id.component)
+			}
+		}
+	}
+	for _, name := range sortedKeys(owners) {
+		if len(owners[name]) > 1 {
+			fmt.Fprintf(out, "! %s is bound by %d workloads (%s); the last one wins\n",
+				name, len(owners[name]), strings.Join(owners[name], ", "))
+		}
+	}
+}
+
+// declaredEnvNames lists every env var a workload's dependencies bind.
+func declaredEnvNames(wl *v1alpha1.Workload) []string {
+	if wl.Spec.Dependencies == nil {
+		return nil
+	}
+	var names []string
+	for _, ep := range wl.Spec.Dependencies.Endpoints {
+		for _, name := range []string{ep.EnvBindings.Address, ep.EnvBindings.Host,
+			ep.EnvBindings.Port, ep.EnvBindings.BasePath} {
+			if name != "" {
+				names = append(names, name)
+			}
+		}
+	}
+	for _, res := range wl.Spec.Dependencies.Resources {
+		for _, name := range res.EnvBindings {
+			if name != "" {
+				names = append(names, name)
+			}
+		}
+	}
+	return names
+}
+
+// bindingNames lists the env vars an endpoint's bindings name, in a stable order.
+func bindingNames(b remoteconnect.EndpointEnvBindings) []string {
+	var names []string
+	for _, name := range []string{b.Address, b.Host, b.Port, b.BasePath} {
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func countDependencies(n int) string {
+	if n == 1 {
+		return "1 dependency"
+	}
+	return fmt.Sprintf("%d dependencies", n)
+}
+
+// commonNamespace returns the namespace every discovered workload shares, if they all
+// share one.
+func commonNamespace(found []discovered) (string, bool) {
+	if len(found) == 0 {
+		return "", false
+	}
+	namespace := found[0].id.namespace
+	for _, f := range found[1:] {
+		if f.id.namespace != namespace {
+			return "", false
+		}
+	}
+	return namespace, true
+}
+
+func countWorkloads(n int) string {
+	if n == 1 {
+		return "1 workload"
+	}
+	return fmt.Sprintf("%d workloads", n)
+}

--- a/internal/occ/cmd/remote/discover_test.go
+++ b/internal/occ/cmd/remote/discover_test.go
@@ -1,0 +1,1079 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package remote
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openchoreo/openchoreo/internal/remoteconnect"
+)
+
+// writeTree materializes name -> content under a fresh temp dir and returns the root.
+func writeTree(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for name, content := range files {
+		path := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+// providerComponent is the component providerWorkloadYAML declares.
+const providerComponent = "comp2"
+
+// noteFor returns the recorded reason for path, or "" when it was not recorded.
+func noteFor(d discovery, path string) string {
+	for _, s := range d.skipped {
+		if s.path == path {
+			return s.reason
+		}
+	}
+	return ""
+}
+
+// squeeze collapses each line's column padding to single spaces, so a table assertion
+// checks field order rather than tabwriter's widths.
+func squeeze(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = strings.Join(strings.Fields(line), " ")
+	}
+	return strings.Join(lines, "\n")
+}
+
+const otherNamespaceWorkloadYAML = `apiVersion: openchoreo.dev/v1alpha1
+kind: Workload
+metadata:
+  name: comp4
+  namespace: acme
+spec:
+  owner:
+    projectName: platform
+    componentName: comp4
+`
+
+const projectYAML = `apiVersion: openchoreo.dev/v1alpha1
+kind: Project
+metadata:
+  name: demo
+`
+
+const twoWorkloadsYAML = consumerWorkloadYAML + "---\n" + `apiVersion: openchoreo.dev/v1alpha1
+kind: Workload
+metadata:
+  name: comp3
+spec:
+  owner:
+    projectName: demo
+    componentName: comp3
+`
+
+// TestDiscoverWorkloadsExpandsDirectoryRecursively covers both component layouts: a
+// nested comp1/workload.yaml and a flat file holding Component + Workload.
+func TestDiscoverWorkloadsExpandsDirectoryRecursively(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"components/comp1/workload.yaml": consumerWorkloadYAML,
+		"components/comp2.yaml":          providerWorkloadYAML,
+		"components/project.yaml":        projectYAML,
+		"components/README.md":           "not yaml",
+	})
+
+	d, err := discoverWorkloads([]string{filepath.Join(root, "components")})
+	if err != nil {
+		t.Fatalf("discoverWorkloads: %v", err)
+	}
+	if !d.fromDir {
+		t.Error("fromDir = false, want true for a directory argument")
+	}
+	found := d.workloads
+	if len(found) != 2 {
+		t.Fatalf("got %d workloads, want 2: %+v", len(found), found)
+	}
+	if got, want := found[0].wl.Spec.Owner.ComponentName, "comp1"; got != want {
+		t.Errorf("found[0] component = %q, want %q", got, want)
+	}
+	if got, want := found[1].wl.Spec.Owner.ComponentName, providerComponent; got != want {
+		t.Errorf("found[1] component = %q, want %q", got, want)
+	}
+}
+
+// TestDiscoverWorkloadsSkipsNonWorkloadFilesInDirectory covers the asymmetry: a walk
+// skips a non-workload file, naming one is an error.
+func TestDiscoverWorkloadsSkipsNonWorkloadFilesInDirectory(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"components/project.yaml": projectYAML,
+		"components/comp2.yaml":   providerWorkloadYAML,
+		"components/garbage.yaml": "this: [is, not: valid",
+		"components/empty.yml":    "",
+		"components/binding.yaml": projectYAML,
+	})
+
+	d, err := discoverWorkloads([]string{filepath.Join(root, "components")})
+	if err != nil {
+		t.Fatalf("discoverWorkloads: %v", err)
+	}
+	if len(d.workloads) != 1 || d.workloads[0].wl.Spec.Owner.ComponentName != providerComponent {
+		t.Fatalf("got %+v, want just comp2", d.workloads)
+	}
+
+	explicit := filepath.Join(root, "components", "project.yaml")
+	if _, err := discoverWorkloads([]string{explicit}); !errors.Is(err, errNoWorkloadDoc) {
+		t.Errorf("explicit non-workload file: err = %v, want errNoWorkloadDoc", err)
+	}
+}
+
+func TestDiscoverWorkloadsTakesEveryWorkloadDoc(t *testing.T) {
+	path := writeWorkloadFileContent(t, "all.yaml", twoWorkloadsYAML)
+
+	d, err := discoverWorkloads([]string{path})
+	if err != nil {
+		t.Fatalf("discoverWorkloads: %v", err)
+	}
+	if d.fromDir {
+		t.Error("fromDir = true, want false for a file argument")
+	}
+	found := d.workloads
+	if len(found) != 2 {
+		t.Fatalf("got %d workloads, want 2", len(found))
+	}
+	for i, want := range []string{"comp1", "comp3"} {
+		if got := found[i].wl.Spec.Owner.ComponentName; got != want {
+			t.Errorf("found[%d] component = %q, want %q", i, got, want)
+		}
+	}
+}
+
+// TestDiscoverWorkloadsDedupesOverlappingArguments names a directory and one of its own
+// files, in both orders.
+func TestDiscoverWorkloadsDedupesOverlappingArguments(t *testing.T) {
+	root := writeTree(t, map[string]string{"components/comp2.yaml": providerWorkloadYAML})
+	dir := filepath.Join(root, "components")
+	file := filepath.Join(dir, "comp2.yaml")
+
+	for _, paths := range [][]string{{dir, file}, {file, dir}} {
+		d, err := discoverWorkloads(paths)
+		if err != nil {
+			t.Fatalf("discoverWorkloads(%v): %v", paths, err)
+		}
+		if len(d.workloads) != 1 {
+			t.Fatalf("discoverWorkloads(%v) got %d workloads, want 1: %+v", paths, len(d.workloads), d.workloads)
+		}
+	}
+}
+
+// TestDiscoverWorkloadsSkipsExcludedDirectories checks the scanner's skip list applies
+// to subdirectories but never to the named root.
+func TestDiscoverWorkloadsSkipsExcludedDirectories(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"components/comp2.yaml":                 providerWorkloadYAML,
+		"components/node_modules/vendored.yaml": consumerWorkloadYAML,
+		"components/.hidden/comp1.yaml":         consumerWorkloadYAML,
+		"components/vendor/comp1.yaml":          consumerWorkloadYAML,
+	})
+
+	d, err := discoverWorkloads([]string{filepath.Join(root, "components")})
+	if err != nil {
+		t.Fatalf("discoverWorkloads: %v", err)
+	}
+	if len(d.workloads) != 1 || d.workloads[0].wl.Spec.Owner.ComponentName != providerComponent {
+		t.Fatalf("got %+v, want just comp2", d.workloads)
+	}
+
+	build := writeTree(t, map[string]string{"build/comp2.yaml": providerWorkloadYAML})
+	d, err = discoverWorkloads([]string{filepath.Join(build, "build")})
+	if err != nil {
+		t.Fatalf("discoverWorkloads(build/): %v", err)
+	}
+	if len(d.workloads) != 1 {
+		t.Fatalf("got %d workloads under an explicitly named build/, want 1", len(d.workloads))
+	}
+}
+
+func TestDiscoverWorkloadsMissingPath(t *testing.T) {
+	root := writeTree(t, map[string]string{"components/comp2.yaml": providerWorkloadYAML})
+
+	_, err := discoverWorkloads([]string{filepath.Join(root, "nope")})
+	if err == nil || !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("err = %v, want it to name a missing path", err)
+	}
+}
+
+func TestDiscoverWorkloadsReportsEmptyDirectory(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"empty-dir/project.yaml": projectYAML,
+		"components/comp2.yaml":  providerWorkloadYAML,
+	})
+	empty := filepath.Join(root, "empty-dir")
+
+	d, err := discoverWorkloads([]string{empty, filepath.Join(root, "components")})
+	if err != nil {
+		t.Fatalf("discoverWorkloads: %v", err)
+	}
+	if len(d.workloads) != 1 {
+		t.Fatalf("got %d workloads, want the one from components/", len(d.workloads))
+	}
+	if len(d.emptyDirs) != 1 || d.emptyDirs[0] != empty {
+		t.Errorf("emptyDirs = %v, want [%s]", d.emptyDirs, empty)
+	}
+	if want := []string{filepath.Join(root, "components")}; !slices.Equal(d.sources, want) {
+		t.Errorf("sources = %v, want %v", d.sources, want)
+	}
+}
+
+func TestConnectDryRunListsExpansionWithoutResolving(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"components/comp1/workload.yaml": consumerWorkloadYAML,
+		"components/comp2.yaml":          providerWorkloadYAML,
+	})
+	dir := filepath.Join(root, "components")
+
+	d := New(erroringResolver{t: t})
+	d.runShell = func(context.Context, []string) error {
+		t.Fatal("runShell should not be called under --dry-run")
+		return nil
+	}
+
+	var out bytes.Buffer
+	if err := d.Connect(context.Background(), ConnectParams{
+		WorkloadPaths: []string{dir},
+		Namespace:     "default",
+		DryRun:        true,
+	}, &out); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		"2 workloads from " + dir + " (namespace default):",
+		"PATH PROJECT COMPONENT",
+		filepath.Join(dir, "comp1", "workload.yaml") + " demo comp1",
+		filepath.Join(dir, "comp2.yaml") + " demo comp2",
+	} {
+		if !strings.Contains(squeeze(got), want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "NAMESPACE") {
+		t.Errorf("shared namespace should not get its own column:\n%s", got)
+	}
+}
+
+// TestConnectDryRunKeepsNamespaceColumnAcrossNamespaces covers a tree whose namespace
+// the summary cannot state.
+func TestConnectDryRunKeepsNamespaceColumnAcrossNamespaces(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"components/comp2.yaml": providerWorkloadYAML,
+		"components/comp4.yaml": otherNamespaceWorkloadYAML,
+	})
+	dir := filepath.Join(root, "components")
+
+	var out bytes.Buffer
+	if err := New(erroringResolver{t: t}).Connect(context.Background(), ConnectParams{
+		WorkloadPaths: []string{dir},
+		Namespace:     "default",
+		DryRun:        true,
+	}, &out); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	got := out.String()
+	if want := "2 workloads from " + dir + ":"; !strings.Contains(got, want) {
+		t.Errorf("output missing %q:\n%s", want, got)
+	}
+	if strings.Contains(got, "(namespace") {
+		t.Errorf("summary should not claim a namespace:\n%s", got)
+	}
+	for _, want := range []string{
+		"PATH NAMESPACE PROJECT COMPONENT",
+		filepath.Join(dir, "comp2.yaml") + " default demo comp2",
+		filepath.Join(dir, "comp4.yaml") + " acme platform comp4",
+	} {
+		if !strings.Contains(squeeze(got), want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestConnectAnnouncesDirectoryExpansion covers the summary header, and its absence
+// when the arguments are files.
+func TestConnectAnnouncesDirectoryExpansion(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"components/comp1.yaml": consumerWorkloadYAML,
+		"components/comp2.yaml": providerWorkloadYAML,
+	})
+	dir := filepath.Join(root, "components")
+
+	run := func(t *testing.T, paths []string) string {
+		t.Helper()
+		d := New(erroringResolver{t: t})
+		d.dialTunnel = func(context.Context, remoteconnect.AgentEndpoint, string) (tunnel, error) {
+			t.Fatal("dialTunnel should not be called for a locally-linked dependency")
+			return nil, nil
+		}
+		d.runShell = func(context.Context, []string) error { return nil }
+		var out bytes.Buffer
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := d.Connect(ctx, ConnectParams{
+			WorkloadPaths: paths,
+			Namespace:     "default",
+			Environment:   "development",
+		}, &out); err != nil {
+			t.Fatalf("Connect: %v", err)
+		}
+		return out.String()
+	}
+
+	if got, want := run(t, []string{dir}), "2 workloads from "+dir+", all treated as running locally"; !strings.Contains(got, want) {
+		t.Errorf("directory output missing %q:\n%s", want, got)
+	}
+	named := run(t, []string{filepath.Join(dir, "comp1.yaml"), filepath.Join(dir, "comp2.yaml")})
+	if strings.Contains(named, "all treated as running locally") {
+		t.Errorf("named files should not print the expansion header:\n%s", named)
+	}
+}
+
+func TestConnectDuplicateWorkloadNamesBothPaths(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"components/comp1.yaml": consumerWorkloadYAML,
+		"components/copy.yaml":  consumerWorkloadYAML,
+	})
+	dir := filepath.Join(root, "components")
+
+	err := New(erroringResolver{t: t}).Connect(context.Background(), ConnectParams{
+		WorkloadPaths: []string{dir},
+		Namespace:     "default",
+		Environment:   "development",
+	}, io.Discard)
+	if err == nil {
+		t.Fatal("Connect: want a duplicate-workload error")
+	}
+	for _, want := range []string{
+		"duplicate workload for default/demo/comp1",
+		filepath.Join(dir, "comp1.yaml"),
+		filepath.Join(dir, "copy.yaml"),
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err, want)
+		}
+	}
+}
+
+// TestConnectWarnsAboutEmptyDirectoryAndContinues covers an unproductive directory
+// argument alongside a productive one.
+func TestConnectWarnsAboutEmptyDirectoryAndContinues(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"empty-dir/project.yaml": projectYAML,
+		"components/comp2.yaml":  providerWorkloadYAML,
+	})
+	empty := filepath.Join(root, "empty-dir")
+
+	var out bytes.Buffer
+	if err := New(erroringResolver{t: t}).Connect(context.Background(), ConnectParams{
+		WorkloadPaths: []string{empty, filepath.Join(root, "components")},
+		Namespace:     "default",
+		DryRun:        true,
+	}, &out); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	got := out.String()
+	if want := "! no Workload documents found under " + empty; !strings.Contains(got, want) {
+		t.Errorf("output missing %q:\n%s", want, got)
+	}
+	if want := "demo " + providerComponent; !strings.Contains(squeeze(got), want) {
+		t.Errorf("output missing the productive directory's workload %q:\n%s", want, got)
+	}
+	if want := "1 workload from " + filepath.Join(root, "components") + " (namespace default):"; !strings.Contains(got, want) {
+		t.Errorf("summary should name only the productive path, want %q:\n%s", want, got)
+	}
+}
+
+func TestConnectErrorsWhenEveryPathIsEmpty(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"empty-dir/project.yaml": projectYAML,
+		"other-dir/binding.yaml": projectYAML,
+	})
+	first := filepath.Join(root, "empty-dir")
+	second := filepath.Join(root, "other-dir")
+
+	var out bytes.Buffer
+	err := New(erroringResolver{t: t}).Connect(context.Background(), ConnectParams{
+		WorkloadPaths: []string{first, second},
+		Namespace:     "default",
+		Environment:   "development",
+	}, &out)
+	if err == nil {
+		t.Fatal("Connect: want an error when no path yields a workload")
+	}
+	if want := "no Workload documents found under " + first + ", " + second; err.Error() != want {
+		t.Errorf("err = %q, want %q", err, want)
+	}
+	if out.Len() != 0 {
+		t.Errorf("nothing should be printed before the error:\n%s", out.String())
+	}
+}
+
+const foreignWorkloadYAML = `apiVersion: apps/v1
+kind: Workload
+metadata:
+  name: theirs
+spec:
+  owner:
+    projectName: theirs
+    componentName: theirs
+`
+
+const ownerlessWorkloadYAML = `apiVersion: openchoreo.dev/v1alpha1
+kind: Workload
+metadata:
+  name: stub
+  namespace: default
+spec: {}
+`
+
+// TestDiscoverWorkloadsIgnoresForeignAPIGroup covers a kind: Workload from another
+// ecosystem, which several projects define.
+func TestDiscoverWorkloadsIgnoresForeignAPIGroup(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"components/foreign.yaml": foreignWorkloadYAML,
+		"components/comp2.yaml":   providerWorkloadYAML,
+	})
+	dir := filepath.Join(root, "components")
+
+	d, err := discoverWorkloads([]string{dir})
+	if err != nil {
+		t.Fatalf("discoverWorkloads: %v", err)
+	}
+	if len(d.workloads) != 1 || d.workloads[0].wl.Spec.Owner.ComponentName != providerComponent {
+		t.Fatalf("got %+v, want just comp2", d.workloads)
+	}
+	if len(d.skipped) != 0 {
+		t.Errorf("a foreign document is not ours to report: %+v", d.skipped)
+	}
+
+	named := filepath.Join(dir, "foreign.yaml")
+	if _, err := discoverWorkloads([]string{named}); !errors.Is(err, errNoWorkloadDoc) {
+		t.Errorf("naming a foreign Workload: err = %v, want errNoWorkloadDoc", err)
+	}
+}
+
+// TestDiscoverWorkloadsRejectsWorkloadWithoutOwner covers the kubebuilder-style stub,
+// whose empty owner would otherwise reach the control plane as project="" component="".
+func TestDiscoverWorkloadsRejectsWorkloadWithoutOwner(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"components/stub.yaml":  ownerlessWorkloadYAML,
+		"components/comp2.yaml": providerWorkloadYAML,
+	})
+	dir := filepath.Join(root, "components")
+
+	d, err := discoverWorkloads([]string{dir})
+	if err != nil {
+		t.Fatalf("discoverWorkloads: %v", err)
+	}
+	if len(d.workloads) != 1 {
+		t.Fatalf("got %d workloads, want just the owned one", len(d.workloads))
+	}
+	stub := filepath.Join(dir, "stub.yaml")
+	if !strings.Contains(noteFor(d, stub), "spec.owner") {
+		t.Errorf("stub was not recorded with a reason: %+v", d.skipped)
+	}
+
+	_, err = discoverWorkloads([]string{stub})
+	if err == nil || !strings.Contains(err.Error(), "spec.owner") {
+		t.Errorf("naming the stub: err = %v, want it to name spec.owner", err)
+	}
+}
+
+// TestConnectDryRunNeedsNoResolver pins that --dry-run reaches no control plane: a nil
+// resolver is enough to complete it.
+func TestConnectDryRunNeedsNoResolver(t *testing.T) {
+	root := writeTree(t, map[string]string{"components/comp2.yaml": providerWorkloadYAML})
+
+	var out bytes.Buffer
+	if err := New(nil).Connect(t.Context(), ConnectParams{
+		WorkloadPaths: []string{filepath.Join(root, "components")},
+		Namespace:     "default",
+		DryRun:        true,
+	}, &out); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if !strings.Contains(out.String(), providerComponent) {
+		t.Errorf("output missing the discovered workload:\n%s", out.String())
+	}
+}
+
+// TestConnectDryRunPrintsTableBeforeReportingDuplicate covers the preview still
+// explaining an expansion that collides.
+func TestConnectDryRunPrintsTableBeforeReportingDuplicate(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"components/comp1.yaml": consumerWorkloadYAML,
+		"components/copy.yaml":  consumerWorkloadYAML,
+	})
+	dir := filepath.Join(root, "components")
+
+	var out bytes.Buffer
+	err := New(nil).Connect(t.Context(), ConnectParams{
+		WorkloadPaths: []string{dir},
+		Namespace:     "default",
+		DryRun:        true,
+	}, &out)
+	if err == nil || !strings.Contains(err.Error(), "duplicate workload") {
+		t.Fatalf("err = %v, want a duplicate-workload error", err)
+	}
+	if want := "2 workloads from " + dir; !strings.Contains(out.String(), want) {
+		t.Errorf("the table should precede the error, want %q:\n%s", want, out.String())
+	}
+}
+
+func TestConnectReportsDuplicateWithinOneFile(t *testing.T) {
+	path := writeWorkloadFileContent(t, "both.yaml", consumerWorkloadYAML+"---\n"+consumerWorkloadYAML)
+
+	err := New(nil).Connect(t.Context(), ConnectParams{
+		WorkloadPaths: []string{path},
+		Namespace:     "default",
+		DryRun:        true,
+	}, io.Discard)
+	if want := "duplicate workload for default/demo/comp1: " + path + " declares it twice"; err == nil || err.Error() != want {
+		t.Errorf("err = %v, want %q", err, want)
+	}
+}
+
+// TestDiscoverWorkloadsOrdersByArgumentThenPath pins the order the flat last-writer-wins
+// env merge depends on.
+func TestDiscoverWorkloadsOrdersByArgumentThenPath(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"second/b.yaml":     providerWorkloadYAML,
+		"first/z.yaml":      consumerWorkloadYAML,
+		"first/a/comp.yaml": otherNamespaceWorkloadYAML,
+	})
+	first := filepath.Join(root, "first")
+	second := filepath.Join(root, "second")
+
+	d, err := discoverWorkloads([]string{first, second})
+	if err != nil {
+		t.Fatalf("discoverWorkloads: %v", err)
+	}
+	want := []string{
+		filepath.Join(first, "a", "comp.yaml"),
+		filepath.Join(first, "z.yaml"),
+		filepath.Join(second, "b.yaml"),
+	}
+	got := make([]string, 0, len(d.workloads))
+	for _, w := range d.workloads {
+		got = append(got, w.path)
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("order = %v, want %v", got, want)
+	}
+}
+
+func TestDiscoverWorkloadsDedupesSources(t *testing.T) {
+	root := writeTree(t, map[string]string{"components/comp2.yaml": providerWorkloadYAML})
+	dir := filepath.Join(root, "components")
+
+	d, err := discoverWorkloads([]string{dir, dir})
+	if err != nil {
+		t.Fatalf("discoverWorkloads: %v", err)
+	}
+	if want := []string{dir}; !slices.Equal(d.sources, want) {
+		t.Errorf("sources = %v, want %v", d.sources, want)
+	}
+}
+
+// perComponentResolver fails the components named in errs and returns an empty success
+// for the rest, so a partial failure can be driven per workload.
+type perComponentResolver struct {
+	errs  map[string]error
+	calls []string
+}
+
+func (r *perComponentResolver) Resolve(_ context.Context, req remoteconnect.ResolveRequest) (*remoteconnect.ResolveResponse, error) {
+	r.calls = append(r.calls, req.Component)
+	if err, bad := r.errs[req.Component]; bad {
+		return nil, err
+	}
+	return &remoteconnect.ResolveResponse{
+		Resources: []remoteconnect.ResourceBindings{{
+			Ref:       "some-db",
+			StaticEnv: map[string]string{envPrefix(req.Component) + "_READY": "1"},
+		}},
+	}, nil
+}
+
+// envPrefix renders a component name as an env var prefix.
+func envPrefix(component string) string {
+	return strings.ToUpper(strings.ReplaceAll(component, "-", "_"))
+}
+
+// resourceWorkloadYAML declares a resource dependency, which is what makes a workload
+// reach the control plane at all.
+func resourceWorkloadYAML(component string) string {
+	return `apiVersion: openchoreo.dev/v1alpha1
+kind: Workload
+metadata:
+  name: ` + component + `
+  namespace: default
+spec:
+  owner:
+    projectName: demo
+    componentName: ` + component + `
+  dependencies:
+    resources:
+      - ref: some-db
+        envBindings:
+          host: ` + envPrefix(component) + `_DB_HOST
+`
+}
+
+// TestConnectContinuesPastAnUnresolvableWorkload covers one undeployed component no
+// longer taking down the whole session.
+func TestConnectContinuesPastAnUnresolvableWorkload(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"components/a.yaml": resourceWorkloadYAML("comp-a"),
+		"components/b.yaml": resourceWorkloadYAML("comp-b"),
+		"components/c.yaml": resourceWorkloadYAML("comp-c"),
+	})
+	resolver := &perComponentResolver{errs: map[string]error{
+		"comp-b": errors.New(`component "comp-b" has no release in environment "development"`),
+	}}
+
+	d := New(resolver)
+	var gotEnv map[string]string
+	d.runShell = func(_ context.Context, env []string) error {
+		gotEnv = envToMap(env)
+		return nil
+	}
+
+	var out bytes.Buffer
+	if err := d.Connect(t.Context(), ConnectParams{
+		WorkloadPaths: []string{filepath.Join(root, "components")},
+		Namespace:     "default",
+		Environment:   "development",
+	}, &out); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	if want := []string{"comp-a", "comp-b", "comp-c"}; !slices.Equal(resolver.calls, want) {
+		t.Errorf("resolve calls = %v, want %v (the failure must not stop the loop)", resolver.calls, want)
+	}
+	for _, want := range []string{"COMP_A_READY", "COMP_C_READY"} {
+		if _, ok := gotEnv[want]; !ok {
+			t.Errorf("subshell env missing %s; the healthy workloads should still bind", want)
+		}
+	}
+	if _, ok := gotEnv["COMP_B_READY"]; ok {
+		t.Error("the failed workload should contribute nothing")
+	}
+
+	got := out.String()
+	for _, want := range []string{
+		"! could not connect demo/comp-b (" + filepath.Join(root, "components", "b.yaml") + "):",
+		"has no release in environment",
+		"! 1 of 3 workloads could not be connected",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestConnectErrorsWhenNoWorkloadResolves(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"components/a.yaml": resourceWorkloadYAML("comp-a"),
+		"components/b.yaml": resourceWorkloadYAML("comp-b"),
+	})
+	boom := errors.New("control plane unreachable")
+	resolver := &perComponentResolver{errs: map[string]error{"comp-a": boom, "comp-b": boom}}
+
+	d := New(resolver)
+	d.runShell = func(context.Context, []string) error {
+		t.Fatal("no subshell should start when nothing resolved")
+		return nil
+	}
+
+	err := d.Connect(t.Context(), ConnectParams{
+		WorkloadPaths: []string{filepath.Join(root, "components")},
+		Namespace:     "default",
+		Environment:   "development",
+	}, io.Discard)
+	if err == nil {
+		t.Fatal("Connect: want an error when every workload failed")
+	}
+	for _, want := range []string{"none of the 2 workloads could be connected", "demo/comp-a", boom.Error()} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("err = %q, missing %q", err, want)
+		}
+	}
+}
+
+// TestConnectSingleWorkloadFailureIsUnchanged pins that the classic one-file
+// invocation still fails with the resolver's own error and no progress noise.
+func TestConnectSingleWorkloadFailureIsUnchanged(t *testing.T) {
+	path := writeWorkloadFileContent(t, "a.yaml", resourceWorkloadYAML("comp-a"))
+	boom := errors.New("404 Not Found")
+	d := New(&perComponentResolver{errs: map[string]error{"comp-a": boom}})
+	d.runShell = func(context.Context, []string) error {
+		t.Fatal("no subshell should start")
+		return nil
+	}
+
+	var out bytes.Buffer
+	err := d.Connect(t.Context(), ConnectParams{
+		WorkloadPaths: []string{path},
+		Namespace:     "default",
+		Environment:   "development",
+	}, &out)
+	if !errors.Is(err, boom) {
+		t.Errorf("err = %v, want the resolver's own error", err)
+	}
+	if strings.Contains(out.String(), "could not connect") {
+		t.Errorf("a single workload needs no per-workload failure line:\n%s", out.String())
+	}
+}
+
+// TestConnectKeepsLocalLinksWhenRemoteHalfFails covers a cross-link surviving its
+// consumer's failed resolve, since a link needs no control plane.
+func TestConnectKeepsLocalLinksWhenRemoteHalfFails(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"components/comp1.yaml": strings.Replace(consumerWorkloadYAML,
+			"  dependencies:\n    endpoints:",
+			"  dependencies:\n    resources:\n      - ref: some-db\n        envBindings:\n          host: DB_HOST\n    endpoints:", 1),
+		"components/comp2.yaml": providerWorkloadYAML,
+	})
+	resolver := &perComponentResolver{errs: map[string]error{"comp1": errors.New("resolve exploded")}}
+
+	d := New(resolver)
+	var gotEnv map[string]string
+	d.runShell = func(_ context.Context, env []string) error {
+		gotEnv = envToMap(env)
+		return nil
+	}
+	d.dialTunnel = func(context.Context, remoteconnect.AgentEndpoint, string) (tunnel, error) {
+		t.Fatal("dialTunnel should not be called for a locally-linked dependency")
+		return nil, nil
+	}
+
+	if err := d.Connect(t.Context(), ConnectParams{
+		WorkloadPaths: []string{filepath.Join(root, "components")},
+		Namespace:     "default",
+		Environment:   "development",
+	}, io.Discard); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if got, want := gotEnv["COMP2_URL"], "http://127.0.0.1:9091"; got != want {
+		t.Errorf("COMP2_URL = %q, want %q even though comp1's resolve failed", got, want)
+	}
+}
+
+// TestConnectDryRunPreviewsLocalLinks covers the block that names the dependencies a
+// directory expansion pulls away from the environment.
+func TestConnectDryRunPreviewsLocalLinks(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"components/comp1.yaml": consumerWorkloadYAML,
+		"components/comp2.yaml": providerWorkloadYAML,
+	})
+	dir := filepath.Join(root, "components")
+
+	run := func(t *testing.T, overrides map[string]LocalTarget) string {
+		t.Helper()
+		var out bytes.Buffer
+		if err := New(nil).Connect(t.Context(), ConnectParams{
+			WorkloadPaths:  []string{dir},
+			Namespace:      "default",
+			LocalOverrides: overrides,
+			DryRun:         true,
+		}, &out); err != nil {
+			t.Fatalf("Connect: %v", err)
+		}
+		return squeeze(out.String())
+	}
+
+	got := run(t, nil)
+	for _, want := range []string{
+		"1 dependency wired to your machine instead of the environment:",
+		"FROM TO LOCAL ADDRESS BINDS",
+		"comp1 demo/comp2/http 127.0.0.1:9091 COMP2_URL",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "would be tunneled") {
+		t.Errorf("nothing here needs a tunnel:\n%s", got)
+	}
+
+	// --local moves the preview's address, so it matches what a real run would wire.
+	if want := "comp1 demo/comp2/http 127.0.0.1:3000 COMP2_URL"; !strings.Contains(
+		run(t, map[string]LocalTarget{"comp2": {Host: "127.0.0.1", Port: 3000}}), want) {
+		t.Errorf("output missing %q", want)
+	}
+}
+
+func TestConnectDryRunCountsTunneledDependencies(t *testing.T) {
+	root := writeTree(t, map[string]string{"components/a.yaml": resourceWorkloadYAML("comp-a")})
+
+	var out bytes.Buffer
+	if err := New(nil).Connect(t.Context(), ConnectParams{
+		WorkloadPaths: []string{filepath.Join(root, "components")},
+		Namespace:     "default",
+		DryRun:        true,
+	}, &out); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	got := out.String()
+	if want := "1 dependency would be tunneled from the environment."; !strings.Contains(got, want) {
+		t.Errorf("output missing %q:\n%s", want, got)
+	}
+	if strings.Contains(got, "wired to your machine") {
+		t.Errorf("there is no cross-link here:\n%s", got)
+	}
+}
+
+const mixedDocsYAML = `apiVersion: openchoreo.dev/v1alpha1
+kind: Workload
+metadata:
+  name: good
+  namespace: default
+spec:
+  owner:
+    projectName: demo
+    componentName: good
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: Workload
+metadata:
+  name: stub
+  namespace: default
+spec: {}
+`
+
+// TestDiscoverWorkloadsKeepsGoodSiblingDocuments covers one unusable document not
+// taking its own file's usable documents down with it.
+func TestDiscoverWorkloadsKeepsGoodSiblingDocuments(t *testing.T) {
+	root := writeTree(t, map[string]string{"components/mixed.yaml": mixedDocsYAML})
+	dir := filepath.Join(root, "components")
+	mixed := filepath.Join(dir, "mixed.yaml")
+
+	d, err := discoverWorkloads([]string{dir})
+	if err != nil {
+		t.Fatalf("discoverWorkloads: %v", err)
+	}
+	if len(d.workloads) != 1 || d.workloads[0].wl.Spec.Owner.ComponentName != "good" {
+		t.Fatalf("got %+v, want the usable sibling", d.workloads)
+	}
+	if got := noteFor(d, mixed); !strings.Contains(got, `"stub"`) || !strings.Contains(got, "spec.owner") {
+		t.Errorf("note = %q, want it to name the unusable document", got)
+	}
+}
+
+func TestDiscoverWorkloadsReportsUnusableDocuments(t *testing.T) {
+	const malformed = "kind: Workload\nmetadata:\n   name: bad\n  namespace: default\n"
+	const templated = "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: {{ .Values.name }}\n"
+	const noAPIVersion = "kind: Workload\nmetadata:\n  name: noapi\nspec:\n  owner: {projectName: p, componentName: c}\n"
+	const badVersion = "apiVersion: openchoreo.dev/v99\nkind: Workload\nmetadata:\n  name: future\nspec:\n  owner: {projectName: p, componentName: c}\n"
+
+	tests := []struct {
+		name, content, wantNote string
+	}{
+		{"malformed but means to be a Workload", malformed, "does not parse"},
+		{"a template that is not a Workload", templated, ""},
+		{"no apiVersion", noAPIVersion, "has no apiVersion"},
+		{"unsupported apiVersion", badVersion, "unsupported apiVersion"},
+		{"another ecosystem's Workload", foreignWorkloadYAML, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := writeTree(t, map[string]string{
+				"components/comp2.yaml":  providerWorkloadYAML,
+				"components/subject.yml": tt.content,
+			})
+			dir := filepath.Join(root, "components")
+
+			d, err := discoverWorkloads([]string{dir})
+			if err != nil {
+				t.Fatalf("discoverWorkloads: %v", err)
+			}
+			if len(d.workloads) != 1 {
+				t.Fatalf("got %d workloads, want only comp2", len(d.workloads))
+			}
+			got := noteFor(d, filepath.Join(dir, "subject.yml"))
+			if tt.wantNote == "" {
+				if got != "" {
+					t.Errorf("note = %q, want silence for a document that is not ours", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tt.wantNote) {
+				t.Errorf("note = %q, want it to contain %q", got, tt.wantNote)
+			}
+		})
+	}
+}
+
+// TestDiscoverWorkloadsNamesEachPathOnce covers a filesystem error not repeating the
+// path the caller already prints.
+func TestDiscoverWorkloadsNamesEachPathOnce(t *testing.T) {
+	root := writeTree(t, map[string]string{"components/subject.yaml": "kind: Workload\nmetadata:\n   a: 1\n  b: 2\n"})
+	subject := filepath.Join(root, "components", "subject.yaml")
+
+	_, err := discoverWorkloads([]string{subject})
+	if err == nil {
+		t.Fatal("want an error for a malformed named file")
+	}
+	if n := strings.Count(err.Error(), subject); n != 1 {
+		t.Errorf("path appears %d times in %q, want once", n, err)
+	}
+}
+
+// TestConnectFailedWorkloadContributesNothing covers a workload that fails partway
+// through its targets: its bindings must not reach the subshell, since the summary
+// tells the developer they are missing.
+func TestConnectFailedWorkloadContributesNothing(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"components/a.yaml": resourceWorkloadYAML("comp-a"),
+		"components/b.yaml": resourceWorkloadYAML("comp-b"),
+	})
+
+	// comp-b's second target names an agent the response never defines, so the workload
+	// fails only after its first target merged env and opened a listener.
+	d := New(&brokenSecondTargetResolver{failFor: "comp-b"})
+	d.dialTunnel = func(context.Context, remoteconnect.AgentEndpoint, string) (tunnel, error) {
+		return &fakeTunnel{addr: "127.0.0.1:1"}, nil
+	}
+	var gotEnv map[string]string
+	d.runShell = func(_ context.Context, env []string) error {
+		gotEnv = envToMap(env)
+		return nil
+	}
+
+	var out bytes.Buffer
+	if err := d.Connect(t.Context(), ConnectParams{
+		WorkloadPaths: []string{filepath.Join(root, "components")},
+		Namespace:     "default",
+		Environment:   "development",
+	}, &out); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	if _, ok := gotEnv["COMP_A_FIRST"]; !ok {
+		t.Error("the healthy workload should still bind")
+	}
+	for _, name := range []string{"COMP_B_FIRST", "COMP_B_READY"} {
+		if got, ok := gotEnv[name]; ok {
+			t.Errorf("%s = %q leaked from the failed workload", name, got)
+		}
+	}
+	if !strings.Contains(out.String(), "! 1 of 2 workloads could not be connected") {
+		t.Errorf("output missing the failure summary:\n%s", out.String())
+	}
+}
+
+// brokenSecondTargetResolver answers with two targets, the second naming an undefined
+// agent for the component in failFor.
+type brokenSecondTargetResolver struct{ failFor string }
+
+func (r *brokenSecondTargetResolver) Resolve(_ context.Context, req remoteconnect.ResolveRequest) (*remoteconnect.ResolveResponse, error) {
+	const agent = "dp-agent"
+	resp := &remoteconnect.ResolveResponse{
+		Capability: "cap",
+		Targets: []remoteconnect.ResolvedTarget{{
+			Key:      "res/some-db/first",
+			Proto:    "tcp",
+			Resource: &remoteconnect.ResourceRender{Ref: "some-db", Address: "first", HostEnv: envPrefix(req.Component) + "_FIRST"},
+			AgentID:  agent,
+		}},
+		Resources: []remoteconnect.ResourceBindings{{
+			Ref:       "some-db",
+			StaticEnv: map[string]string{envPrefix(req.Component) + "_READY": "1"},
+		}},
+		Agents: map[string]remoteconnect.AgentEndpoint{agent: {Endpoint: "router:8443"}},
+	}
+	if req.Component == r.failFor {
+		resp.Targets = append(resp.Targets, remoteconnect.ResolvedTarget{
+			Key:      "res/some-db/second",
+			Proto:    "tcp",
+			Resource: &remoteconnect.ResourceRender{Ref: "some-db", Address: "second", HostEnv: "UNREACHED"},
+			AgentID:  "undefined-agent",
+		})
+	}
+	return resp, nil
+}
+
+// TestConnectDryRunWarnsAboutBindingCollisions covers the preview naming env vars two
+// workloads both claim, which the flat merge silently resolves by order.
+func TestConnectDryRunWarnsAboutBindingCollisions(t *testing.T) {
+	collide := func(component string) string {
+		return `apiVersion: openchoreo.dev/v1alpha1
+kind: Workload
+metadata:
+  name: ` + component + `
+  namespace: default
+spec:
+  owner:
+    projectName: demo
+    componentName: ` + component + `
+  dependencies:
+    resources:
+      - ref: db-` + component + `
+        envBindings:
+          host: SHARED_HOST
+`
+	}
+	root := writeTree(t, map[string]string{
+		"components/a.yaml": collide("comp-a"),
+		"components/b.yaml": collide("comp-b"),
+	})
+
+	var out bytes.Buffer
+	if err := New(nil).Connect(t.Context(), ConnectParams{
+		WorkloadPaths: []string{filepath.Join(root, "components")},
+		Namespace:     "default",
+		DryRun:        true,
+	}, &out); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if want := "! SHARED_HOST is bound by 2 workloads (comp-a, comp-b); the last one wins"; !strings.Contains(out.String(), want) {
+		t.Errorf("output missing %q:\n%s", want, out.String())
+	}
+}
+
+// TestConnectNoDirectoryHeaderWhenDirectoryContributedNothing covers the header only
+// appearing when a directory actually chose part of the set.
+func TestConnectNoDirectoryHeaderWhenDirectoryContributedNothing(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"empty-dir/project.yaml": projectYAML,
+		"comp2.yaml":             providerWorkloadYAML,
+	})
+	file := filepath.Join(root, "comp2.yaml")
+
+	d := New(erroringResolver{t: t})
+	d.runShell = func(context.Context, []string) error { return nil }
+	var out bytes.Buffer
+	if err := d.Connect(t.Context(), ConnectParams{
+		WorkloadPaths: []string{filepath.Join(root, "empty-dir"), file},
+		Namespace:     "default",
+		Environment:   "development",
+	}, &out); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if strings.Contains(out.String(), "all treated as running locally") {
+		t.Errorf("no directory chose the set, so no header belongs here:\n%s", out.String())
+	}
+}

--- a/internal/occ/cmd/remote/discover_unix_test.go
+++ b/internal/occ/cmd/remote/discover_unix_test.go
@@ -1,0 +1,203 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build unix
+
+package remote
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestDiscoverWorkloadsFollowsSymlinkedDirectoryArgument(t *testing.T) {
+	root := writeTree(t, map[string]string{"real/comp2.yaml": providerWorkloadYAML})
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(filepath.Join(root, "real"), link); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := discoverWorkloads([]string{link})
+	if err != nil {
+		t.Fatalf("discoverWorkloads: %v", err)
+	}
+	if len(d.workloads) != 1 {
+		t.Fatalf("got %d workloads through a symlinked directory, want 1 (emptyDirs=%v)", len(d.workloads), d.emptyDirs)
+	}
+	// Paths are reported under the name the developer gave, not the link target.
+	if got := d.workloads[0].path; !strings.HasPrefix(got, link) {
+		t.Errorf("path = %q, want it under %q", got, link)
+	}
+}
+
+func TestDiscoverWorkloadsFollowsSymlinkedSubdirectoryInsideTheRoot(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"components/real/comp1.yaml": consumerWorkloadYAML,
+		"components/comp2.yaml":      providerWorkloadYAML,
+	})
+	dir := filepath.Join(root, "components")
+	if err := os.Symlink(filepath.Join(dir, "real"), filepath.Join(dir, "alias")); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := discoverWorkloads([]string{dir})
+	if err != nil {
+		t.Fatalf("discoverWorkloads: %v", err)
+	}
+	if len(d.workloads) != 2 {
+		t.Fatalf("got %d workloads, want 2 with the in-root symlink followed once", len(d.workloads))
+	}
+}
+
+// TestDiscoverWorkloadsRefusesSymlinkOutOfTheRoot covers a link that would pull in
+// workloads the developer never named.
+func TestDiscoverWorkloadsRefusesSymlinkOutOfTheRoot(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"components/comp2.yaml": providerWorkloadYAML,
+		"sibling.yaml":          consumerWorkloadYAML,
+		"elsewhere/comp3.yaml":  otherNamespaceWorkloadYAML,
+	})
+	dir := filepath.Join(root, "components")
+	up := filepath.Join(dir, "up")
+	if err := os.Symlink("..", up); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := discoverWorkloads([]string{dir})
+	if err != nil {
+		t.Fatalf("discoverWorkloads: %v", err)
+	}
+	if len(d.workloads) != 1 || d.workloads[0].wl.Spec.Owner.ComponentName != providerComponent {
+		t.Fatalf("got %+v, want only the workload inside the named root", d.workloads)
+	}
+	if got := noteFor(d, up); !strings.Contains(got, "outside") {
+		t.Errorf("note for the escaping link = %q, want it to say the link leads outside", got)
+	}
+}
+
+func TestDiscoverWorkloadsTerminatesOnSymlinkCycle(t *testing.T) {
+	root := writeTree(t, map[string]string{"components/comp2.yaml": providerWorkloadYAML})
+	dir := filepath.Join(root, "components")
+	if err := os.Symlink(dir, filepath.Join(dir, "self")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(root, filepath.Join(dir, "up")); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := discoverWorkloads([]string{dir})
+	if err != nil {
+		t.Fatalf("discoverWorkloads: %v", err)
+	}
+	if len(d.workloads) != 1 {
+		t.Fatalf("got %d workloads, want 1", len(d.workloads))
+	}
+}
+
+// TestDiscoverWorkloadsDedupesSymlinkedAlias covers a second name for one file, which
+// must not read as two workloads claiming the same component.
+func TestDiscoverWorkloadsDedupesSymlinkedAlias(t *testing.T) {
+	root := writeTree(t, map[string]string{"components/comp2.yaml": providerWorkloadYAML})
+	dir := filepath.Join(root, "components")
+	if err := os.Symlink(filepath.Join(dir, "comp2.yaml"), filepath.Join(dir, "latest.yaml")); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := discoverWorkloads([]string{dir})
+	if err != nil {
+		t.Fatalf("discoverWorkloads: %v", err)
+	}
+	if len(d.workloads) != 1 {
+		t.Fatalf("got %d workloads for one file under two names, want 1", len(d.workloads))
+	}
+	if err := New(erroringResolver{t: t}).Connect(t.Context(), ConnectParams{
+		WorkloadPaths: []string{dir},
+		Namespace:     "default",
+		DryRun:        true,
+	}, io.Discard); err != nil {
+		t.Errorf("Connect: %v, want no duplicate-workload error", err)
+	}
+}
+
+// TestDiscoverWorkloadsSkipsIrregularFile covers a FIFO named *.yaml, which blocks
+// forever on read. A regression here hangs rather than fails.
+func TestDiscoverWorkloadsSkipsIrregularFile(t *testing.T) {
+	root := writeTree(t, map[string]string{"components/comp2.yaml": providerWorkloadYAML})
+	dir := filepath.Join(root, "components")
+	fifo := filepath.Join(dir, "pipe.yaml")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := discoverWorkloads([]string{dir})
+	if err != nil {
+		t.Fatalf("discoverWorkloads: %v", err)
+	}
+	if len(d.workloads) != 1 {
+		t.Fatalf("got %d workloads, want the one regular file", len(d.workloads))
+	}
+	if got := noteFor(d, fifo); got != "not a regular file" {
+		t.Errorf("note for the FIFO = %q, want %q", got, "not a regular file")
+	}
+}
+
+func TestDiscoverWorkloadsSkipsDanglingSymlink(t *testing.T) {
+	root := writeTree(t, map[string]string{"components/comp2.yaml": providerWorkloadYAML})
+	dir := filepath.Join(root, "components")
+	dangling := filepath.Join(dir, "gone.yaml")
+	if err := os.Symlink(filepath.Join(root, "nowhere.yaml"), dangling); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := discoverWorkloads([]string{dir})
+	if err != nil {
+		t.Fatalf("discoverWorkloads: %v", err)
+	}
+	if len(d.workloads) != 1 {
+		t.Fatalf("got %d workloads, want 1 alongside the dangling link", len(d.workloads))
+	}
+	if noteFor(d, dangling) == "" {
+		t.Errorf("dangling symlink was not recorded: %+v", d.skipped)
+	}
+}
+
+func TestDiscoverWorkloadsSkipsUnreadablePaths(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses file permissions")
+	}
+	root := writeTree(t, map[string]string{
+		"components/comp2.yaml":       providerWorkloadYAML,
+		"components/locked.yaml":      providerWorkloadYAML,
+		"components/lockeddir/x.yaml": providerWorkloadYAML,
+	})
+	dir := filepath.Join(root, "components")
+	lockedFile := filepath.Join(dir, "locked.yaml")
+	lockedDir := filepath.Join(dir, "lockeddir")
+	if err := os.Chmod(lockedFile, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(lockedDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(lockedFile, 0o600)
+		_ = os.Chmod(lockedDir, 0o700)
+	})
+
+	d, err := discoverWorkloads([]string{dir})
+	if err != nil {
+		t.Fatalf("discoverWorkloads: %v", err)
+	}
+	if len(d.workloads) != 1 {
+		t.Fatalf("got %d workloads, want the one readable file", len(d.workloads))
+	}
+	for _, path := range []string{lockedFile, lockedDir} {
+		if noteFor(d, path) == "" {
+			t.Errorf("%s was not recorded: %+v", path, d.skipped)
+		}
+	}
+}

--- a/internal/occ/cmd/remote/params.go
+++ b/internal/occ/cmd/remote/params.go
@@ -5,10 +5,12 @@ package remote
 
 // ConnectParams are the inputs to `occ remote`.
 type ConnectParams struct {
-	// WorkloadPaths are paths to one or more local workload.yaml files. When an
-	// endpoint dependency declared by one workload matches another workload's own
-	// (namespace, project, component) identity, it is wired directly to a local
-	// host:port instead of being tunneled through the control plane.
+	// WorkloadPaths are paths to one or more local files or directories. A file
+	// contributes every Workload document it holds; a directory contributes every
+	// Workload document beneath it, recursively. When an endpoint dependency declared
+	// by one workload matches another discovered workload's own (namespace, project,
+	// component) identity, it is wired directly to a local host:port instead of being
+	// tunneled through the control plane.
 	WorkloadPaths []string
 	// Namespace is the control-plane namespace (org). Falls back to each workload
 	// file's metadata.namespace when set there.
@@ -29,6 +31,9 @@ type ConnectParams struct {
 	// no credential enters the local process. Those bindings are reported as omitted
 	// instead, which is how `occ remote` behaved before value resolution existed.
 	NoSecrets bool
+	// DryRun prints the workloads WorkloadPaths expand to and returns, without
+	// resolving dependencies or contacting the control plane.
+	DryRun bool
 }
 
 // LocalTarget is a local host:port a cross-linked dependency should point at directly.


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This PR adds directory based workload file discovery for the `occ remote` commnd.

```
occ remote components/ ...
```

## Related Issues
https://github.com/openchoreo/openchoreo/issues/4684

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content
