### PR TITLE
fix(cli): atomic cache writes and cross-process lock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/getkin/kin-openapi v0.145.0
 	github.com/go-logr/logr v1.4.4
 	github.com/go-playground/validator/v10 v10.30.3
+	github.com/gofrs/flock v0.13.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/cel-go v0.30.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPE
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/goccy/go-yaml v1.18.0 h1:8W7wMFS12Pcas7KU+VVkaiCng+kG8QiFeFwzFb+rwuw=
 github.com/goccy/go-yaml v1.18.0/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
+github.com/gofrs/flock v0.13.0 h1:95JolYOvGMqeH31+FC7D2+uULf6mG61mEZ/A8dRYMzw=
+github.com/gofrs/flock v0.13.0/go.mod h1:jxeyy9R1auM5S6JYDBhDt+E2TCo7DkratH4Pgi8P+Z0=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=

--- a/pkg/fsindex/cache/atomic_write.go
+++ b/pkg/fsindex/cache/atomic_write.go
@@ -12,7 +12,9 @@ import (
 // atomicWriteFile writes data to path by writing a same-directory temp file
 // and renaming it into place. On Windows, the destination is removed first
 // because os.Rename cannot replace an existing file.
-func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+func atomicWriteFile(path string, data []byte) error {
+	const perm os.FileMode = 0600
+
 	dir := filepath.Dir(path)
 	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp.*")
 	if err != nil {

--- a/pkg/fsindex/cache/atomic_write.go
+++ b/pkg/fsindex/cache/atomic_write.go
@@ -1,0 +1,69 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// atomicWriteFile writes data to path by writing a same-directory temp file
+// and renaming it into place. On Windows, the destination is removed first
+// because os.Rename cannot replace an existing file.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp.*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file for %s: %w", path, err)
+	}
+	tmpName := tmp.Name()
+
+	cleanup := true
+	defer func() {
+		if cleanup {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("failed to set permissions on temp file %s: %w", tmpName, err)
+	}
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("failed to write temp file %s: %w", tmpName, err)
+	}
+
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("failed to sync temp file %s: %w", tmpName, err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file %s: %w", tmpName, err)
+	}
+
+	if err := replaceFile(tmpName, path); err != nil {
+		return err
+	}
+	cleanup = false
+	return nil
+}
+
+func replaceFile(src, dst string) error {
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	}
+
+	// Windows cannot rename over an existing destination.
+	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove existing file %s: %w", dst, err)
+	}
+	if err := os.Rename(src, dst); err != nil {
+		return fmt.Errorf("failed to rename %s to %s: %w", src, dst, err)
+	}
+	return nil
+}

--- a/pkg/fsindex/cache/atomic_write_test.go
+++ b/pkg/fsindex/cache/atomic_write_test.go
@@ -17,7 +17,7 @@ func TestAtomicWriteFile_CreatesAndReplaces(t *testing.T) {
 	path := filepath.Join(dir, "index.json")
 
 	first := []byte(`{"version":1}`)
-	if err := atomicWriteFile(path, first, 0600); err != nil {
+	if err := atomicWriteFile(path, first); err != nil {
 		t.Fatalf("atomicWriteFile() first write: %v", err)
 	}
 
@@ -30,7 +30,7 @@ func TestAtomicWriteFile_CreatesAndReplaces(t *testing.T) {
 	}
 
 	second := []byte(`{"version":2,"resources":[]}`)
-	if err := atomicWriteFile(path, second, 0600); err != nil {
+	if err := atomicWriteFile(path, second); err != nil {
 		t.Fatalf("atomicWriteFile() replace: %v", err)
 	}
 

--- a/pkg/fsindex/cache/atomic_write_test.go
+++ b/pkg/fsindex/cache/atomic_write_test.go
@@ -1,0 +1,110 @@
+// Copyright 2025 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestAtomicWriteFile_CreatesAndReplaces(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "index.json")
+
+	first := []byte(`{"version":1}`)
+	if err := atomicWriteFile(path, first, 0600); err != nil {
+		t.Fatalf("atomicWriteFile() first write: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() after first write: %v", err)
+	}
+	if string(got) != string(first) {
+		t.Fatalf("content = %q, want %q", got, first)
+	}
+
+	second := []byte(`{"version":2,"resources":[]}`)
+	if err := atomicWriteFile(path, second, 0600); err != nil {
+		t.Fatalf("atomicWriteFile() replace: %v", err)
+	}
+
+	got, err = os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() after replace: %v", err)
+	}
+	if string(got) != string(second) {
+		t.Fatalf("content = %q, want %q", got, second)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir(): %v", err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != "index.json" {
+			t.Fatalf("unexpected leftover file %q", entry.Name())
+		}
+	}
+}
+
+func TestLoadOrBuild_Concurrent(t *testing.T) {
+	repoPath := setupTestRepo(t)
+
+	const workers = 16
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			pi, err := LoadOrBuild(repoPath)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if pi == nil || pi.Index == nil {
+				errs <- errors.New("LoadOrBuild returned nil index")
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("concurrent LoadOrBuild() error: %v", err)
+	}
+
+	indexPath := filepath.Join(repoPath, DirName, IndexFile)
+	metaPath := filepath.Join(repoPath, DirName, MetadataFile)
+
+	indexData, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("read index.json: %v", err)
+	}
+	if !json.Valid(indexData) {
+		t.Fatalf("index.json is not valid JSON after concurrent LoadOrBuild: %s", indexData)
+	}
+
+	metaData, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("read metadata.json: %v", err)
+	}
+	if !json.Valid(metaData) {
+		t.Fatalf("metadata.json is not valid JSON after concurrent LoadOrBuild: %s", metaData)
+	}
+
+	pi, err := LoadOrBuild(repoPath)
+	if err != nil {
+		t.Fatalf("final LoadOrBuild() error: %v", err)
+	}
+	if pi.Index.Stats().TotalResources == 0 {
+		t.Fatal("expected indexed resources after concurrent LoadOrBuild")
+	}
+}

--- a/pkg/fsindex/cache/cache.go
+++ b/pkg/fsindex/cache/cache.go
@@ -214,7 +214,7 @@ func (pi *PersistentIndex) saveToDisk() error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal index: %w", err)
 	}
-	if err := atomicWriteFile(indexPath, indexData, 0600); err != nil {
+	if err := atomicWriteFile(indexPath, indexData); err != nil {
 		return fmt.Errorf("failed to write index file: %w", err)
 	}
 
@@ -227,7 +227,7 @@ func (pi *PersistentIndex) saveToDisk() error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal metadata: %w", err)
 	}
-	if err := atomicWriteFile(metaPath, metaData, 0600); err != nil {
+	if err := atomicWriteFile(metaPath, metaData); err != nil {
 		return fmt.Errorf("failed to write metadata file: %w", err)
 	}
 

--- a/pkg/fsindex/cache/cache.go
+++ b/pkg/fsindex/cache/cache.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gofrs/flock"
+
 	"github.com/openchoreo/openchoreo/pkg/fsindex/index"
 	"github.com/openchoreo/openchoreo/pkg/fsindex/scanner"
 )
@@ -23,6 +25,7 @@ const (
 	DirName      = ".occ"
 	IndexFile    = "index.json"
 	MetadataFile = "metadata.json"
+	LockFile     = "index.lock"
 )
 
 // FileState tracks the state of a single file for change detection
@@ -56,8 +59,34 @@ type PersistentIndex struct {
 	metadata *CacheMetadata
 }
 
+// withCacheLock runs fn while holding an exclusive cross-process lock on the
+// repository cache directory. This prevents concurrent LoadOrBuild/ForceRebuild
+// callers from corrupting .occ/index.json and .occ/metadata.json.
+func withCacheLock(repoPath string, fn func() (*PersistentIndex, error)) (*PersistentIndex, error) {
+	cacheDir := filepath.Join(repoPath, DirName)
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create cache directory: %w", err)
+	}
+
+	lock := flock.New(filepath.Join(cacheDir, LockFile))
+	if err := lock.Lock(); err != nil {
+		return nil, fmt.Errorf("failed to acquire cache lock: %w", err)
+	}
+	defer func() {
+		_ = lock.Unlock()
+	}()
+
+	return fn()
+}
+
 // LoadOrBuild loads existing index from cache or builds a new one
 func LoadOrBuild(repoPath string) (*PersistentIndex, error) {
+	return withCacheLock(repoPath, func() (*PersistentIndex, error) {
+		return loadOrBuildLocked(repoPath)
+	})
+}
+
+func loadOrBuildLocked(repoPath string) (*PersistentIndex, error) {
 	pi := &PersistentIndex{
 		Index:    index.New(repoPath),
 		repoPath: repoPath,
@@ -185,7 +214,7 @@ func (pi *PersistentIndex) saveToDisk() error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal index: %w", err)
 	}
-	if err := os.WriteFile(indexPath, indexData, 0600); err != nil {
+	if err := atomicWriteFile(indexPath, indexData, 0600); err != nil {
 		return fmt.Errorf("failed to write index file: %w", err)
 	}
 
@@ -198,7 +227,7 @@ func (pi *PersistentIndex) saveToDisk() error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal metadata: %w", err)
 	}
-	if err := os.WriteFile(metaPath, metaData, 0600); err != nil {
+	if err := atomicWriteFile(metaPath, metaData, 0600); err != nil {
 		return fmt.Errorf("failed to write metadata file: %w", err)
 	}
 
@@ -497,12 +526,14 @@ func (pi *PersistentIndex) incrementalUpdate(changedFiles []string) error {
 
 // ForceRebuild forces a full rebuild of the index, ignoring cache
 func ForceRebuild(repoPath string) (*PersistentIndex, error) {
-	pi := &PersistentIndex{
-		Index:    index.New(repoPath),
-		repoPath: repoPath,
-		cacheDir: filepath.Join(repoPath, DirName),
-	}
-	return pi.fullRebuild()
+	return withCacheLock(repoPath, func() (*PersistentIndex, error) {
+		pi := &PersistentIndex{
+			Index:    index.New(repoPath),
+			repoPath: repoPath,
+			cacheDir: filepath.Join(repoPath, DirName),
+		}
+		return pi.fullRebuild()
+	})
 }
 
 // ClearCache removes the cache directory


### PR DESCRIPTION
## Purpose
PersistentIndex cache writes in `pkg/fsindex/cache` were non-atomic (`os.WriteFile` in place) and had no cross-process locking. Concurrent `LoadOrBuild` / `ForceRebuild` callers (parallel tests, CI, concurrent CLI usage) could interleave or truncate `.occ/index.json` and `.occ/metadata.json`, leaving corrupt JSON that breaks subsequent loads until `.occ` is purged.

This PR makes cache persistence safe under concurrent access.

Fixes #4082

## Approach
- Write cache files atomically via same-directory temp file + rename (Windows-safe replace)
- Hold an exclusive cross-process lock (`github.com/gofrs/flock`) on `.occ/index.lock` for the full `LoadOrBuild` / `ForceRebuild` critical section
- Add unit coverage for atomic replace and concurrent `LoadOrBuild`

## Related Issues
- Fixes #4082

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
Allowed PR scopes are `api`, `controller`, `cli`, `helm`, `deps`. Used `cli` because this cache is consumed by OCC CLI commands (`workload`, `componentrelease`, `releasebinding`).