### PR TITLE
feat: add clusterTrait sample for HPA and allow it in componentType samples

### DIFF
--- a/make/lint.mk
+++ b/make/lint.mk
@@ -98,7 +98,8 @@ GETTING_STARTED_FILES := \
 	$(GETTING_STARTED_DIR)/ci-workflows/gcp-buildpacks-builder.yaml \
 	$(GETTING_STARTED_DIR)/ci-workflows/ballerina-buildpack-builder.yaml \
 	$(GETTING_STARTED_DIR)/ci-workflows/dockerfile-builder.yaml \
-	$(GETTING_STARTED_DIR)/component-traits/alert-rule-trait.yaml
+	$(GETTING_STARTED_DIR)/component-traits/alert-rule-trait.yaml \
+	$(GETTING_STARTED_DIR)/component-traits/hpa-trait.yaml
 
 .PHONY: samples-gen
 samples-gen: ## Generate samples/getting-started/all.yaml from individual files

--- a/samples/getting-started/all.yaml
+++ b/samples/getting-started/all.yaml
@@ -206,6 +206,8 @@ spec:
 
   allowedTraits:
     - kind: ClusterTrait
+      name: horizontal-pod-autoscaler
+    - kind: ClusterTrait
       name: observability-alert-rule
 
   validations:
@@ -379,6 +381,8 @@ spec:
       name: ballerina-buildpack-builder
 
   allowedTraits:
+    - kind: ClusterTrait
+      name: horizontal-pod-autoscaler
     - kind: ClusterTrait
       name: observability-alert-rule
 
@@ -650,6 +654,8 @@ spec:
       name: dockerfile-builder
 
   allowedTraits:
+    - kind: ClusterTrait
+      name: horizontal-pod-autoscaler
     - kind: ClusterTrait
       name: observability-alert-rule
 
@@ -2992,3 +2998,144 @@ spec:
               enabled: ${has(environmentConfigs.actions) && has(environmentConfigs.actions.incident) && (environmentConfigs.actions.incident.enabled || environmentConfigs.actions.incident.triggerAiRca || environmentConfigs.actions.incident.triggerAiCostAnalysis)}
               triggerAiCostAnalysis: ${has(environmentConfigs.actions) && has(environmentConfigs.actions.incident) && environmentConfigs.actions.incident.enabled && environmentConfigs.actions.incident.triggerAiCostAnalysis}
               triggerAiRca: ${has(environmentConfigs.actions) && has(environmentConfigs.actions.incident) && environmentConfigs.actions.incident.enabled && environmentConfigs.actions.incident.triggerAiRca}
+
+---
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterTrait
+metadata:
+  name: horizontal-pod-autoscaler
+spec:
+  parameters:
+    openAPIV3Schema:
+      type: object
+      x-openchoreo-backstage-portal:
+        ui:order:
+          - replicas
+          - targetUtilization
+      properties:
+        replicas:
+          type: object
+          default: {}
+          title: Replicas
+          x-openchoreo-backstage-portal:
+            ui:order:
+              - min
+              - max
+          properties:
+            min:
+              type: integer
+              default: 1
+              minimum: 1
+              title: Minimum
+            max:
+              type: integer
+              default: 10
+              minimum: 1
+              title: Maximum
+          required:
+            - min
+            - max
+        targetUtilization:
+          type: object
+          default: {}
+          title: Target utilization
+          description: "Target utilization levels the autoscaler maintains by adding or removing replicas."
+          x-openchoreo-backstage-portal:
+            ui:order:
+              - cpu
+              - memory
+          properties:
+            cpu:
+              type: integer
+              default: 80
+              minimum: 1
+              maximum: 100
+              title: CPU
+              description: "Average CPU across pods, as a percentage of the pod's CPU request."
+            memory:
+              type: integer
+              minimum: 1
+              maximum: 100
+              title: Memory
+              description: "Average memory across pods, as a percentage of the pod's memory request. Optional; when unset, memory is not used for scaling."
+
+  environmentConfigs:
+    openAPIV3Schema:
+      type: object
+      x-openchoreo-backstage-portal:
+        ui:order:
+          - enabled
+          - minReplicas
+          - maxReplicas
+      properties:
+        enabled:
+          type: boolean
+          default: true
+          description: "Controls whether autoscaling is active in this environment. When disabled, no HorizontalPodAutoscaler is created."
+          x-openchoreo-backstage-portal:
+            ui:widget: radio
+        minReplicas:
+          type: integer
+          minimum: 1
+          description: "Optional per-environment override for the lower replica bound."
+          x-openchoreo-backstage-portal:
+            ui:placeholder: "Defaults to the value set in parameters"
+        maxReplicas:
+          type: integer
+          minimum: 1
+          description: "Optional per-environment override for the upper replica bound."
+          x-openchoreo-backstage-portal:
+            ui:placeholder: "Defaults to the value set in parameters"
+
+  validations:
+    - rule: "${(has(environmentConfigs.maxReplicas) ? environmentConfigs.maxReplicas : parameters.replicas.max) >= (has(environmentConfigs.minReplicas) ? environmentConfigs.minReplicas : parameters.replicas.min)}"
+      message: "maxReplicas must be greater than or equal to minReplicas."
+
+  creates:
+    - includeWhen: ${environmentConfigs.enabled}
+      template:
+        apiVersion: autoscaling/v2
+        kind: HorizontalPodAutoscaler
+        metadata:
+          name: ${metadata.name}-${trait.instanceName}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: ${metadata.name}
+          minReplicas: |
+            ${has(environmentConfigs.minReplicas) ? environmentConfigs.minReplicas : parameters.replicas.min}
+          maxReplicas: |
+            ${has(environmentConfigs.maxReplicas) ? environmentConfigs.maxReplicas : parameters.replicas.max}
+          metrics: |
+            ${[
+              {
+                "type": "Resource",
+                "resource": {
+                  "name": "cpu",
+                  "target": {"type": "Utilization", "averageUtilization": parameters.targetUtilization.cpu}
+                }
+              }
+            ] + (has(parameters.targetUtilization.memory) ? [
+              {
+                "type": "Resource",
+                "resource": {
+                  "name": "memory",
+                  "target": {"type": "Utilization", "averageUtilization": parameters.targetUtilization.memory}
+                }
+              }
+            ] : [])}
+
+  # Remove the ComponentType's static replica count so it doesn't interfere with the HPA.
+  patches:
+    - target:
+        group: apps
+        version: v1
+        kind: Deployment
+        where: ${environmentConfigs.enabled}
+      operations:
+        - op: remove
+          path: /spec/replicas

--- a/samples/getting-started/component-traits/hpa-trait.yaml
+++ b/samples/getting-started/component-traits/hpa-trait.yaml
@@ -1,0 +1,139 @@
+---
+apiVersion: openchoreo.dev/v1alpha1
+kind: ClusterTrait
+metadata:
+  name: horizontal-pod-autoscaler
+spec:
+  parameters:
+    openAPIV3Schema:
+      type: object
+      x-openchoreo-backstage-portal:
+        ui:order:
+          - replicas
+          - targetUtilization
+      properties:
+        replicas:
+          type: object
+          default: {}
+          title: Replicas
+          x-openchoreo-backstage-portal:
+            ui:order:
+              - min
+              - max
+          properties:
+            min:
+              type: integer
+              default: 1
+              minimum: 1
+              title: Minimum
+            max:
+              type: integer
+              default: 10
+              minimum: 1
+              title: Maximum
+          required:
+            - min
+            - max
+        targetUtilization:
+          type: object
+          default: {}
+          title: Target utilization
+          description: "Target utilization levels the autoscaler maintains by adding or removing replicas."
+          x-openchoreo-backstage-portal:
+            ui:order:
+              - cpu
+              - memory
+          properties:
+            cpu:
+              type: integer
+              default: 80
+              minimum: 1
+              maximum: 100
+              title: CPU
+              description: "Average CPU across pods, as a percentage of the pod's CPU request."
+            memory:
+              type: integer
+              minimum: 1
+              maximum: 100
+              title: Memory
+              description: "Average memory across pods, as a percentage of the pod's memory request. Optional; when unset, memory is not used for scaling."
+
+  environmentConfigs:
+    openAPIV3Schema:
+      type: object
+      x-openchoreo-backstage-portal:
+        ui:order:
+          - enabled
+          - minReplicas
+          - maxReplicas
+      properties:
+        enabled:
+          type: boolean
+          default: true
+          description: "Controls whether autoscaling is active in this environment. When disabled, no HorizontalPodAutoscaler is created."
+          x-openchoreo-backstage-portal:
+            ui:widget: radio
+        minReplicas:
+          type: integer
+          minimum: 1
+          description: "Optional per-environment override for the lower replica bound."
+          x-openchoreo-backstage-portal:
+            ui:placeholder: "Defaults to the value set in parameters"
+        maxReplicas:
+          type: integer
+          minimum: 1
+          description: "Optional per-environment override for the upper replica bound."
+          x-openchoreo-backstage-portal:
+            ui:placeholder: "Defaults to the value set in parameters"
+
+  validations:
+    - rule: "${(has(environmentConfigs.maxReplicas) ? environmentConfigs.maxReplicas : parameters.replicas.max) >= (has(environmentConfigs.minReplicas) ? environmentConfigs.minReplicas : parameters.replicas.min)}"
+      message: "maxReplicas must be greater than or equal to minReplicas."
+
+  creates:
+    - includeWhen: ${environmentConfigs.enabled}
+      template:
+        apiVersion: autoscaling/v2
+        kind: HorizontalPodAutoscaler
+        metadata:
+          name: ${metadata.name}-${trait.instanceName}
+          namespace: ${metadata.namespace}
+          labels: ${metadata.labels}
+        spec:
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: ${metadata.name}
+          minReplicas: |
+            ${has(environmentConfigs.minReplicas) ? environmentConfigs.minReplicas : parameters.replicas.min}
+          maxReplicas: |
+            ${has(environmentConfigs.maxReplicas) ? environmentConfigs.maxReplicas : parameters.replicas.max}
+          metrics: |
+            ${[
+              {
+                "type": "Resource",
+                "resource": {
+                  "name": "cpu",
+                  "target": {"type": "Utilization", "averageUtilization": parameters.targetUtilization.cpu}
+                }
+              }
+            ] + (has(parameters.targetUtilization.memory) ? [
+              {
+                "type": "Resource",
+                "resource": {
+                  "name": "memory",
+                  "target": {"type": "Utilization", "averageUtilization": parameters.targetUtilization.memory}
+                }
+              }
+            ] : [])}
+
+  # Remove the ComponentType's static replica count so it doesn't interfere with the HPA.
+  patches:
+    - target:
+        group: apps
+        version: v1
+        kind: Deployment
+        where: ${environmentConfigs.enabled}
+      operations:
+        - op: remove
+          path: /spec/replicas

--- a/samples/getting-started/component-types/service.yaml
+++ b/samples/getting-started/component-types/service.yaml
@@ -19,6 +19,8 @@ spec:
 
   allowedTraits:
     - kind: ClusterTrait
+      name: horizontal-pod-autoscaler
+    - kind: ClusterTrait
       name: observability-alert-rule
 
   validations:

--- a/samples/getting-started/component-types/webapp.yaml
+++ b/samples/getting-started/component-types/webapp.yaml
@@ -17,6 +17,8 @@ spec:
 
   allowedTraits:
     - kind: ClusterTrait
+      name: horizontal-pod-autoscaler
+    - kind: ClusterTrait
       name: observability-alert-rule
 
   validations:

--- a/samples/getting-started/component-types/worker.yaml
+++ b/samples/getting-started/component-types/worker.yaml
@@ -19,6 +19,8 @@ spec:
 
   allowedTraits:
     - kind: ClusterTrait
+      name: horizontal-pod-autoscaler
+    - kind: ClusterTrait
       name: observability-alert-rule
 
   validations:


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
Add a clusterTrait sample for Horizontal Pod Autoscaling and add it as an allowedTrait in worker, webapp and service componentType

## Approach
- Defined a clusterTrait for HPA
- Added the HPA clusterTrait as an allowedTrait in worker, webapp and service componentTypes
- Added `x-openchoreo-backstage-portal` annotations to the OpenAPI schema to control how the trait form is displayed in the backstage portal. With the current annotations, the form displays as follows
<img width="957" height="898" alt="Screenshot 2026-09-10 at 13 46 10" src="https://github.com/user-attachments/assets/2243adb3-2275-4d74-9c7d-13dce9e9f996" />


## Related Issues
https://github.com/openchoreo/openchoreo/issues/4690

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [x] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
