### PR TITLE
refactor(api): rename audit origin to surface and record the user agent

### DIFF
--- a/cmd/openchoreo-api/main.go
+++ b/cmd/openchoreo-api/main.go
@@ -252,9 +252,9 @@ func main() {
 		// and never calls next, so mcpaudit's own middleware — which lives
 		// inside the MCP server, below all of this — never sees a 401.
 		// Auth401Interceptor only adds a WWW-Authenticate header; it emits
-		// nothing. OriginMCP so an MCP token rejection isn't recorded as if
+		// nothing. SurfaceMCP so an MCP token rejection isn't recorded as if
 		// it had arrived over REST.
-		unauthedMCPMw := audit.NewUnauthenticatedMiddleware(auditEmitter, audit.OriginMCP, cfg.Audit.Enabled)
+		unauthedMCPMw := audit.NewUnauthenticatedMiddleware(auditEmitter, audit.SurfaceMCP, cfg.Audit.Enabled)
 		mcpHandler := middleware.Chain(mcpLoggerMw, unauthedMCPMw, mcpAuth401Mw, jwtMiddleware)(mcpServer)
 
 		baseMux.Handle("/mcp", mcpHandler)
@@ -341,7 +341,7 @@ func main() {
 		// two routes reach the data plane — a live shell and a live traffic
 		// stream — so a rejected attempt on them is exactly the event worth
 		// recording.
-		unauthedExecWirelogsMw := audit.NewUnauthenticatedMiddleware(auditEmitter, audit.OriginAPI, cfg.Audit.Enabled)
+		unauthedExecWirelogsMw := audit.NewUnauthenticatedMiddleware(auditEmitter, audit.SurfaceREST, cfg.Audit.Enabled)
 
 		execAuthzChecker := svcpkg.NewAuthzChecker(runtime.pdp, logger.With("component", "exec-authz"))
 		gwTLSConf, err := gatewayClient.BuildTLSConfig(&gatewayClient.TLSConfig{

--- a/internal/auditconfig/audit.go
+++ b/internal/auditconfig/audit.go
@@ -55,7 +55,7 @@ type SelectorConfig struct {
 	Resources    []string `koanf:"resources"`
 	Operations   []string `koanf:"operations"`
 	Actions      []string `koanf:"actions"`
-	Origins      []string `koanf:"origins"`
+	Surfaces     []string `koanf:"surfaces"`
 	ActorTypes   []string `koanf:"actor_types"`
 	Actors       []string `koanf:"actors"`
 	Entitlements []string `koanf:"entitlements"`
@@ -76,8 +76,8 @@ var (
 	validCategories = []string{
 		string(audit.CategoryManagement), string(audit.CategoryAuthorization),
 	}
-	validOrigins = []string{string(audit.OriginAPI), string(audit.OriginMCP)}
-	validResults = []string{
+	validSurfaces = []string{string(audit.SurfaceREST), string(audit.SurfaceMCP)}
+	validResults  = []string{
 		string(audit.ResultSuccess), string(audit.ResultFailure),
 		string(audit.ResultDenied), string(audit.ResultUnauthenticated),
 	}
@@ -183,13 +183,13 @@ func (sc SelectorConfig) toSelector(
 		categories = append(categories, audit.Category(c))
 	}
 
-	origins := make([]audit.Origin, 0, len(sc.Origins))
-	for i, o := range sc.Origins {
-		if fe := config.MustBeOneOf(path.Child("origins").Index(i), o, validOrigins); fe != nil {
+	surfaces := make([]audit.Surface, 0, len(sc.Surfaces))
+	for i, o := range sc.Surfaces {
+		if fe := config.MustBeOneOf(path.Child("surfaces").Index(i), o, validSurfaces); fe != nil {
 			errs = append(errs, fe)
 			continue
 		}
-		origins = append(origins, audit.Origin(o))
+		surfaces = append(surfaces, audit.Surface(o))
 	}
 
 	results := make([]audit.Result, 0, len(sc.Results))
@@ -234,7 +234,7 @@ func (sc SelectorConfig) toSelector(
 		Resources:    sc.Resources,
 		Operations:   sc.Operations,
 		Actions:      sc.Actions,
-		Origins:      origins,
+		Surfaces:     surfaces,
 		ActorTypes:   sc.ActorTypes,
 		Actors:       sc.Actors,
 		Entitlements: sc.Entitlements,

--- a/internal/observer/api/handlers/audit_wiring_test.go
+++ b/internal/observer/api/handlers/audit_wiring_test.go
@@ -258,7 +258,7 @@ func TestAuthRejectionEmitsUnauthenticatedEvent(t *testing.T) {
 			"middlewares both fired for the same request")
 	event := events[0]
 
-	assert.Equal(t, "api", event["origin"], "a REST rejection must not be stamped as MCP")
+	assert.Equal(t, "rest", event["surface"], "a REST rejection must not be stamped as MCP")
 	assert.Equal(t, "unauthenticated", event["result"])
 
 	actor, ok := event["actor"].(map[string]any)
@@ -317,7 +317,7 @@ func TestMCPMiddlewaresAuditUnauthenticated(t *testing.T) {
 			"auth and never runs; two means it is nested with another instance")
 
 	event := events[0]
-	assert.Equal(t, "mcp", event["origin"],
+	assert.Equal(t, "mcp", event["surface"],
 		"an MCP rejection stamped as api would misattribute it to the REST surface")
 	assert.Equal(t, "unauthenticated", event["result"])
 }

--- a/internal/observer/api/handlers/handler.go
+++ b/internal/observer/api/handlers/handler.go
@@ -158,7 +158,7 @@ func ObserverMiddlewares(opts ObserverMiddlewareOptions) ([]gen.MiddlewareFunc, 
 		return nil, err
 	}
 	unauthenticatedAuditMw := audit.NewUnauthenticatedMiddleware(
-		opts.AuditEmitter, audit.OriginAPI, opts.AuditEnabled)
+		opts.AuditEmitter, audit.SurfaceREST, opts.AuditEnabled)
 
 	return []gen.MiddlewareFunc{
 		RequireJSONContentType(opts.Logger),
@@ -194,7 +194,7 @@ type MCPMiddlewareOptions struct {
 // ObserverMiddlewares. Reverse the two and an MCP token rejection silently
 // emits nothing.
 //
-// The OriginMCP instance is separate from ObserverMiddlewares' OriginAPI one:
+// The SurfaceMCP instance is separate from ObserverMiddlewares' SurfaceREST one:
 // sharing would misattribute MCP rejections to REST, and nesting would
 // double-emit. They never stack, since /mcp is registered on the base mux.
 //
@@ -212,7 +212,7 @@ func MCPMiddlewares(opts MCPMiddlewareOptions) ([]middleware.Middleware, error) 
 	}
 
 	return []middleware.Middleware{
-		audit.NewUnauthenticatedMiddleware(opts.AuditEmitter, audit.OriginMCP, opts.AuditEnabled),
+		audit.NewUnauthenticatedMiddleware(opts.AuditEmitter, audit.SurfaceMCP, opts.AuditEnabled),
 		opts.Auth401,
 		opts.JWTAuth,
 	}, nil

--- a/internal/openchoreo-api/api/handlers/audit_wiring_test.go
+++ b/internal/openchoreo-api/api/handlers/audit_wiring_test.go
@@ -98,7 +98,7 @@ func TestAuditMiddlewareWired(t *testing.T) {
 	assert.Equal(t, "create_project", record["action"])
 	assert.Equal(t, "management", record["category"])
 	assert.Equal(t, "success", record["result"])
-	assert.Equal(t, "api", record["origin"], "REST-originated events must carry origin=api")
+	assert.Equal(t, "rest", record["surface"], "REST-originated events must carry surface=rest")
 
 	actor, ok := record["actor"].(map[string]any)
 	require.True(t, ok, "actor must be a nested group")

--- a/internal/openchoreo-api/api/handlers/exec_wirelogs_audit_test.go
+++ b/internal/openchoreo-api/api/handlers/exec_wirelogs_audit_test.go
@@ -67,7 +67,7 @@ func TestExecWirelogsAuth401IsAudited(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			unauthedMw := audit.NewUnauthenticatedMiddleware(emitter, audit.OriginAPI, true)
+			unauthedMw := audit.NewUnauthenticatedMiddleware(emitter, audit.SurfaceREST, true)
 
 			inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				t.Error("handler must not run on a rejected request")
@@ -89,8 +89,8 @@ func TestExecWirelogsAuth401IsAudited(t *testing.T) {
 			if records[0]["result"] != "unauthenticated" {
 				t.Errorf("result = %v, want unauthenticated", records[0]["result"])
 			}
-			if records[0]["origin"] != string(audit.OriginAPI) {
-				t.Errorf("origin = %v, want %q", records[0]["origin"], audit.OriginAPI)
+			if records[0]["surface"] != string(audit.SurfaceREST) {
+				t.Errorf("surface = %v, want %q", records[0]["surface"], audit.SurfaceREST)
 			}
 			actor, ok := records[0]["actor"].(map[string]any)
 			if !ok || actor["id"] != "anonymous" {
@@ -113,7 +113,7 @@ func TestExecWirelogsAuthenticatedRequestEmitsExactlyOnce(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	unauthedMw := audit.NewUnauthenticatedMiddleware(emitter, audit.OriginAPI, true)
+	unauthedMw := audit.NewUnauthenticatedMiddleware(emitter, audit.SurfaceREST, true)
 
 	passthroughAuth := func(next http.Handler) http.Handler { return next }
 	inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/openchoreo-api/api/handlers/handler.go
+++ b/internal/openchoreo-api/api/handlers/handler.go
@@ -104,7 +104,7 @@ func OpenAPIMiddlewares(opts OpenAPIMiddlewareOptions) ([]gen.MiddlewareFunc, er
 		return nil, fmt.Errorf("audit: %w", err)
 	}
 
-	unauthenticatedAuditMw := audit.NewUnauthenticatedMiddleware(opts.AuditEmitter, audit.OriginAPI, opts.AuditEnabled)
+	unauthenticatedAuditMw := audit.NewUnauthenticatedMiddleware(opts.AuditEmitter, audit.SurfaceREST, opts.AuditEnabled)
 
 	loggerMw := apilogger.LoggerMiddleware(opts.Logger.With("component", "openapi"))
 

--- a/internal/openchoreo-api/config/audit_test.go
+++ b/internal/openchoreo-api/config/audit_test.go
@@ -159,19 +159,19 @@ audit:
 	}
 }
 
-func TestAuditConfig_RejectsInvalidOriginValue(t *testing.T) {
+func TestAuditConfig_RejectsInvalidSurfaceValue(t *testing.T) {
 	cfg := loadAuditTestConfig(t, `
 audit:
   policies:
     - match:
-        origins: [bogus]
+        surfaces: [bogus]
       set:
         publish: false
 `)
 
 	err := cfg.Validate()
 	if err == nil {
-		t.Fatal("Validate() = nil, want an error for an unrecognized origin value")
+		t.Fatal("Validate() = nil, want an error for an unrecognized surface value")
 	}
 	if !strings.Contains(err.Error(), "must be one of") {
 		t.Errorf("Validate() error = %q, want it to mention the allowed values", err.Error())

--- a/internal/server/middleware/audit/adapter.go
+++ b/internal/server/middleware/audit/adapter.go
@@ -174,7 +174,7 @@ func SourceIPFromHeader(h http.Header) string {
 // Envelope differently. sourceIPFallback applies only when the header carries
 // no IP hint — REST passes r.RemoteAddr, MCP passes "".
 func EmitFromContext(
-	ctx context.Context, emitter *Emitter, op *Operation, origin Origin, result Result,
+	ctx context.Context, emitter *Emitter, op *Operation, surface Surface, result Result,
 	auditData *AuditData, header http.Header, sourceIPFallback string,
 ) {
 	sourceIP := SourceIPFromHeader(header)
@@ -182,7 +182,7 @@ func EmitFromContext(
 		sourceIP = sourceIPFallback
 	}
 	env := Envelope{
-		Origin:    origin,
+		Surface:   surface,
 		Actor:     ExtractActor(ctx),
 		Result:    result,
 		Resource:  auditData.Resource,
@@ -190,6 +190,7 @@ func EmitFromContext(
 		Request:   auditData.Request,
 		RequestID: RequestIDFromHeader(header),
 		SourceIP:  sourceIP,
+		UserAgent: header.Get("User-Agent"),
 		Metadata:  auditData.Metadata,
 	}
 	emitter.Emit(ctx, op, env)

--- a/internal/server/middleware/audit/emitter.go
+++ b/internal/server/middleware/audit/emitter.go
@@ -54,7 +54,7 @@ func (e *Emitter) Emit(_ context.Context, op *Operation, env Envelope) {
 	settings := e.policies.Resolve(ResolveContext{
 		Operation: op,
 		Actor:     env.Actor,
-		Origin:    env.Origin,
+		Surface:   env.Surface,
 		Result:    env.Result,
 	})
 	if !settings.Publish {
@@ -88,12 +88,13 @@ func buildEvent(op *Operation, env Envelope, serviceName string) *Event {
 		Producer:  serviceName,
 		Actor:     env.Actor,
 		Result:    env.Result,
-		Origin:    env.Origin,
+		Surface:   env.Surface,
 		HTTP:      env.Request.HTTP,
 		Resource:  withHierarchyNamespaceFallback(env.Resource, env.Hierarchy),
 		Hierarchy: env.Hierarchy,
 		RequestID: env.RequestID,
 		SourceIP:  env.SourceIP,
+		UserAgent: env.UserAgent,
 		Metadata:  env.Metadata,
 	}
 	if op != nil {

--- a/internal/server/middleware/audit/emitter_test.go
+++ b/internal/server/middleware/audit/emitter_test.go
@@ -53,7 +53,7 @@ func TestEmitter_FansOutToEverySink(t *testing.T) {
 	}
 
 	op := &Operation{ID: testProjectOpID, Action: testCreateProjectAction, ResourceType: "project", Category: CategoryManagement}
-	emitter.Emit(context.Background(), op, Envelope{Origin: OriginAPI, Result: ResultSuccess})
+	emitter.Emit(context.Background(), op, Envelope{Surface: SurfaceREST, Result: ResultSuccess})
 
 	if len(sinkA.events) != 1 || len(sinkB.events) != 1 {
 		t.Fatalf("expected exactly one event per sink, got sinkA=%d sinkB=%d", len(sinkA.events), len(sinkB.events))
@@ -84,7 +84,7 @@ func TestEmitter_StampsIdentityForEverySink(t *testing.T) {
 	}
 
 	op := &Operation{ID: testProjectOpID, Action: testCreateProjectAction, ResourceType: "project", Category: CategoryManagement}
-	emitter.Emit(context.Background(), op, Envelope{Origin: OriginAPI, Result: ResultSuccess})
+	emitter.Emit(context.Background(), op, Envelope{Surface: SurfaceREST, Result: ResultSuccess})
 
 	for name, sink := range map[string]*recordingSink{"sinkA": sinkA, "sinkB": sinkB} {
 		if len(sink.events) != 1 {
@@ -106,7 +106,7 @@ func TestEmitter_StampsIdentityForEverySink(t *testing.T) {
 func TestBuildEvent_TakesEntryCapturedFactsFromEnvelope(t *testing.T) {
 	entryTime := time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC)
 	env := Envelope{
-		Origin: OriginAPI, Result: ResultSuccess,
+		Surface: SurfaceREST, Result: ResultSuccess,
 		Request: RequestInfo{
 			EventTime: entryTime,
 			HTTP:      &HTTPInfo{Method: "POST", Path: "/api/v1/namespaces/ns-1/projects"},
@@ -144,7 +144,7 @@ func TestEmitter_StampsResourceTypeFromOperation(t *testing.T) {
 	}
 
 	op := &Operation{ID: testProjectOpID, Action: testCreateProjectAction, ResourceType: "project", Category: CategoryManagement}
-	emitter.Emit(context.Background(), op, Envelope{Origin: OriginAPI, Result: ResultDenied})
+	emitter.Emit(context.Background(), op, Envelope{Surface: SurfaceREST, Result: ResultDenied})
 
 	if len(sink.events) != 1 {
 		t.Fatalf("expected exactly one event, got %d", len(sink.events))
@@ -165,7 +165,7 @@ func TestBuildEvent_FillsEmptyNamespaceFromHierarchy(t *testing.T) {
 	op := &Operation{ID: testProjectOpID, Action: testCreateProjectAction, ResourceType: "namespace", Category: CategoryManagement}
 	resource := &Resource{Name: "ns-1"}
 	env := Envelope{
-		Origin: OriginAPI, Result: ResultSuccess,
+		Surface: SurfaceREST, Result: ResultSuccess,
 		Resource: resource, Hierarchy: Hierarchy{Namespace: "ns-1"},
 	}
 
@@ -188,7 +188,7 @@ func TestBuildEvent_FillsEmptyNamespaceFromHierarchy(t *testing.T) {
 func TestBuildEvent_DoesNotOverrideExistingNamespace(t *testing.T) {
 	op := &Operation{ID: testProjectOpID, Action: testCreateProjectAction, ResourceType: "component", Category: CategoryManagement}
 	env := Envelope{
-		Origin: OriginAPI, Result: ResultSuccess,
+		Surface: SurfaceREST, Result: ResultSuccess,
 		Resource: &Resource{Namespace: "handler-namespace"}, Hierarchy: Hierarchy{Namespace: "hierarchy-namespace"},
 	}
 
@@ -205,7 +205,7 @@ func TestBuildEvent_DoesNotOverrideExistingNamespace(t *testing.T) {
 func TestBuildEvent_CarriesHierarchyEvenWithNilResource(t *testing.T) {
 	op := &Operation{ID: testProjectOpID, Action: testCreateProjectAction, ResourceType: "component", Category: CategoryManagement}
 	env := Envelope{
-		Origin: OriginAPI, Result: ResultDenied,
+		Surface: SurfaceREST, Result: ResultDenied,
 		Hierarchy: Hierarchy{Namespace: "ns-1", Project: "p1", Component: "c1"},
 	}
 
@@ -232,7 +232,7 @@ func TestEmitter_SkipsAllSinksWhenPolicyDenies(t *testing.T) {
 	}
 
 	op := &Operation{ID: testProjectOpID, Action: testCreateProjectAction, ResourceType: "project", Category: CategoryManagement}
-	emitter.Emit(context.Background(), op, Envelope{Origin: OriginAPI, Result: ResultSuccess})
+	emitter.Emit(context.Background(), op, Envelope{Surface: SurfaceREST, Result: ResultSuccess})
 
 	if len(sink.events) != 0 {
 		t.Errorf("expected no events when policy denies publish, got %d", len(sink.events))

--- a/internal/server/middleware/audit/envelope.go
+++ b/internal/server/middleware/audit/envelope.go
@@ -7,7 +7,7 @@ package audit
 // carries no HTTP or MCP types — an adapter translates its surface's
 // request/response into an Envelope before calling Emit.
 type Envelope struct {
-	Origin    Origin
+	Surface   Surface
 	Actor     Actor
 	Result    Result
 	Resource  *Resource
@@ -15,5 +15,6 @@ type Envelope struct {
 	Request   RequestInfo
 	RequestID string
 	SourceIP  string
+	UserAgent string
 	Metadata  map[string]any
 }

--- a/internal/server/middleware/audit/logger_test.go
+++ b/internal/server/middleware/audit/logger_test.go
@@ -11,11 +11,11 @@ import (
 	"testing"
 )
 
-// TestLogEvent_IncludesOriginAndOperationID guards against a regression where
+// TestLogEvent_IncludesSurfaceAndOperationID guards against a regression where
 // Origin and OperationID were added to Event (for the MCP adapter) but never
 // wired into LogEvent's manually-built slog attrs, so every emitted record
 // silently dropped both fields regardless of what Emit passed in.
-func TestLogEvent_IncludesOriginAndOperationID(t *testing.T) {
+func TestLogEvent_IncludesSurfaceAndOperationID(t *testing.T) {
 	var buf bytes.Buffer
 	logger := NewLogger(&buf)
 
@@ -23,7 +23,7 @@ func TestLogEvent_IncludesOriginAndOperationID(t *testing.T) {
 		Actor:       Actor{Type: "user", ID: "u1"},
 		Action:      "create_project",
 		Category:    CategoryManagement,
-		Origin:      OriginMCP,
+		Surface:     SurfaceMCP,
 		OperationID: testProjectOpID,
 		Result:      ResultSuccess,
 	})
@@ -33,8 +33,8 @@ func TestLogEvent_IncludesOriginAndOperationID(t *testing.T) {
 		t.Fatalf("failed to unmarshal log line: %v", err)
 	}
 
-	if record["origin"] != "mcp" {
-		t.Errorf("origin = %v, want mcp", record["origin"])
+	if record["surface"] != "mcp" {
+		t.Errorf("surface = %v, want mcp", record["surface"])
 	}
 	if record["operation_id"] != testProjectOpID {
 		t.Errorf("operation_id = %v, want CreateProject", record["operation_id"])
@@ -61,8 +61,8 @@ func TestLogEvent_OmitsEmptyOriginAndOperationID(t *testing.T) {
 		t.Fatalf("failed to unmarshal log line: %v", err)
 	}
 
-	if _, ok := record["origin"]; ok {
-		t.Errorf("origin = %v, want absent when Origin is unset", record["origin"])
+	if _, ok := record["surface"]; ok {
+		t.Errorf("surface = %v, want absent when Surface is unset", record["surface"])
 	}
 	if _, ok := record["operation_id"]; ok {
 		t.Errorf("operation_id = %v, want absent when OperationID is unset", record["operation_id"])

--- a/internal/server/middleware/audit/middleware.go
+++ b/internal/server/middleware/audit/middleware.go
@@ -167,7 +167,7 @@ func (m *Middleware) Handler(next http.Handler) http.Handler {
 		defer func() {
 			if p := recover(); p != nil {
 				markEmitted(ctx)
-				EmitFromContext(ctx, m.emitter, op, OriginAPI, ResultFailure, auditData, r.Header, r.RemoteAddr)
+				EmitFromContext(ctx, m.emitter, op, SurfaceREST, ResultFailure, auditData, r.Header, r.RemoteAddr)
 				panic(p)
 			}
 			// A hijacking handler (e.g. exec's WebSocket upgrade) can call
@@ -180,7 +180,7 @@ func (m *Middleware) Handler(next http.Handler) http.Handler {
 				result = *auditData.Result
 			}
 			markEmitted(ctx)
-			EmitFromContext(ctx, m.emitter, op, OriginAPI, result, auditData, r.Header, r.RemoteAddr)
+			EmitFromContext(ctx, m.emitter, op, SurfaceREST, result, auditData, r.Header, r.RemoteAddr)
 		}()
 
 		next.ServeHTTP(rw, r.WithContext(ctx))

--- a/internal/server/middleware/audit/policy.go
+++ b/internal/server/middleware/audit/policy.go
@@ -18,7 +18,7 @@ type Selector struct {
 	Resources    []string
 	Operations   []string
 	Actions      []string
-	Origins      []Origin
+	Surfaces     []Surface
 	ActorTypes   []string
 	Actors       []string
 	Entitlements []string
@@ -56,7 +56,7 @@ type Settings struct {
 type ResolveContext struct {
 	Operation *Operation
 	Actor     Actor
-	Origin    Origin
+	Surface   Surface
 	Result    Result
 }
 
@@ -130,7 +130,7 @@ func (ps *PolicySet) Resolve(rc ResolveContext) Settings {
 
 func (s Selector) isEmpty() bool {
 	return len(s.Categories) == 0 && len(s.Resources) == 0 && len(s.Operations) == 0 &&
-		len(s.Actions) == 0 && len(s.Origins) == 0 && len(s.ActorTypes) == 0 &&
+		len(s.Actions) == 0 && len(s.Surfaces) == 0 && len(s.ActorTypes) == 0 &&
 		len(s.Actors) == 0 && len(s.Entitlements) == 0 && len(s.Results) == 0
 }
 
@@ -147,7 +147,7 @@ func (s Selector) matches(rc ResolveContext) bool {
 	if len(s.Actions) > 0 && (rc.Operation == nil || !slices.Contains(s.Actions, rc.Operation.Action)) {
 		return false
 	}
-	if len(s.Origins) > 0 && !slices.Contains(s.Origins, rc.Origin) {
+	if len(s.Surfaces) > 0 && !slices.Contains(s.Surfaces, rc.Surface) {
 		return false
 	}
 	if len(s.ActorTypes) > 0 && !slices.Contains(s.ActorTypes, rc.Actor.Type) {
@@ -194,7 +194,7 @@ func clonePolicy(p Policy) Policy {
 			Resources:    slices.Clone(p.Match.Resources),
 			Operations:   slices.Clone(p.Match.Operations),
 			Actions:      slices.Clone(p.Match.Actions),
-			Origins:      slices.Clone(p.Match.Origins),
+			Surfaces:     slices.Clone(p.Match.Surfaces),
 			ActorTypes:   slices.Clone(p.Match.ActorTypes),
 			Actors:       slices.Clone(p.Match.Actors),
 			Entitlements: slices.Clone(p.Match.Entitlements),

--- a/internal/server/middleware/audit/record_shape_test.go
+++ b/internal/server/middleware/audit/record_shape_test.go
@@ -60,7 +60,7 @@ func recordCases() []recordCase {
 				},
 				Action:       "update_release_binding",
 				Category:     CategoryManagement,
-				Origin:       OriginAPI,
+				Surface:      SurfaceREST,
 				OperationID:  "UpdateReleaseBinding",
 				HTTP:         &HTTPInfo{Method: "PUT", Path: "/api/v1/namespaces/ns-1/release-bindings/rb-1"},
 				ResourceType: "releasebindings",
@@ -80,7 +80,8 @@ func recordCases() []recordCase {
 				`"entitlements":{"groups":["dev","ops"]}},` +
 				`"action":"update_release_binding","category":"management","result":"success",` +
 				`"request_id":"11111111-1111-4111-8111-111111111111","source_ip":"10.0.0.1",` +
-				`"producer":"openchoreo-api","origin":"api","operation_id":"UpdateReleaseBinding",` +
+				`"user_agent":"",` +
+				`"producer":"openchoreo-api","surface":"rest","operation_id":"UpdateReleaseBinding",` +
 				`"http":{"method":"PUT","path":"/api/v1/namespaces/ns-1/release-bindings/rb-1"},` +
 				`"resource":{"type":"releasebindings","namespace":"ns-1","environment":"ns-1/production",` +
 				`"project":"p1","component":"c1","uid":"uid-1","name":"rb-1"},` +
@@ -94,7 +95,7 @@ func recordCases() []recordCase {
 				Actor:        Actor{Type: "user", ID: "u1"},
 				Action:       "update_project",
 				Category:     CategoryManagement,
-				Origin:       OriginMCP,
+				Surface:      SurfaceMCP,
 				OperationID:  "UpdateProject",
 				HTTP:         nil,
 				ResourceType: "projects",
@@ -111,7 +112,8 @@ func recordCases() []recordCase {
 				`"actor":{"type":"user","id":"u1"},` +
 				`"action":"update_project","category":"management","result":"denied",` +
 				`"request_id":"22222222-2222-4222-8222-222222222222","source_ip":"10.0.0.2",` +
-				`"producer":"openchoreo-api","origin":"mcp","operation_id":"UpdateProject",` +
+				`"user_agent":"",` +
+				`"producer":"openchoreo-api","surface":"mcp","operation_id":"UpdateProject",` +
 				`"resource":{"type":"projects","namespace":"ns-1","project":"p1"}}` + "\n",
 		},
 		{
@@ -135,6 +137,7 @@ func recordCases() []recordCase {
 				`"actor":{"type":"anonymous","id":"anonymous"},` +
 				`"action":"","category":"","result":"unauthenticated",` +
 				`"request_id":"33333333-3333-4333-8333-333333333333","source_ip":"10.0.0.3",` +
+				`"user_agent":"",` +
 				`"producer":"openchoreo-api",` +
 				`"http":{"method":"POST","path":"/api/v1/namespaces/ns-1/projects"}}` + "\n",
 		},
@@ -146,7 +149,7 @@ func recordCases() []recordCase {
 				EventID:   "01920000-0000-7000-8000-000000000008",
 				EventTime: fixedTime,
 				Actor:     Actor{Type: "anonymous", ID: "anonymous"},
-				Origin:    OriginMCP,
+				Surface:   SurfaceMCP,
 				Result:    ResultUnauthenticated,
 				RequestID: "88888888-8888-4888-8888-888888888888",
 				SourceIP:  "10.0.0.8",
@@ -159,7 +162,8 @@ func recordCases() []recordCase {
 				`"actor":{"type":"anonymous","id":"anonymous"},` +
 				`"action":"","category":"","result":"unauthenticated",` +
 				`"request_id":"88888888-8888-4888-8888-888888888888","source_ip":"10.0.0.8",` +
-				`"producer":"openchoreo-api","origin":"mcp",` +
+				`"user_agent":"",` +
+				`"producer":"openchoreo-api","surface":"mcp",` +
 				`"http":{"method":"POST","path":"/mcp"}}` + "\n",
 		},
 		{
@@ -181,6 +185,7 @@ func recordCases() []recordCase {
 				`"actor":{"type":"user","id":"u1"},` +
 				`"action":"delete_project","category":"management","result":"success",` +
 				`"request_id":"55555555-5555-4555-8555-555555555555","source_ip":"10.0.0.5",` +
+				`"user_agent":"",` +
 				`"producer":"openchoreo-api"}` + "\n",
 		},
 		{
@@ -191,7 +196,7 @@ func recordCases() []recordCase {
 				Actor:        Actor{Type: "service_account", ID: "sa-1"},
 				Action:       "create_secret",
 				Category:     CategoryAuthorization,
-				Origin:       OriginAPI,
+				Surface:      SurfaceREST,
 				OperationID:  "CreateSecret",
 				ResourceType: "secrets",
 				Resource: &Resource{
@@ -210,7 +215,8 @@ func recordCases() []recordCase {
 				`"actor":{"type":"service_account","id":"sa-1"},` +
 				`"action":"create_secret","category":"authorization","result":"failure",` +
 				`"request_id":"44444444-4444-4444-8444-444444444444","source_ip":"10.0.0.4",` +
-				`"producer":"observer","origin":"api","operation_id":"CreateSecret",` +
+				`"user_agent":"",` +
+				`"producer":"observer","surface":"rest","operation_id":"CreateSecret",` +
 				`"resource":{"type":"secrets","namespace":"ns-1","name":"s1",` +
 				`"metadata":{"kind":"opaque"}}}` + "\n",
 		},
@@ -236,6 +242,7 @@ func recordCases() []recordCase {
 				`"actor":{"type":"user","id":"u1"},` +
 				`"action":"create_project","category":"management","result":"success",` +
 				`"request_id":"77777777-7777-4777-8777-777777777777","source_ip":"10.0.0.7",` +
+				`"user_agent":"",` +
 				`"producer":"openchoreo-api","metadata":{"empty":{},"keep":"v"}}` + "\n",
 		},
 		{
@@ -264,6 +271,7 @@ func recordCases() []recordCase {
 				`"actor":{"type":"user","id":"u1","entitlements":{"groups":["dev"],"roles":["admin"]}},` +
 				`"action":"create_project","category":"management","result":"success",` +
 				`"request_id":"66666666-6666-4666-8666-666666666666","source_ip":"10.0.0.6",` +
+				`"user_agent":"",` +
 				`"producer":"openchoreo-api","metadata":{"a":2,"z":1}}` + "\n",
 		},
 	}

--- a/internal/server/middleware/audit/types.go
+++ b/internal/server/middleware/audit/types.go
@@ -85,12 +85,13 @@ const (
 	ResultUnauthenticated Result = "unauthenticated"
 )
 
-// Origin identifies which surface produced an audit event.
-type Origin string
+// Surface identifies which surface of the API a call arrived through. MCP
+// wraps the same API, so the REST value is "rest" rather than "api".
+type Surface string
 
 const (
-	OriginAPI Origin = "api"
-	OriginMCP Origin = "mcp"
+	SurfaceREST Surface = "rest"
+	SurfaceMCP  Surface = "mcp"
 )
 
 // SchemaVersion is stamped on every published event as "schema_version".
@@ -125,8 +126,8 @@ type Event struct {
 	Actor        Actor
 	Action       string // Semantic action name (e.g., "create_project")
 	Category     Category
-	Origin       Origin // Surface that produced the event: api | mcp
-	OperationID  string // Canonical operation identifier, e.g. "CreateProject"
+	Surface      Surface // Which surface of the API the call arrived through: rest | mcp
+	OperationID  string  // Canonical operation identifier, e.g. "CreateProject"
 	HTTP         *HTTPInfo
 	ResourceType string
 	Resource     *Resource // Target resource (can be nil for non-resource actions)
@@ -134,8 +135,11 @@ type Event struct {
 	Result       Result
 	RequestID    string // Correlation ID linking to the access log line
 	SourceIP     string // Client IP address
-	Producer     string // Emitting service (e.g., "openchoreo-api")
-	Metadata     map[string]any
+	// UserAgent is client-supplied and unverifiable, like SourceIP. It is the
+	// only field that separates a portal session from occ, CI or an agent.
+	UserAgent string
+	Producer  string // Emitting service (e.g., "openchoreo-api")
+	Metadata  map[string]any
 }
 
 // eventJSON is the single definition of the published audit record. Field
@@ -151,8 +155,9 @@ type eventJSON struct {
 	Result        Result         `json:"result"`
 	RequestID     string         `json:"request_id"`
 	SourceIP      string         `json:"source_ip"`
+	UserAgent     string         `json:"user_agent"`
 	Producer      string         `json:"producer"`
-	Origin        Origin         `json:"origin,omitempty"`
+	Surface       Surface        `json:"surface,omitempty"`
 	OperationID   string         `json:"operation_id,omitempty"`
 	HTTP          *HTTPInfo      `json:"http,omitempty"`
 	Resource      *resourceJSON  `json:"resource,omitempty"`
@@ -191,8 +196,9 @@ func (e Event) MarshalJSON() ([]byte, error) {
 		Result:        e.Result,
 		RequestID:     e.RequestID,
 		SourceIP:      e.SourceIP,
+		UserAgent:     e.UserAgent,
 		Producer:      e.Producer,
-		Origin:        e.Origin,
+		Surface:       e.Surface,
 		OperationID:   e.OperationID,
 		HTTP:          e.HTTP,
 		Resource:      e.resolvedResource(),

--- a/internal/server/middleware/audit/unauthenticated_middleware.go
+++ b/internal/server/middleware/audit/unauthenticated_middleware.go
@@ -37,7 +37,7 @@ import (
 // origin stamps the surface the rejected request was aimed at. It is a
 // parameter rather than a constant because the same middleware guards more
 // than one surface: the generated REST routes and the exec/wirelogs routes
-// are OriginAPI, while /mcp is OriginMCP. Without it every MCP token
+// are SurfaceREST, while /mcp is SurfaceMCP. Without it every MCP token
 // rejection would be recorded as if it had arrived over REST.
 //
 // The event it emits carries a nil Operation, so Action, Category,
@@ -45,7 +45,7 @@ import (
 // operation-derived policy selector short-circuits on them (see
 // Selector.matches). A rejection is therefore selectable only by origins,
 // results, actor_types and actors — on either surface.
-func NewUnauthenticatedMiddleware(emitter *Emitter, origin Origin, enabled bool) func(http.Handler) http.Handler {
+func NewUnauthenticatedMiddleware(emitter *Emitter, surface Surface, enabled bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if !enabled {
@@ -78,7 +78,7 @@ func NewUnauthenticatedMiddleware(emitter *Emitter, origin Origin, enabled bool)
 				}
 
 				_, auditData := NewAuditContext(r.Context(), nil, reqInfo)
-				EmitFromContext(r.Context(), emitter, nil, origin, result, auditData, r.Header, r.RemoteAddr)
+				EmitFromContext(r.Context(), emitter, nil, surface, result, auditData, r.Header, r.RemoteAddr)
 
 				if p != nil {
 					panic(p)

--- a/internal/server/middleware/audit/unauthenticated_middleware_test.go
+++ b/internal/server/middleware/audit/unauthenticated_middleware_test.go
@@ -60,7 +60,7 @@ func chain(outer, auth func(http.Handler) http.Handler, inner *Middleware, handl
 func TestUnauthenticatedMiddleware_401NoSubjectEmits(t *testing.T) {
 	sink := &recordingSink{}
 	emitter := newTestUnauthenticatedEmitter(t, sink)
-	outer := NewUnauthenticatedMiddleware(emitter, OriginAPI, true)
+	outer := NewUnauthenticatedMiddleware(emitter, SurfaceREST, true)
 	inner := newMiddleware(slog.Default(), map[string]*Operation{}, emitter, true)
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -96,7 +96,7 @@ func TestUnauthenticatedMiddleware_AuthenticatedRequestEmitsExactlyOnce(t *testi
 		t.Run(http.StatusText(code), func(t *testing.T) {
 			sink := &recordingSink{}
 			emitter := newTestUnauthenticatedEmitter(t, sink)
-			outer := NewUnauthenticatedMiddleware(emitter, OriginAPI, true)
+			outer := NewUnauthenticatedMiddleware(emitter, SurfaceREST, true)
 			op := &Operation{ID: testProjectOpID, Action: "create_project", ResourceType: "project", Category: CategoryManagement}
 			inner := newMiddleware(slog.Default(), map[string]*Operation{testProjectPattern: op}, emitter, true)
 
@@ -122,16 +122,16 @@ func TestUnauthenticatedMiddleware_AuthenticatedRequestEmitsExactlyOnce(t *testi
 // TestUnauthenticatedMiddleware_StampsOrigin guards the reason origin is a
 // parameter rather than a constant: one instance of this middleware guards
 // /mcp and another guards the REST routes, and an MCP token rejection
-// recorded as origin: api would be indistinguishable from a REST one — which
+// recorded as surface: rest would be indistinguishable from a REST one — which
 // is the only selector, alongside results, that can reach these events at
 // all (they carry a nil Operation, so every operation-derived selector
 // short-circuits).
-func TestUnauthenticatedMiddleware_StampsOrigin(t *testing.T) {
-	for _, origin := range []Origin{OriginAPI, OriginMCP} {
-		t.Run(string(origin), func(t *testing.T) {
+func TestUnauthenticatedMiddleware_StampsSurface(t *testing.T) {
+	for _, surface := range []Surface{SurfaceREST, SurfaceMCP} {
+		t.Run(string(surface), func(t *testing.T) {
 			sink := &recordingSink{}
 			emitter := newTestUnauthenticatedEmitter(t, sink)
-			mw := NewUnauthenticatedMiddleware(emitter, origin, true)
+			mw := NewUnauthenticatedMiddleware(emitter, surface, true)
 
 			next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusUnauthorized)
@@ -143,8 +143,8 @@ func TestUnauthenticatedMiddleware_StampsOrigin(t *testing.T) {
 			if len(sink.events) != 1 {
 				t.Fatalf("len(sink.events) = %d, want 1", len(sink.events))
 			}
-			if got := sink.events[0].Origin; got != origin {
-				t.Errorf("Origin = %q, want %q", got, origin)
+			if got := sink.events[0].Surface; got != surface {
+				t.Errorf("Surface = %q, want %q", got, surface)
 			}
 			if got := sink.events[0].Result; got != ResultUnauthenticated {
 				t.Errorf("Result = %q, want %q", got, ResultUnauthenticated)
@@ -158,7 +158,7 @@ func TestUnauthenticatedMiddleware_NonAuthFailuresDoNotEmit(t *testing.T) {
 	for _, code := range tests {
 		sink := &recordingSink{}
 		emitter := newTestUnauthenticatedEmitter(t, sink)
-		mw := NewUnauthenticatedMiddleware(emitter, OriginAPI, true)
+		mw := NewUnauthenticatedMiddleware(emitter, SurfaceREST, true)
 
 		next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(code)
@@ -177,7 +177,7 @@ func TestUnauthenticatedMiddleware_NonAuthFailuresDoNotEmit(t *testing.T) {
 func TestUnauthenticatedMiddleware_Disabled(t *testing.T) {
 	sink := &recordingSink{}
 	emitter := newTestUnauthenticatedEmitter(t, sink)
-	mw := NewUnauthenticatedMiddleware(emitter, OriginAPI, false)
+	mw := NewUnauthenticatedMiddleware(emitter, SurfaceREST, false)
 
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
@@ -198,7 +198,7 @@ func TestUnauthenticatedMiddleware_Disabled(t *testing.T) {
 func TestUnauthenticatedMiddleware_PanicNoAuthEmitsFailureAndRepanics(t *testing.T) {
 	sink := &recordingSink{}
 	emitter := newTestUnauthenticatedEmitter(t, sink)
-	mw := NewUnauthenticatedMiddleware(emitter, OriginAPI, true)
+	mw := NewUnauthenticatedMiddleware(emitter, SurfaceREST, true)
 
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		panic("boom")
@@ -230,7 +230,7 @@ func TestUnauthenticatedMiddleware_PanicNoAuthEmitsFailureAndRepanics(t *testing
 func TestUnauthenticatedMiddleware_PanicAfterAuthEmitsExactlyOnce(t *testing.T) {
 	sink := &recordingSink{}
 	emitter := newTestUnauthenticatedEmitter(t, sink)
-	outer := NewUnauthenticatedMiddleware(emitter, OriginAPI, true)
+	outer := NewUnauthenticatedMiddleware(emitter, SurfaceREST, true)
 	op := &Operation{ID: testProjectOpID, Action: "create_project", ResourceType: "project", Category: CategoryManagement}
 	inner := newMiddleware(slog.Default(), map[string]*Operation{testProjectPattern: op}, emitter, true)
 

--- a/pkg/mcp/mcpaudit/audit_middleware.go
+++ b/pkg/mcp/mcpaudit/audit_middleware.go
@@ -81,12 +81,12 @@ func newAuditMiddleware(
 			defer func() {
 				if p := recover(); p != nil {
 					audit.EmitFromContext(
-						ctx, emitter, op, audit.OriginMCP, audit.ResultFailure, auditData, requestHeader(req), "",
+						ctx, emitter, op, audit.SurfaceMCP, audit.ResultFailure, auditData, requestHeader(req), "",
 					)
 					panic(p)
 				}
 				audit.EmitFromContext(
-					ctx, emitter, op, audit.OriginMCP, classifyResult(res, err), auditData, requestHeader(req), "",
+					ctx, emitter, op, audit.SurfaceMCP, classifyResult(res, err), auditData, requestHeader(req), "",
 				)
 			}()
 

--- a/pkg/mcp/server_audit_test.go
+++ b/pkg/mcp/server_audit_test.go
@@ -264,8 +264,8 @@ func TestNewHTTPServer_AuditWired(t *testing.T) {
 		if record["action"] != "create_project" {
 			t.Errorf("action = %v, want create_project", record["action"])
 		}
-		if record["origin"] != "mcp" {
-			t.Errorf("origin = %v, want mcp", record["origin"])
+		if record["surface"] != "mcp" {
+			t.Errorf("surface = %v, want mcp", record["surface"])
 		}
 		if record["result"] != "success" {
 			t.Errorf("result = %v, want success", record["result"])


### PR DESCRIPTION
## Purpose
`origin` read as provenance, but the value answers "which way in". And `api` vs `mcp` implied MCP is not an API when it wraps the same one.

Separately, nothing in the record told a portal session apart from `occ`, CI or an agent.

## Approach
The field is now `surface` over `rest` and `mcp`, with the audit config key following from `origins:` to `surfaces:`.

`user_agent` is read from the request header in `EmitFromContext`, which was already being handed it, so no signature changed and both surfaces get it. Client-supplied, so treat it as a claim rather than proof.

Schema version stays at `1.0`. Both changes are breaking, but v1 has not shipped.

## Related Issues
Part of #3343.

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [x] This PR includes AI-generated code or content

## Remarks
The observer read contract on `feat/audit-observer-contract` encodes `origin` in its query filter, record type and OpenAPI spec. It needs the same rename before it lands.

The four failing webhook and controller suites fail the same way without this change and none of them import the audit packages.