### PR TITLE
fix: report RenderedRelease health only for the generation it describes

### DIFF
--- a/internal/controller/renderedrelease/controller.go
+++ b/internal/controller/renderedrelease/controller.go
@@ -166,14 +166,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	// Mark resources as successfully applied and persist to API
-	if changed := controller.MarkTrueCondition(release, controller.ConditionType(ConditionResourcesApplied),
-		controller.ConditionReason(ReasonApplySucceeded), "All resources applied successfully"); changed {
-		if statusErr := r.Status().Update(ctx, release); statusErr != nil {
-			logger.Error(statusErr, "Failed to update Release status with apply success")
-			return ctrl.Result{}, statusErr
-		}
-	}
+	// Mark resources as successfully applied, but leave persisting it to the status
+	// update at the end of this reconcile.
+	// Writing it here would publish a state that contradicts itself: the condition
+	// would report this generation as applied while Status.Resources still holds
+	// the health of the generation being replaced. A consumer that reads the
+	// condition to decide whether the health beside it is current -- which is the
+	// only signal available for that -- would act on the previous revision's
+	// health. The delivery events built on it reported a rollout as succeeded
+	// before its pods existed.
+	//
+	// The apply-failure branch above still persists immediately, because there the
+	// point is to surface the error before returning.
+	controller.MarkTrueCondition(release, controller.ConditionType(ConditionResourcesApplied),
+		controller.ConditionReason(ReasonApplySucceeded), "All resources applied successfully")
 
 	// PHASE 2: Discover live resources that we manage in the target plane
 	// This queries both current resource types (from spec) and previous resource types (from status)

--- a/internal/controller/renderedrelease/controller_status.go
+++ b/internal/controller/renderedrelease/controller_status.go
@@ -31,10 +31,10 @@ func (r *Reconciler) updateStatus(ctx context.Context, old, release *openchoreov
 	// Update the status
 	release.Status.Resources = resourceStatuses
 
-	// Sync conditions in old to match release before comparison, because conditions
-	// (e.g., ResourcesApplied) were already persisted earlier in the reconcile loop.
-	// Without this, DeepEqual sees a false diff and triggers a redundant status update.
-	old.Status.Conditions = release.Status.Conditions
+	// Conditions are deliberately part of the comparison. The apply-success
+	// condition is no longer persisted mid-reconcile, so this update is what
+	// publishes it -- masking it here would drop it whenever the resource
+	// statuses happened not to change.
 
 	// Check if the entire status actually changed and skip update if not
 	if apiequality.Semantic.DeepEqual(old.Status, release.Status) {
@@ -114,6 +114,18 @@ func (r *Reconciler) buildResourceStatus(ctx context.Context, old *openchoreov1a
 				healthStatus = openchoreov1alpha1.HealthStatusUnknown
 			}
 
+			// The live snapshot can predate the apply this reconcile just made:
+			// server-side apply is a quorum write, while List is served from the
+			// API server's watch cache, which can lag it. Judging that snapshot
+			// reports the previous revision's health under the current generation
+			// -- for a Deployment mid-rollout, Healthy for a revision whose new
+			// ReplicaSet does not exist yet. The apply response carries the
+			// server's generation for the spec that was written, so a live object
+			// behind it has not been observed yet.
+			if snapshotPrecedesApply(desiredObj, liveResource) {
+				healthStatus = openchoreov1alpha1.HealthStatusProgressing
+			}
+
 			// Check if this resource existed before and if its status changed
 			if oldResource, exists := oldResourceMap[resourceID]; exists {
 				// Check if the resource status has actually changed
@@ -147,6 +159,19 @@ func (r *Reconciler) buildResourceStatus(ctx context.Context, old *openchoreov1a
 	}
 
 	return resourceStatuses
+}
+
+// snapshotPrecedesApply reports whether live was read before the spec that
+// applied wrote became visible.
+//
+// applied is the object handed to server-side apply, which controller-runtime
+// replaces with the server's response, so its generation is the one the write
+// produced. Generation is absent for kinds that do not track it (ConfigMap,
+// Secret, HTTPRoute status aside), which reads as zero on both sides and so
+// never trips this.
+func snapshotPrecedesApply(applied, live *unstructured.Unstructured) bool {
+	appliedGen, liveGen := applied.GetGeneration(), live.GetGeneration()
+	return appliedGen > 0 && liveGen > 0 && liveGen < appliedGen
 }
 
 // hasTransitioningResources checks if any resources are in a transitioning state

--- a/internal/controller/renderedrelease/controller_unit_test.go
+++ b/internal/controller/renderedrelease/controller_unit_test.go
@@ -1858,3 +1858,161 @@ func TestExtractDeploymentConditions(t *testing.T) {
 		}
 	})
 }
+
+// ─────────────────────────────────────────────────────────────
+// Health must describe the spec that was applied
+// ─────────────────────────────────────────────────────────────
+
+// healthyDeployment builds a Deployment that reads as fully rolled out at the
+// given generation: every replica updated, ready and available.
+func healthyDeployment(generation, observedGeneration int64) *unstructured.Unstructured {
+	const resourceID = "deployment-checkout"
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion("apps/v1")
+	obj.SetKind("Deployment")
+	obj.SetName("checkout")
+	obj.SetNamespace("dp-ns")
+	obj.SetGeneration(generation)
+	obj.SetLabels(map[string]string{labels.LabelKeyRenderedReleaseResourceID: resourceID})
+	if err := unstructured.SetNestedMap(obj.Object, map[string]any{
+		"observedGeneration":  observedGeneration,
+		"replicas":            int64(1),
+		"updatedReplicas":     int64(1),
+		"readyReplicas":       int64(1),
+		"availableReplicas":   int64(1),
+		"unavailableReplicas": int64(0),
+	}, "status"); err != nil {
+		panic(err)
+	}
+	if err := unstructured.SetNestedSlice(obj.Object, []any{
+		map[string]any{"type": "Available", "status": "True", "reason": "MinimumReplicasAvailable"},
+		map[string]any{"type": "Progressing", "status": "True", "reason": "NewReplicaSetAvailable"},
+	}, "status", "conditions"); err != nil {
+		panic(err)
+	}
+	if err := unstructured.SetNestedField(obj.Object, int64(1), "spec", "replicas"); err != nil {
+		panic(err)
+	}
+	return obj
+}
+
+// TestBuildResourceStatusRejectsPreApplySnapshot pins that health is only
+// reported for a snapshot of the spec this reconcile applied.
+//
+// applyResources uses server-side apply, and the client writes the server's
+// response back into the desired object, so its generation is the one the write
+// produced. The List that follows is served from the API server's watch cache
+// and can lag that write, handing back the previous revision -- fully rolled out
+// and healthy, with its own generation and observedGeneration agreeing, so
+// getDeploymentHealth has no way to notice.
+//
+// Publishing that as this generation's health told the delivery events a rollout
+// had succeeded before its new ReplicaSet existed, which is what succeededAt --
+// and therefore Lead Time for Changes -- is measured from.
+func TestBuildResourceStatusRejectsPreApplySnapshot(t *testing.T) {
+	ctx := context.Background()
+	r := &Reconciler{}
+	emptyRelease := &openchoreov1alpha1.RenderedRelease{}
+
+	t.Run("live snapshot behind the apply is Progressing, not Healthy", func(t *testing.T) {
+		// The apply returned generation 7; the cache still holds generation 6,
+		// settled and healthy on the revision being replaced.
+		applied := healthyDeployment(7, 7)
+		live := healthyDeployment(6, 6)
+
+		result := r.buildResourceStatus(ctx, emptyRelease,
+			[]*unstructured.Unstructured{applied}, []*unstructured.Unstructured{live})
+		if len(result) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(result))
+		}
+		if got := result[0].HealthStatus; got != openchoreov1alpha1.HealthStatusProgressing {
+			t.Errorf("health = %q, want Progressing: the snapshot predates the applied spec", got)
+		}
+	})
+
+	t.Run("live snapshot at the applied generation is judged normally", func(t *testing.T) {
+		applied := healthyDeployment(7, 7)
+		live := healthyDeployment(7, 7)
+
+		result := r.buildResourceStatus(ctx, emptyRelease,
+			[]*unstructured.Unstructured{applied}, []*unstructured.Unstructured{live})
+		if len(result) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(result))
+		}
+		if got := result[0].HealthStatus; got != openchoreov1alpha1.HealthStatusHealthy {
+			t.Errorf("health = %q, want Healthy", got)
+		}
+	})
+
+	t.Run("kinds without a generation are unaffected", func(t *testing.T) {
+		// ConfigMaps do not track generation, so both sides read zero. Comparing
+		// them must not make every such resource permanently Progressing.
+		desired := buildResourcesDesired("res-cm", "my-cm")
+		live := buildResourcesLive("res-cm", "my-cm", map[string]interface{}{})
+
+		result := r.buildResourceStatus(ctx, emptyRelease,
+			[]*unstructured.Unstructured{desired}, []*unstructured.Unstructured{live})
+		if len(result) != 1 {
+			t.Fatalf("expected 1 result, got %d", len(result))
+		}
+		if got := result[0].HealthStatus; got == openchoreov1alpha1.HealthStatusProgressing {
+			t.Errorf("health = %q, want anything but Progressing for a generation-less kind", got)
+		}
+	})
+}
+
+// TestUpdateStatusPersistsConditionOnlyChange pins that the apply-success
+// condition reaches the API server.
+//
+// It used to be persisted by its own Status().Update mid-reconcile, and
+// updateStatus copied conditions onto old before comparing so that write would
+// not look like a diff. It is now published here instead, together with the
+// resource statuses it will be read beside -- so the comparison has to include
+// conditions, or a reconcile whose resource health did not change would drop the
+// condition entirely.
+func TestUpdateStatusPersistsConditionOnlyChange(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	if err := openchoreov1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	release := &openchoreov1alpha1.RenderedRelease{
+		ObjectMeta: metav1.ObjectMeta{Name: "rr-1", Namespace: "ns-1", Generation: 3},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(release).WithStatusSubresource(release).Build()
+	r := &Reconciler{Client: cl}
+
+	old := release.DeepCopy()
+	updated := release.DeepCopy()
+	// Same resources on both sides; only the condition differs.
+	statuses := []openchoreov1alpha1.RenderedManifestStatus{
+		{ID: "res-1", Kind: "ConfigMap", HealthStatus: openchoreov1alpha1.HealthStatusHealthy},
+	}
+	old.Status.Resources = statuses
+	updated.Status.Conditions = []metav1.Condition{{
+		Type:               ConditionResourcesApplied,
+		Status:             metav1.ConditionTrue,
+		Reason:             ReasonApplySucceeded,
+		ObservedGeneration: 3,
+		LastTransitionTime: metav1.Now(),
+	}}
+
+	changed, err := r.updateStatus(ctx, old, updated, statuses)
+	if err != nil {
+		t.Fatalf("updateStatus returned %v", err)
+	}
+	if !changed {
+		t.Fatal("a condition-only change must still be persisted")
+	}
+
+	stored := &openchoreov1alpha1.RenderedRelease{}
+	if err := cl.Get(ctx, client.ObjectKey{Name: "rr-1", Namespace: "ns-1"}, stored); err != nil {
+		t.Fatalf("get stored release: %v", err)
+	}
+	if len(stored.Status.Conditions) != 1 ||
+		stored.Status.Conditions[0].Type != ConditionResourcesApplied {
+		t.Errorf("stored conditions = %+v, want ResourcesApplied", stored.Status.Conditions)
+	}
+}


### PR DESCRIPTION
Fixes #4714

## Fixes

1. The apply-success condition is no longer persisted by its own status update in
   PHASE 1. It is marked in memory and written by the PHASE 4 `updateStatus`, together
   with the resource statuses it will be read beside, so the condition and the health
   it vouches for become visible in one write.

   The apply-failure branch still persists immediately: it returns early, so there is
   no later write to defer to, and the point there is to surface the error.

2. `updateStatus` stops copying `old.Status.Conditions` over before its change
   comparison. That copy existed only to hide the false diff the mid-reconcile write
   created. With that write gone, this update is what publishes the condition, so
   masking it would drop the condition entirely on any reconcile whose resource
   statuses happened not to change.

3. A live snapshot whose generation is behind the applied generation is reported
   `Progressing`. Server-side apply returns the object, so the desired copy carries
   the generation the write produced, while the `List` that follows is served from the
   API server's watch cache and can lag it. Kinds that do not track generation read as
   zero on both sides and never trip the check.
