### PR TITLE
feat: add support for querying platform log filter values

### DIFF
--- a/internal/observer/api/gen/client.gen.go
+++ b/internal/observer/api/gen/client.gen.go
@@ -136,6 +136,9 @@ type ClientInterface interface {
 	// GetPlatformLogs request
 	GetPlatformLogs(ctx context.Context, params *GetPlatformLogsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// GetPlatformLogFilterValues request
+	GetPlatformLogFilterValues(ctx context.Context, params *GetPlatformLogFilterValuesParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// QueryTracesWithBody request with any body
 	QueryTracesWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -359,6 +362,18 @@ func (c *Client) QueryRuntimeTopology(ctx context.Context, body QueryRuntimeTopo
 
 func (c *Client) GetPlatformLogs(ctx context.Context, params *GetPlatformLogsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetPlatformLogsRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) GetPlatformLogFilterValues(ctx context.Context, params *GetPlatformLogFilterValuesParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewGetPlatformLogFilterValuesRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -1178,6 +1193,219 @@ func NewGetPlatformLogsRequest(server string, params *GetPlatformLogsParams) (*h
 	return req, nil
 }
 
+// NewGetPlatformLogFilterValuesRequest generates requests for GetPlatformLogFilterValues
+func NewGetPlatformLogFilterValuesRequest(server string, params *GetPlatformLogFilterValuesParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1alpha1/platform-logs/filter-values")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "filter", runtime.ParamLocationQuery, params.Filter); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "startTime", runtime.ParamLocationQuery, params.StartTime); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "endTime", runtime.ParamLocationQuery, params.EndTime); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+		if params.ClusterInstance != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "clusterInstance", runtime.ParamLocationQuery, *params.ClusterInstance); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Namespace != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "namespace", runtime.ParamLocationQuery, *params.Namespace); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.PodName != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "podName", runtime.ParamLocationQuery, *params.PodName); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ContainerName != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "containerName", runtime.ParamLocationQuery, *params.ContainerName); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Labels != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "labels", runtime.ParamLocationQuery, *params.Labels); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.LogLevels != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", false, "logLevels", runtime.ParamLocationQuery, *params.LogLevels); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.SearchPhrase != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "searchPhrase", runtime.ParamLocationQuery, *params.SearchPhrase); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ValueSearch != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "valueSearch", runtime.ParamLocationQuery, *params.ValueSearch); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.MaxValues != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "maxValues", runtime.ParamLocationQuery, *params.MaxValues); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewQueryTracesRequest calls the generic QueryTraces builder with application/json body
 func NewQueryTracesRequest(server string, body QueryTracesJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -1422,6 +1650,9 @@ type ClientWithResponsesInterface interface {
 
 	// GetPlatformLogsWithResponse request
 	GetPlatformLogsWithResponse(ctx context.Context, params *GetPlatformLogsParams, reqEditors ...RequestEditorFn) (*GetPlatformLogsResp, error)
+
+	// GetPlatformLogFilterValuesWithResponse request
+	GetPlatformLogFilterValuesWithResponse(ctx context.Context, params *GetPlatformLogFilterValuesParams, reqEditors ...RequestEditorFn) (*GetPlatformLogFilterValuesResp, error)
 
 	// QueryTracesWithBodyWithResponse request with any body
 	QueryTracesWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*QueryTracesResp, error)
@@ -1730,6 +1961,33 @@ func (r GetPlatformLogsResp) StatusCode() int {
 	return 0
 }
 
+type GetPlatformLogFilterValuesResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *PlatformLogFilterValuesResponse
+	JSON400      *ErrorResponse
+	JSON401      *ErrorResponse
+	JSON403      *ErrorResponse
+	JSON500      *ErrorResponse
+	JSON501      *ErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r GetPlatformLogFilterValuesResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetPlatformLogFilterValuesResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type QueryTracesResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -1989,6 +2247,15 @@ func (c *ClientWithResponses) GetPlatformLogsWithResponse(ctx context.Context, p
 		return nil, err
 	}
 	return ParseGetPlatformLogsResp(rsp)
+}
+
+// GetPlatformLogFilterValuesWithResponse request returning *GetPlatformLogFilterValuesResp
+func (c *ClientWithResponses) GetPlatformLogFilterValuesWithResponse(ctx context.Context, params *GetPlatformLogFilterValuesParams, reqEditors ...RequestEditorFn) (*GetPlatformLogFilterValuesResp, error) {
+	rsp, err := c.GetPlatformLogFilterValues(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetPlatformLogFilterValuesResp(rsp)
 }
 
 // QueryTracesWithBodyWithResponse request with arbitrary body returning *QueryTracesResp
@@ -2620,6 +2887,67 @@ func ParseGetPlatformLogsResp(rsp *http.Response) (*GetPlatformLogsResp, error) 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest PlatformLogsResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 501:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON501 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetPlatformLogFilterValuesResp parses an HTTP response from a GetPlatformLogFilterValuesWithResponse call
+func ParseGetPlatformLogFilterValuesResp(rsp *http.Response) (*GetPlatformLogFilterValuesResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetPlatformLogFilterValuesResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest PlatformLogFilterValuesResponse
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/internal/observer/api/gen/models.gen.go
+++ b/internal/observer/api/gen/models.gen.go
@@ -24,12 +24,12 @@ const (
 
 // Defines values for AlertRuleConditionOperator.
 const (
-	Eq  AlertRuleConditionOperator = "eq"
-	Gt  AlertRuleConditionOperator = "gt"
-	Gte AlertRuleConditionOperator = "gte"
-	Lt  AlertRuleConditionOperator = "lt"
-	Lte AlertRuleConditionOperator = "lte"
-	Neq AlertRuleConditionOperator = "neq"
+	AlertRuleConditionOperatorEq  AlertRuleConditionOperator = "eq"
+	AlertRuleConditionOperatorGt  AlertRuleConditionOperator = "gt"
+	AlertRuleConditionOperatorGte AlertRuleConditionOperator = "gte"
+	AlertRuleConditionOperatorLt  AlertRuleConditionOperator = "lt"
+	AlertRuleConditionOperatorLte AlertRuleConditionOperator = "lte"
+	AlertRuleConditionOperatorNeq AlertRuleConditionOperator = "neq"
 )
 
 // Defines values for AlertRuleSourceType.
@@ -95,6 +95,12 @@ const (
 	MetricsQueryRequestMetricResource MetricsQueryRequestMetric = "resource"
 )
 
+// Defines values for PlatformLogFilterValuesResponseTotalRelation.
+const (
+	PlatformLogFilterValuesResponseTotalRelationEq  PlatformLogFilterValuesResponseTotalRelation = "eq"
+	PlatformLogFilterValuesResponseTotalRelationGte PlatformLogFilterValuesResponseTotalRelation = "gte"
+)
+
 // Defines values for RuntimeTopologyEdgeProtocol.
 const (
 	RuntimeTopologyEdgeProtocolHttp RuntimeTopologyEdgeProtocol = "http"
@@ -127,6 +133,14 @@ const (
 	TracesQueryRequestSortOrderDesc TracesQueryRequestSortOrder = "desc"
 )
 
+// Defines values for PlatformLogFilterValuesFilter.
+const (
+	PlatformLogFilterValuesFilterClusterInstance PlatformLogFilterValuesFilter = "clusterInstance"
+	PlatformLogFilterValuesFilterContainerName   PlatformLogFilterValuesFilter = "containerName"
+	PlatformLogFilterValuesFilterNamespace       PlatformLogFilterValuesFilter = "namespace"
+	PlatformLogFilterValuesFilterPodName         PlatformLogFilterValuesFilter = "podName"
+)
+
 // Defines values for PlatformLogsSortOrder.
 const (
 	PlatformLogsSortOrderAsc  PlatformLogsSortOrder = "asc"
@@ -145,6 +159,22 @@ const (
 const (
 	Asc  GetPlatformLogsParamsSortOrder = "asc"
 	Desc GetPlatformLogsParamsSortOrder = "desc"
+)
+
+// Defines values for GetPlatformLogFilterValuesParamsFilter.
+const (
+	GetPlatformLogFilterValuesParamsFilterClusterInstance GetPlatformLogFilterValuesParamsFilter = "clusterInstance"
+	GetPlatformLogFilterValuesParamsFilterContainerName   GetPlatformLogFilterValuesParamsFilter = "containerName"
+	GetPlatformLogFilterValuesParamsFilterNamespace       GetPlatformLogFilterValuesParamsFilter = "namespace"
+	GetPlatformLogFilterValuesParamsFilterPodName         GetPlatformLogFilterValuesParamsFilter = "podName"
+)
+
+// Defines values for GetPlatformLogFilterValuesParamsLogLevels.
+const (
+	DEBUG GetPlatformLogFilterValuesParamsLogLevels = "DEBUG"
+	ERROR GetPlatformLogFilterValuesParamsLogLevels = "ERROR"
+	INFO  GetPlatformLogFilterValuesParamsLogLevels = "INFO"
+	WARN  GetPlatformLogFilterValuesParamsLogLevels = "WARN"
 )
 
 // Alert A single fired alert.
@@ -744,6 +774,50 @@ type PlatformLog struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
+// PlatformLogFilterValue One value a filter takes, with how many records carry it.
+type PlatformLogFilterValue struct {
+	// Count Matching records carrying this value, within the queried window. May be
+	// approximate on a high-cardinality filter where the backend answers from a
+	// partial term count, so treat it as an ordering hint and a sense of scale
+	// rather than a total.
+	Count int64 `json:"count"`
+
+	// Value The value, exactly as it would be sent back as a filter.
+	Value string `json:"value"`
+}
+
+// PlatformLogFilterValuesResponse defines model for PlatformLogFilterValuesResponse.
+type PlatformLogFilterValuesResponse struct {
+	// Filter The filter these values belong to, echoed from the request so a client
+	// handling several pickers can match a response to the one that asked.
+	Filter string `json:"filter"`
+
+	// TookMs The time taken to compute the values in milliseconds.
+	TookMs int64 `json:"tookMs"`
+
+	// TotalRelation Whether `totalValues` is exact (`eq`) or a lower bound (`gte`). Counting
+	// distinct values exactly is itself an expensive aggregation on a
+	// high-cardinality field, and most backends answer approximately, so a
+	// capped or estimated count is labelled rather than passed off as exact.
+	TotalRelation PlatformLogFilterValuesResponseTotalRelation `json:"totalRelation"`
+
+	// TotalValues How many distinct values match, of which at most `maxValues` were returned.
+	// Read together with `totalRelation` - this is what lets a picker say "412
+	// more values, keep typing to narrow" rather than silently ending its list.
+	TotalValues int64 `json:"totalValues"`
+
+	// Values The distinct values, ordered by `count` descending then `value` ascending.
+	// Records on which the field is absent are not represented: no empty-string
+	// entry, because no filter value would select one.
+	Values []PlatformLogFilterValue `json:"values"`
+}
+
+// PlatformLogFilterValuesResponseTotalRelation Whether `totalValues` is exact (`eq`) or a lower bound (`gte`). Counting
+// distinct values exactly is itself an expensive aggregation on a
+// high-cardinality field, and most backends answer approximately, so a
+// capped or estimated count is labelled rather than passed off as exact.
+type PlatformLogFilterValuesResponseTotalRelation string
+
 // PlatformLogsResponse defines model for PlatformLogsResponse.
 type PlatformLogsResponse struct {
 	// Logs Log entries matching the query.
@@ -1127,6 +1201,15 @@ type FinOpsProject = string
 // FinOpsStartTime defines model for FinOpsStartTime.
 type FinOpsStartTime = time.Time
 
+// PlatformLogFilterValuesFilter defines model for PlatformLogFilterValuesFilter.
+type PlatformLogFilterValuesFilter string
+
+// PlatformLogFilterValuesMaxValues defines model for PlatformLogFilterValuesMaxValues.
+type PlatformLogFilterValuesMaxValues = int
+
+// PlatformLogFilterValuesValueSearch defines model for PlatformLogFilterValuesValueSearch.
+type PlatformLogFilterValuesValueSearch = string
+
 // PlatformLogsClusterInstance defines model for PlatformLogsClusterInstance.
 type PlatformLogsClusterInstance = []string
 
@@ -1243,6 +1326,71 @@ type GetPlatformLogsParamsLogLevels string
 
 // GetPlatformLogsParamsSortOrder defines parameters for GetPlatformLogs.
 type GetPlatformLogsParamsSortOrder string
+
+// GetPlatformLogFilterValuesParams defines parameters for GetPlatformLogFilterValues.
+type GetPlatformLogFilterValuesParams struct {
+	// Filter The filter to list values for, named as the query parameter that accepts it -
+	// `podName` lists the values that filter takes.
+	//
+	// Only the coordinate filters are listed. `logLevels` is a fixed enum a client
+	// already knows, and `labels` is a selector rather than a field with values.
+	Filter GetPlatformLogFilterValuesParamsFilter `form:"filter" json:"filter"`
+
+	// StartTime Inclusive lower bound of the log window (RFC 3339, absolute UTC).
+	StartTime PlatformLogsStartTime `form:"startTime" json:"startTime"`
+
+	// EndTime Exclusive upper bound of the log window (RFC 3339, absolute UTC). Must be strictly
+	// greater than startTime.
+	EndTime PlatformLogsEndTime `form:"endTime" json:"endTime"`
+
+	// ClusterInstance Clusters the records were collected from, as configured on each logs collector.
+	// Comma-separated; OR within.
+	ClusterInstance *PlatformLogsClusterInstance `form:"clusterInstance,omitempty" json:"clusterInstance,omitempty"`
+
+	// Namespace Kubernetes namespaces of the pods. Comma-separated; OR within.
+	Namespace *PlatformLogsNamespace `form:"namespace,omitempty" json:"namespace,omitempty"`
+
+	// PodName Pod names. Comma-separated; OR within.
+	PodName *PlatformLogsPodName `form:"podName,omitempty" json:"podName,omitempty"`
+
+	// ContainerName Container names. Comma-separated; OR within.
+	ContainerName *PlatformLogsContainerName `form:"containerName,omitempty" json:"containerName,omitempty"`
+
+	// Labels Kubernetes label selector over the pod labels on each record. Comma means AND
+	// here, matching `kubectl -l`. Equality-based selectors only (`key=value`); set-based
+	// operators are not supported. This is how plane attribution is expressed, for
+	// example `openchoreo.dev/plane=controlplane,app.kubernetes.io/name=openbao`.
+	Labels *PlatformLogsLabels `form:"labels,omitempty" json:"labels,omitempty"`
+
+	// LogLevels Log severities to include. Comma-separated; OR within. Named to match
+	// `LogsQueryRequest.logLevels` on the component and workflow endpoints.
+	LogLevels *PlatformLogsLogLevels `form:"logLevels,omitempty" json:"logLevels,omitempty"`
+
+	// SearchPhrase Text to search for within log messages. Entries not containing the phrase are
+	// excluded.
+	SearchPhrase *PlatformLogsSearchPhrase `form:"searchPhrase,omitempty" json:"searchPhrase,omitempty"`
+
+	// ValueSearch Return only values containing this text, case-insensitively. This is how a
+	// picker narrows as its user types, and it is what makes a high-cardinality
+	// filter usable at all: `podName` on a busy plane has more distinct values than
+	// any list should offer, and typing three characters cuts it to something
+	// choosable.
+	//
+	// Distinct from `searchPhrase`, which narrows the *records* considered. This
+	// narrows the *values* returned from those records.
+	ValueSearch *PlatformLogFilterValuesValueSearch `form:"valueSearch,omitempty" json:"valueSearch,omitempty"`
+
+	// MaxValues The maximum number of values to return, ordered by `count` descending then
+	// `value` ascending - so a truncated list holds the busiest. Named to stay
+	// distinct from `limit`, which is a record page size and has no meaning here.
+	MaxValues *PlatformLogFilterValuesMaxValues `form:"maxValues,omitempty" json:"maxValues,omitempty"`
+}
+
+// GetPlatformLogFilterValuesParamsFilter defines parameters for GetPlatformLogFilterValues.
+type GetPlatformLogFilterValuesParamsFilter string
+
+// GetPlatformLogFilterValuesParamsLogLevels defines parameters for GetPlatformLogFilterValues.
+type GetPlatformLogFilterValuesParamsLogLevels string
 
 // QueryEventsJSONRequestBody defines body for QueryEvents for application/json ContentType.
 type QueryEventsJSONRequestBody = EventsQueryRequest

--- a/internal/observer/api/gen/server.gen.go
+++ b/internal/observer/api/gen/server.gen.go
@@ -57,6 +57,9 @@ type ServerInterface interface {
 	// Query platform logs
 	// (GET /api/v1alpha1/platform-logs)
 	GetPlatformLogs(w http.ResponseWriter, r *http.Request, params GetPlatformLogsParams)
+	// List the distinct values one platform logs filter can take
+	// (GET /api/v1alpha1/platform-logs/filter-values)
+	GetPlatformLogFilterValues(w http.ResponseWriter, r *http.Request, params GetPlatformLogFilterValuesParams)
 	// Query traces
 	// (POST /api/v1alpha1/traces/query)
 	QueryTraces(w http.ResponseWriter, r *http.Request)
@@ -558,6 +561,148 @@ func (siw *ServerInterfaceWrapper) GetPlatformLogs(w http.ResponseWriter, r *htt
 	handler.ServeHTTP(w, r)
 }
 
+// GetPlatformLogFilterValues operation middleware
+func (siw *ServerInterfaceWrapper) GetPlatformLogFilterValues(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetPlatformLogFilterValuesParams
+
+	// ------------- Required query parameter "filter" -------------
+
+	if paramValue := r.URL.Query().Get("filter"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "filter"})
+		return
+	}
+
+	err = runtime.BindQueryParameter("form", true, true, "filter", r.URL.Query(), &params.Filter)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "filter", Err: err})
+		return
+	}
+
+	// ------------- Required query parameter "startTime" -------------
+
+	if paramValue := r.URL.Query().Get("startTime"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "startTime"})
+		return
+	}
+
+	err = runtime.BindQueryParameter("form", true, true, "startTime", r.URL.Query(), &params.StartTime)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "startTime", Err: err})
+		return
+	}
+
+	// ------------- Required query parameter "endTime" -------------
+
+	if paramValue := r.URL.Query().Get("endTime"); paramValue != "" {
+
+	} else {
+		siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "endTime"})
+		return
+	}
+
+	err = runtime.BindQueryParameter("form", true, true, "endTime", r.URL.Query(), &params.EndTime)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "endTime", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "clusterInstance" -------------
+
+	err = runtime.BindQueryParameter("form", false, false, "clusterInstance", r.URL.Query(), &params.ClusterInstance)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "clusterInstance", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "namespace" -------------
+
+	err = runtime.BindQueryParameter("form", false, false, "namespace", r.URL.Query(), &params.Namespace)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "namespace", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "podName" -------------
+
+	err = runtime.BindQueryParameter("form", false, false, "podName", r.URL.Query(), &params.PodName)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "podName", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "containerName" -------------
+
+	err = runtime.BindQueryParameter("form", false, false, "containerName", r.URL.Query(), &params.ContainerName)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "containerName", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "labels" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "labels", r.URL.Query(), &params.Labels)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "labels", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "logLevels" -------------
+
+	err = runtime.BindQueryParameter("form", false, false, "logLevels", r.URL.Query(), &params.LogLevels)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "logLevels", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "searchPhrase" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "searchPhrase", r.URL.Query(), &params.SearchPhrase)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "searchPhrase", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "valueSearch" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "valueSearch", r.URL.Query(), &params.ValueSearch)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "valueSearch", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "maxValues" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "maxValues", r.URL.Query(), &params.MaxValues)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "maxValues", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetPlatformLogFilterValues(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // QueryTraces operation middleware
 func (siw *ServerInterfaceWrapper) QueryTraces(w http.ResponseWriter, r *http.Request) {
 
@@ -794,6 +939,7 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 	m.HandleFunc("PUT "+options.BaseURL+"/api/v1alpha1/incidents/{incidentId}", wrapper.UpdateIncident)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/metrics/runtime-topology", wrapper.QueryRuntimeTopology)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1alpha1/platform-logs", wrapper.GetPlatformLogs)
+	m.HandleFunc("GET "+options.BaseURL+"/api/v1alpha1/platform-logs/filter-values", wrapper.GetPlatformLogFilterValues)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/traces/query", wrapper.QueryTraces)
 	m.HandleFunc("POST "+options.BaseURL+"/api/v1alpha1/traces/{traceId}/spans/query", wrapper.QuerySpansForTrace)
 	m.HandleFunc("GET "+options.BaseURL+"/api/v1alpha1/traces/{traceId}/spans/{spanId}", wrapper.GetSpanDetailsForTrace)
@@ -1425,6 +1571,68 @@ func (response GetPlatformLogs501JSONResponse) VisitGetPlatformLogsResponse(w ht
 	return json.NewEncoder(w).Encode(response)
 }
 
+type GetPlatformLogFilterValuesRequestObject struct {
+	Params GetPlatformLogFilterValuesParams
+}
+
+type GetPlatformLogFilterValuesResponseObject interface {
+	VisitGetPlatformLogFilterValuesResponse(w http.ResponseWriter) error
+}
+
+type GetPlatformLogFilterValues200JSONResponse PlatformLogFilterValuesResponse
+
+func (response GetPlatformLogFilterValues200JSONResponse) VisitGetPlatformLogFilterValuesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetPlatformLogFilterValues400JSONResponse ErrorResponse
+
+func (response GetPlatformLogFilterValues400JSONResponse) VisitGetPlatformLogFilterValuesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetPlatformLogFilterValues401JSONResponse ErrorResponse
+
+func (response GetPlatformLogFilterValues401JSONResponse) VisitGetPlatformLogFilterValuesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetPlatformLogFilterValues403JSONResponse ErrorResponse
+
+func (response GetPlatformLogFilterValues403JSONResponse) VisitGetPlatformLogFilterValuesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetPlatformLogFilterValues500JSONResponse ErrorResponse
+
+func (response GetPlatformLogFilterValues500JSONResponse) VisitGetPlatformLogFilterValuesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetPlatformLogFilterValues501JSONResponse ErrorResponse
+
+func (response GetPlatformLogFilterValues501JSONResponse) VisitGetPlatformLogFilterValuesResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(501)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type QueryTracesRequestObject struct {
 	Body *QueryTracesJSONRequestBody
 }
@@ -1651,6 +1859,9 @@ type StrictServerInterface interface {
 	// Query platform logs
 	// (GET /api/v1alpha1/platform-logs)
 	GetPlatformLogs(ctx context.Context, request GetPlatformLogsRequestObject) (GetPlatformLogsResponseObject, error)
+	// List the distinct values one platform logs filter can take
+	// (GET /api/v1alpha1/platform-logs/filter-values)
+	GetPlatformLogFilterValues(ctx context.Context, request GetPlatformLogFilterValuesRequestObject) (GetPlatformLogFilterValuesResponseObject, error)
 	// Query traces
 	// (POST /api/v1alpha1/traces/query)
 	QueryTraces(ctx context.Context, request QueryTracesRequestObject) (QueryTracesResponseObject, error)
@@ -2019,6 +2230,32 @@ func (sh *strictHandler) GetPlatformLogs(w http.ResponseWriter, r *http.Request,
 	}
 }
 
+// GetPlatformLogFilterValues operation middleware
+func (sh *strictHandler) GetPlatformLogFilterValues(w http.ResponseWriter, r *http.Request, params GetPlatformLogFilterValuesParams) {
+	var request GetPlatformLogFilterValuesRequestObject
+
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetPlatformLogFilterValues(ctx, request.(GetPlatformLogFilterValuesRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetPlatformLogFilterValues")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetPlatformLogFilterValuesResponseObject); ok {
+		if err := validResponse.VisitGetPlatformLogFilterValuesResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // QueryTraces operation middleware
 func (sh *strictHandler) QueryTraces(w http.ResponseWriter, r *http.Request) {
 	var request QueryTracesRequestObject
@@ -2137,165 +2374,191 @@ func (sh *strictHandler) Health(w http.ResponseWriter, r *http.Request) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+y963Ibt5Yo/Cqo/jIVO1+TkuwoO1YqPxRFztYeW9KR5EnVMXVCsHuRxKgJdAC0aMal",
-	"qnmIeYfzHudR5klO4daNbqLJJk3ZPrP1JzHVuC6sG9YNH6OEzXJGgUoRHX2McszxDCRw/es1oRe5OHEt",
-	"1J9SEAknuSSMRkdR+QlRPIM++n0KFAmQMaKYczYXSE4BcRA5owKQZEhOiUCC0EkGqJy6j67gz4JwEGiY",
-	"c/bvkMhhP4ojoub4swC+iOJIzRAdVeuN4kgkU5hhtSz4gGd5pr9PIbljhewJ4PckgSiO5CJXX4TkhE6i",
-	"h4fYbuyUpjdEDdrc1umHJCsEuQdU5DlwNGIFTREb690kTEg0JzRlc/Ts6vUJevny5avnffS2EBKNAKlp",
-	"Epkt0IQDlsCRnGKKhMRcqtna9gV2MXHEDSzS6EjyAsK7fLH/4ofe/mHvxfc3B/tH+/tH+wf/M4qjMeMz",
-	"LKOjKMUSetKM1779e8IZnQVP1vtoztYtO8dy6q+6GqPbynPO0iLRs7Qv7TeOaZFhTuRieWkayXIOAqiM",
-	"EeBkWmESUtiVZ0QiQiVDjCrsSxhPkTpHBRA0KpI7kIiNB9Qi41/QR++EQr5Bsb//MklYQaX+J5g/FJTY",
-	"30NEmcRqIWg+BQ5IfVKTqpnYGA2nwwF9NmUFF89jNEyH6FmKF+rfjKPhfIiezQHuxPM+es04slBBw4Pp",
-	"MEbDF6n678v5sD+gLVgy8QAThu9BGsXqkCRw1f9/vT/ovbp9v997dfvd+2k6v/1mBdjP8QxEjpMASZSf",
-	"VmEDLft3w4UUxrjI5IoVXRpusLwe+6Ez36nYHCLUcCHLadoI0n5uAfMkyXszknBm2YxYsYlrR/vL2zij",
-	"jtNkbN6J08RIQMJoqiggIYIw+rxtByXP2ZSpvNyGqVxmWKqmb9hEnGSFkMDPqJCYhtDJNnDnpChUoLki",
-	"qIRlGSQSUjTmbBYjLFDC6JhMCg4pYtQQfMYmwjVlvD+gJ2w2wz0BSoBJSH9CF1doTuSUUENM8CHPWArR",
-	"0RhnAlpES2PVQSi9d80Oots4IhJmWlTO8Ic3QCdyGh29OHy5BJ9YNTgzjV/sl58x51gtoKDkzwLsd3VA",
-	"D3Ek5EKfioJp1IQvoxITCvwch7Cq/KzJQ/TRCuh0hU1txhbIzDDFE+BfEDDbifSMTQJ0hkeCZYUE9O7m",
-	"JCDfB7RFwLcy721E/I+9g+9vDv529FIR5JbU+AaPIBPLMPnXYgScggSBMtUECTD0hNi93hagnKXmmyhJ",
-	"z1CrxSk0A0wFOj7/dUCVPIzRDMtkSugEDe+KESQyQ71s2EenfxY4I3LRG2EBaTmTGjZboGfDO1j8fI+z",
-	"AobPf1Kc3LQbUJYDx7oh5qCELxJFnjMuIe2jG8XGiUBTNkd5hikgLCUno0ILaCIQfFB6goA0RmPGB7QU",
-	"uCwHmkwZB9ZP4X5Pd/5Z4Thnmf4R4zzv35UA6hO2p07xZ9VxhNkKEW3A1SI21s4bxXWK+WHt4ZIZCcjH",
-	"t/gDmRUzRIvZCLhCdIXkQCUnIJRA5CALTttER6ZH9ffgZPXRwf6+XqMaXv9SPwm1P8vlEipB8YKl9bLJ",
-	"G7gP4uMbNkEC7oETaRdJlHhMYSUDQ4ojpaq1Rr0BHapp/ofaj7pVgJD9zM05VFhsRKtTGDFN0Zzxu3HG",
-	"5ghomjNCpeguNMqx25ji6dXVxVUUR78fX53XOCNQBbH30a+nv7z7LYqjs/PXF65dbLvdrmSY338yv1yh",
-	"8XncodTrhOOYOUt3IlZ8jTEIvYpgepZMeoZOvpyMuWRpWOxesnR3Aje3s7QpIQYYGfCelbq9v40Pfxz9",
-	"8OOr0WEvn4vR4RcE0TVgnkwvpxyLAJxu4INU9Cp0K8WZLWw0j5qBEHiigHhquZXi+lb/UIJF458eWskE",
-	"xdQ1k0jbWbLwlxNmzEqq0YRkgMaYZJBuzIevGZcXPAW+vF/1CaWEg772Ohak9qrEt5B4lreq8OWoQV6s",
-	"J1IIZVkJ1r/0H2/XLnjLW0kXZWmnFxKjAv2woQr04IbU6H+cAQ9IyWNnihqrpSCsWqnF51zpHUoKqT76",
-	"z2dpAJGnYPqgs1+jAE3pb/+mtJpwX63wOLjqxqFRCE1IClSeUjxSmBkyiMipVdjMcniRgdJ/vJuTZEhy",
-	"MpkAR25Agebq3qz3Xk08YiwDTDVPAIlTLPWpfMNhHB1F/99edZPeswDe09B96xo/xBFlkoxJog0lJ1NM",
-	"aVDeKxD4LVFim9ZA0kens1wuEBlb0lRb0d0WGs8chwuMjWcldEPzhIBdY3zqt6PQ8BTl5+YpdlTT7V/Y",
-	"SJsaHuKoDsqjjyFUvCoy6HQkuuFD7FTSNV2uQLCCJ2CvC+3Lc/O3EYPGPjnFEhljnzqy8jSXqCthNCVm",
-	"jI5bOil7PMT1RYTW5P2ldkh6mSEUoEHh3kSo1WNYNXYRHsd9DY7leDmhYxbF0RxzJfWiOEqUXpzgLKgU",
-	"mqPrDMJr03z1GZ/4J7O8i/LgSjaDW4FcP3J1N+D3OAuPC4otmqFcQ/QM+pM+GkQHs0EUo0F0OBtEz0OA",
-	"d/fFtiXPcsyJUKu0DVGh7qNKB6nm9U5hoohZmygnEvQ/9Rn9qYQa/Bk8CjnlIKYsaxEY5WfL/jWhWNYs",
-	"QpLAXOHUyEbstnMiJ5fVbvBkwmFiwOigd2ihdzANQm8lMlyXCBbAZ/1tYzSYgeQkCQ9pvlWHY35b64Ee",
-	"U4SO3ygcwRH1p2rAjE3Wjmb+EIT2Im9wAkuAFeZkTBGt3WMcjYp0AjKsloWhXrvDLosCaDN1aRqiqcEI",
-	"u0aniHURS7G9/S9d+gOntGRl0OK4si9EG5kKYqupXycsX8vLSt/jtddHc8KaIt7QlEPIyyViqkMTWJ20",
-	"6tjTasPEoT5vfRgPvqb8vqZBV+ZEH2q369DJ+ERaVIsWTSojQqrVl6RSal1rpU1QqWLs7q1YwcckvgOq",
-	"sMgQbUll2nkzI1lGjBPEo1oPiSSTbbJFf/LQtUn7vtVqCYwlxp2wEEEm7X7yvxczTHsccKpUeM/65Jxp",
-	"S0hVNnlHAnLk3dmvlZPIjaWdWtbbOYKM0YkixL6PaEVB0uBseeH21PAkXL4zbijFMr0JvhVW1tSGH2cM",
-	"BwUXjMckIUCTRchZIWRvDmQylZCiUQbmqqlmxjRFM5gxxbclychfRrIsrWVA7WLQcXWn2u//eGjN0z8e",
-	"/ov6y1xJ2jkWKMfECAH1Q0kEYzpY2kfFujy+tR/a33q3A1Q3aCul/fNK2D1w0e/MoWGV776BbRBw5a8a",
-	"0GLcWqQxJxPGm7fm1HaAOnQTn/TSGvM2/3EDRrnvTl4xUFfYiC7GFSMZdoUUDUlRYyBxPWwmKEQaGBA3",
-	"Yjs8AMSeb9w34DouUkONGvHfruKqV5Cw2Qxoit2d4zPy1/UssuDczt3lEn3J2ZiY2/fXQKs1KvpqqIQv",
-	"nfhGoO2O8TvAbXv8S4teidLXdXV2BT6v4/Dbn+hqNlENE96IkO0aY4vp7XWGZakx5sB7FTlqeWDDPfro",
-	"dyKnrJBo6EU1DWPEKAyoF7XlhQmqHoHmKNR6QBshX9Y/0EVzrWt6SxpsA4ZmyBD8TjlnvB2AoD6faE9Q",
-	"8BKnPqOEpaBjYRAbCeD3wFEV2ljZyi9+ue7920HvTe/Fi7Cw1l6V9QxIz+la+xO8JUIQOkFu52hMIEsF",
-	"+rYUJ99qhe1bK1K+Dd6oicxW7tab2d6+Rjh1d+A4Kigu5JRx8pc2WY8ZH5E0BXWwlMnXrKCG9Ok4I5qG",
-	"tQWJ4uxaQ06fh2l7pralqAvSjpfy03tthJfGwNA0ZbSA1xi0FO5XOwscTmXvDZpC9FenKejhAmZUi7Ln",
-	"rebLixzoifalNiRkNSwiAmEhWEKw0sbnRIf3bXg7aZ1LXVvWTLVWZnh8sdNOmxJ1470uS9vO8+1ivyWD",
-	"7rRbWlOJN96rQfZ/JbRln3ekusV48QGmmz8bvWfZPQhreTzhjP6DjZ63T3neyebeZcrVc7TcJNxEBnSf",
-	"OJuVvZ3Oy9eoNj6turbVaZ5Px8gQZ+SARZuXQEwZlzGa4WRKKFSCxvSxl0O3IIMu13iuBHAGEtI2tNnU",
-	"L+eYZrfrdbvh16xTm3/NYs/VgFmMfjd+mo5mdS1Lngy8EaNwMY6O3m9l6l3d6Xcb1FXrc/tkIL5dh46t",
-	"2uq9yxJqIQuhF04gRaJIEhBiXGTZoqvO7alXOzIZ20Xt2GRcBria4WOU4DyHFGGJFAF0tCX/Xcr8rfYN",
-	"CXVG1wpuYhnmGZZAk8Xl4X7twrUKjkujnkmYhUDqxn71mGO/2v3YM8D0jRl/94Nzw41PWGHu3bsdvaKL",
-	"q0edp6CfZ6YQZp/Z6KIV0VYuAAlxTITN9EB4TRBWckfZPIN0AumxXCf1dWCT4gHlVHMskD9GZ1m5Mvqr",
-	"8sMYL7DvzLdhL24FobG3CV5ZNZ77tn65XUa5Mfs4JidMyGOKs4Ugoj387PjM2HewbalBXsHCaXrLM3sR",
-	"Z0tTXyV45YxXJ8fbzLNdRJQ2HEAABOfqz01dei2cOQh1idganV3/zqgsJJbF2l07Ar42rbdQtr1Nd9S3",
-	"3eltC4pygE8IvXP7vixkq06+a4LdKT5td7zLCqT68+06ALWGETzx6Sc+/cSnvwyf/prY6HW5ieCVVxYi",
-	"gOPljTqR5F5N2GAFJShD92w385Nd5Slwbjd2kSZGtXpCXbvV4XNVs442kfIutSOLSJX5sWOjiL+zLuaP",
-	"N2xSetJaLokuX3XR99gWpqn+gLmS5HO8EK4SSB9lcA+ZjRmzHjPVzH6vOF5ppFLHjnLO7kkKOvJ6hv7r",
-	"P/7T81eZlgLlLC8yLAGNmJz+VKWLuu82OCBbVC0pECX6lu+xepUtaMImZhNB1sIm7b06+hZXoZo7ET+N",
-	"Z1O9vzyy7Wi0ms5s93YF4rzdyGXqL2ynblMs0QQo6CRPN9POHaYtk6wPWVpdJcLmcHiVIjbY0A7csFtM",
-	"tZ0Ddlv4faLrtev+8rZ84pu6EzK36cWbD72l11NNuMFc27s9N5xic4fndhjQIrj+GdXLzK/a8MkVDLpk",
-	"lzcyyAMZdk+OxK9PYfbIo01XzthEtGoyn+ZCLLXKHanLekGP5T706rFs6UO0Tpovxo5W5e+5BDkLTIbg",
-	"AySF9AP7OJQ5c1Mp8zDG7+Ba+5hEo4aHvG1kyGtjKjCkIIHPCDXRPhVamLIzXmEedNqf9NHBLEaHsxgd",
-	"qP+83Ff/mq4l3TLncDsarqNVRcbdWKyzxS07t9fx2bBLXHPasDtyCdc3va/oUxfmDqcYTOdDv+9Y02Hl",
-	"BKwY+cnjLuUlROkXx4WcXnImdWU8D8QtdyDdHr3o7ys9yHRCjty827FAKYwJhVQxuavXJ+jV31782B9Q",
-	"rzzWHwKSghO5+ANM+YmhjhqjNY37gwQqCKMxyhVyS53ItRhQNyT6P//7hYm+bvgKbCyvjqT/wwQ3h+pC",
-	"uexDvzmysdDvrt7UzClrKzqMAHPgf8xATlkq/ijLiQXqtrhPyPRBkikRYXv6wdHvoyngtFH5bu1KVkC5",
-	"3ZaugABUulIWRCCgY8YTUxzRVDTVkAna00ueu5xSePWmLO60hDO1QHDFrMXR3p4LR+83iprNkrzNiq7G",
-	"+iNcX6ERh+6Hfa5Zj4eJFy5C/u3JJbpugMHj2Yr3dTx6Q0qmxwZ41mDJ9c3HvuwLE8EKPA2sP8TGvVo/",
-	"a6xsJnviSMPaWpJQnhXCVlpaCJLgDCWM8ZRQLJW+oq6GFR+h6YD6lQJNqiWogygrgBAZ4gBJx0KhXp1Q",
-	"7ahoVgnVbF1znUpxq8qDrjSOnM2Cgfv6zzbD1tlItDOnoJTQSb+TwWX5Blf6s3Bqimfg7LIuw1b6HnWN",
-	"MQvmBHOtKdt6Uq4u45XWH5QyKdAcskz9f0wyCaZ+6hEamv7DAfWL5WoNJdbmU8NEpuqLTpmFTICpcexq",
-	"v5mjXEK5FtumV9dvEaMUOLl3QT8+ykn4IN0B4hTnEngfHY9qxtsBtV9Qgill0tOnGIXasjYznboygsOM",
-	"TYaIY1tQCVM0tC2GZYlBVKqa7sIxoApu7qLo/tqynDVmpVDdPa/sXqCwTsbC6EhZ2jLHOUuhHFBhtdLB",
-	"0iLTGNJvsSSdBdSqs0uE05SDENst0bN9bRTi3Wp5VprMu5uT/uNZoP0aapvect94NTjLi2BJff2u91yf",
-	"tT/iVbcGRELlD99HwTz4x7sIb7yC5nkaSLh1xeZYQqdaTz7eOOfxwiYhVkPUkxEVaLXU7qNS9ILJP9O8",
-	"bUCHZduhKWIPCRkTSH/SCY5Lg1m9SNs4mWJWcyJgmwzHRtb19rmOjSCM9nTXbrk+fvruFu6UUIWMnaWX",
-	"+eusZxJv5bzw1lofbRceiloRPC+heXP7fUMlt0nSGxvpvd1Wo2xhiW83NCyjXl7oMsli95HWSV5Y09vj",
-	"DP7OpZXuduSUiLsrwOkvCwnicYb/nRMJjzS+qS/xWGdqRn+8YzXjP9LJUpBzxu+uIAFy/1jwt5PccEzF",
-	"jMhHmWUVzbsSEEsMxjVANo9DxEg7zYS52XAQRSaV0pEwoZ8dss1tLnshYEA9BfzPAlNJ5KJ69UXpypop",
-	"udzW4SB68XJ/NoiGOqLx5PLdgGolKmFcKTTq++H+W+IamMN/HrwMd6zCBLZ8PqS1qn9YJ6gKqCx9AqTa",
-	"rOhWacdxyXoN3sOX+7OWklGez8Gr2dvSfrNqQY+0RY9vNHa5v/+WtC87vNPDYJ9mVZIKTh6ImwPXl9ZS",
-	"SieodRVUAeiG5Sxjk8VpGrJlHFNXOyJFkuPxmCRIBzDZxBsLS6pvhQxhJDGfgNR/WI5gCgn2a6mtdjoG",
-	"TKmtvErsTSe6fj+9V58YPRrQXqWS9cyzSuXvIzT85qPgSamePhzp39em4sWDbf/Nx1TIWptUSNdmqGaY",
-	"YAlzvFgeH6Gh/Xb0zUf7L6XzdB+6uXj4YEpMHKFuiy/bf/NxyoRUg7Z719bHPtcRwDJXq4hJlrDAdex3",
-	"wo1VVX12ylgTQ/qeq67dP9ep7GxjjecshSsYa5avEW3b/s27ibaNOruqHboD0bytIN2gG1tDFdDfb24u",
-	"bQ1SUb2OYoVMnUn1By470fiCzMsl6v5nbtXoWcKoIELqux+RU7SHc7J3f7Bnx9/Tt/KghKing9YXe7gv",
-	"p+qemCg6y8rFIdsn9pbQ7+KHaiaI1md79XizvQrM9mrXszWSSJvyCNMdzNHMJW3chRr2EI1iTm2pqNHe",
-	"9QMl89onXpX+2TAEltP7fdAzymjvxYcPzxur2nwxD+vJ7zxYAOnYiKMmHLjpi6TtHBsSIlKUFY8hdZTa",
-	"bw/3DFocNy4KN7XqzNKHO1tCxTFQ3wZhhY72YRlJEH7m5VP5P20zrG5bOmzzKoi2TtXaKmQaXLfdUEVx",
-	"/oDePwYONLH6i0adFozpI1OWBOeAUshBsWRG0VCtYai1E/Wvn32VxMcL4/+2oec22jutgstTLPGAIqUk",
-	"gLD6FdVU1HPiY4STO6DpT8g3+T1Th/JcjT0mWQapGqMctCz8lWi+pFNgjEPNLtZpNEq7UQPpRZaFulz5",
-	"b1MLC6QpAk6o5Fj/el4N5OkyWKIMsJDV05ZMyKF+x7Ja914dNmrVYsqKLNUvpYH8qXrQdW9YYY9en33c",
-	"yQOekd1qEP0ZYZSSsT5YWb7WGLo3dX2gFj3TU9XPVz/Nqeu/272jhDMhes66ahYlnm9RprctpruPLkvM",
-	"8dxgDfQoBIyLbEDV2oTRr0ubeQmyacBtTgQqKL7HJFN/a9S2XcfKGl55dSXzoOZgFIbGDrheODjgN9N5",
-	"6RDtoOHVdKoca94GSQFl5B4U0m1WRtZ/hjQEJ+tPLUvkt+L18/6mttRwsHOncs8eX25cDBi/yxhOy4fQ",
-	"2skmtOAtubp3u25ydaOCjVi60CR6eXF949RlnOVTXCnNls33SjY/oF6gG5oVQjqOU9nBYwc6Yx7yUwf+",
-	"6z/+04mOAXWDourZ2F6zR0/7d1IjXlhufPt+OUptY4oRGZuXajmYlySFtUrp4D91WxY2O5kVydT8s6qA",
-	"GeB+mwd4Wv2tc7SbBdupo1s/2tk83tTyHlH5gJ/bF9vT7M57jJcVUhDrjC6vUwPqMPpZnRczpaqOe7n1",
-	"fz7vo1/NQoR536iohwDUE5bVQiwjEdvswTIbZK/xHkvXuwusJbiSDUJaG3Syk8DWzQ6/GRTurSAcXtqJ",
-	"3Cvn6vKym+pa+YpzHyntTxiy0+hkw23ME6LqZqifjdQPfc6nRBGPtXXNsXehSgvuvO7h+zu6lliSpFzB",
-	"gD6bO75oFEZ9uZ9wnE+1xnZ+cVMpM+51abfsnxCRhvuMYEDHIJOpfv/UvAyYLSoFwGPox5dnQVJX2+5s",
-	"Zw+ZBkO2fAXVbQfVd7dgoaPZDJv0zk0Q3PZaQjv79w7I1ai4jLNs67SQ27ZKyX6NaN9hextYTgWHponB",
-	"Bs+ZP49qgSBVMXjvEXMT9jbLC2mKJ/RXSYJujL3MiTL1AjoXJ6jYzs4SS/ylhI75Osf0jI7ZilBGkWPq",
-	"HpLEivaTgPHaPRAMK4LwQvJAc1Q1gTdAYJmpff3ovCX8Jm28jqSHJBRRTFmVYLIU8rIcaLOR1FezdJb2",
-	"OVZ6qYZ3iwfftDBrDz986Nwzx58A7dLFsxriYsVCV6xQfepW59YCLzhCt2CJ1hE2FeAbnWO3IiLqnL1K",
-	"QEG6a6vkcapTenQsfq2eh1pmjMYsy9jc8TUl3G50xJPkC3MwZlg0YylkIUtdCiuLh+i66N6MfXRhDBWD",
-	"iN0ZE4cuKa7+yTgaRAUVIAeR79dgd+qHLQquv7eY4lqqe/8K95CpVffGOFFbbVzH7VK9Tn10s8hJgrNs",
-	"oa4BRnfR1yu9HyKqZfe7xcHcKEYXZo1W+ujcCcclW/jipoxLD/P4nEtP0xnlp1joCu8rih9huiiZbrWP",
-	"KdY5LaYEvTm0sPLOGfNY4zLfs58dZ2lt0Br0qtbW5jCoJYyphqK2iyC0N+Yxm0Fct25jvwa2Yf6rv3Vj",
-	"n43NraUFBd9fQWKSifarxpPW8KQ1PGkNj6U1lHS4Lhlcc7HVRZNMk45hzeU1YUdh8SWXfZQUcD36lsnf",
-	"GsRfLvfb2jvqpFpa1MY4E11Mag3eWLrsSpOPb1LTg4bF8lPdtf9eZSRqyN3GO7ahZy3fH4+gzfAdKNoq",
-	"QGtYn23TkfdVF4FOsbShsiZLMF4dKiCxuGvVZF2VtKuiTdvd4CkyTWkmRfpabdes7hedIntcyKn6ZRJm",
-	"Xzsc/cfvN0vk84/fb2wSt34iu5ZK3UdnlitpRNGtLD86riWem1RvhAX61iwAaYdAorsY38C3fZ2lqxaq",
-	"GJVuVWGBjqZ7eNBc1FzbtCXb+BeNA9T37t0Ani0ngjbqHZWZz8eXZ1VNO+fG01ZxQwY240rEA+qw1ZbM",
-	"095nbY0uT8L0q3Ct9JeJJYeZGtDLONX5ZHowhweiP6BnUj/pPuFYcXsdueMs4dZAj0ckI3KBZiwtMjB8",
-	"H2RiirTiRBY40zEW6J7gAVWbVXdp43JxeaOMCweCMiPYjtcf0AG9mdoEK/vCZi3G4luBvvsuL0YZSb77",
-	"TkEzRtZxYNNfZ5i44gMDmitebCLLcTLVd3455ayYmAVbl1Efnd4rDmTenDc4xMEFaAiEB/QXv8IAfEgg",
-	"l2i4NwWcyenQ+AIykoBlhBZJjnOcTAG96CsWU/DMS86fz+d9rD/3GZ/s2b5i783Zyen59WnvRX+/P5Wz",
-	"zHuULWpBpyiOFJQM2h309/v7rngBzkl0FL3s7/dfqisTllNNlnt9hQW9O8rmdI8pKuuVKfw9vwKBDf1s",
-	"On2VHBboU2pYxAPasKt7xzvcmyX5sKSNvi4WkGRE+yMdshGFUgOaEpGU4Z7B+hOlg1/n5BtFQqtjGtUu",
-	"NSIpJLQJfYbXHCFsZ3SuIWRwR/XGNgN7BGPGARE5oNo+YZDD4EKJSeoSE/0Gck2FEH250nJUn9CL/X3H",
-	"dmzYDM7zzC5u79/tY05GsKwTO2tm1nwuVJ1kxanW+H109P7WcyipzaL1IyjhNBFKrFw4UInoVo3rom3N",
-	"8y0m2FYLvmAAjNZB/KJ49lGZ0msXeJSxfjh6BPPATlTGhP7C0sXOTiDwmNRDXbjaomqPhgOh94MCB3+6",
-	"4pWghzj6vtOKygSM2vuZUeSZabd7q9JyQe+9yYe46/5r73wGdn5G73FGUscbzG4PdrRbNzjjaGY3rlmF",
-	"t6nau5m729a7xrDf77/c0Z6uC/PknlGtPiz+skEXihNSZuoMCSWTFM+8JzB3hMnGqIruGjMWIxejNcI8",
-	"rko3oBH+S4mMUy/mJzXmfJfLa2FXPTK6O8C99sc8/BS8t+++nvb2D2oA9DYQegN1l6htQ93M8Kgc/3Bn",
-	"CO7xDR2CRZlEpHq/1el4CaNjMikUvWv105YK8SDRePd1d0A4ZxLVRvZjIKwQAScDnGSyQqEmldTCu8mk",
-	"SsPuLobesMljCaGlwqifWQQtV54MHNOb1gqTT+LnSfx8kvjR5PhPKnze9F68+qqET4D7Zob1Od6rOWGN",
-	"89ay79Yx35q5pDv/ddk5j8OCQ/VgPzMXDtYODZybbfeJvPhLc8cvysa+HDP47LQ7K8nGka8jJJ+CbUKA",
-	"fuCrIxmbtptS8bHu9UhEbAb/kjRcW0H78ZlmTxT8RMGhq99n3L8tr4DeVTlvQS6CHdk6JmLpOMBDEiak",
-	"2KvcIHsfy38/7PlOj72P3q+HtTZtjMYZlqV/Lwfeq7JIdPkTU8VTlOUzynkH1AYpab8CuQfqe1/66J2A",
-	"KtdS3y789FLJkCn2OaClsdq4cIYTjmmRYU7kQrcTeUYkApxMaxXnJDNO1VGR3IEULWboUsM9URDUTgGO",
-	"ZyB1XeeWKPyqyd5rQi9yUT1Z0lYyfKmLp0h372R18+4dyt1173Jd+r832Eu6WYffqhO0WQuPJBnUoa4U",
-	"CSVmh7G6/yQYvphg+H7/+8838zmT6DUraPpVKpUn7SwXVwz3/29UdrRCw5DcDoXGXr1uqFgrRDiZTGVP",
-	"kL+MianWueGvdwEMZTXRAa0JjVPF5Rt1S1VvzKtX7SrnWlkGRBf8NnXVEJ5gQi0U9SiQuro3tUrPZf5d",
-	"Ycot30xhQNsFlrH1albnyle70LAik2ZTeAZojhdapC1QypyHXh9E6d+t11mY4YWJuTf1CVzx1XIduriD",
-	"YOpbi4i7ahzXk4z7FBn3mOKqpabvSsG1iriexNeT+PoKxNfVOv6PkZcvb9McauWU14qy8jnXbmaU6lnZ",
-	"DS0pZ96zsY9hTAm/CP2Z7SktjwgHT9/B8cmq8mRV+X/DqlJ7+dkyloqsV/KWj+6fZ6k2nTT0qOV416py",
-	"ePlqvWSoyFOsH5Yjql2O5TRydYSiaoaoSfK+D6oZmHwbR3kRYHfv9FRIZ1/ZBRDajd+ZrmfVU/ePye8u",
-	"C/mFmZ1ewXpOZw/vidH9M6pZJRJQJtH4a9K3vjpeaxkPqdhHJ17bVhyrXaFzRgb9Jgy5t5VvXSGdsihP",
-	"Xc3UqbNLNumjAcXlvUpXmUHP/FQCGxwv4qryXpmv8FwbBKruuvLNgD4rrQjWJOFqMdmC1X5xa/E8NlZs",
-	"nWawXBx0QJ+5Eq8JK6iMbfq3/WHLvnpVZ8Xzqv7KcgngAa3XAA4rvI3yMI8kBlrqq31mUdBW9ilAAFfN",
-	"ok9P+u+T/rs+LqBZK8xji01CCzBHV0Wu597qWml11e8bmqhS/d6ZCTvleO4nB3hvJKIeso8bxl69Qf1O",
-	"Yuw9KdhDWJe4Q3APfCGn9XwVlw2VZ5iCe9BQ9Ad06FdC9IJGtQFT959T4GJK8l4yheQOUsPXgOeYy3hA",
-	"a7soiyBWbptmOURChQSc6qSWt0UmSc88dGtMswJdXFVFFEo9Xo9yfP6r22Ol4Otx3EOE9q0H/4FB98Yh",
-	"OAM1T+17hwqwplqrjkgrR/m58QqpBtm/vPxVgZqzTP8cIv/FQ5OEqgdTABxQbbyo1WzVXUvoO1Tuo19A",
-	"nRM2q7TLZzzWZagTNpthMaAzwFRv3n9M8OKqxarsvyq3sUnZ73zSeFGzg0nW776RXdrveGlf8tuw20nt",
-	"ycwNO9unxjbtxSZv4H6LjiZT9nLKsdh4qRvZyP2OG3iDa5vUGfGbLrLMRH9Uu3zwBcWAIHDtDN/lSm2D",
-	"+4ZS8GSTf7KK7SqQPa/hG+agL6aiegV8YRIzv1xeSR9dF3yME79oup/qoouHGxWClCVP+YBiKuYu0bm+",
-	"S1dvUl2R0OH+gSmJIZT+oCRVSOuqDbAqpNrqWSbNvJsnwdZn2NCNcOPqJDzGZSpQaOUzX6RC1TACuGKa",
-	"PV2dnphkh6tTWVrEUa+loXb6/WhrvT3s6bJF3ejZ1E8y1iJTDm5D0tZFpF4zfmOLwG3gI3B14wJuAVe2",
-	"bkOfwH9j9hIo1hUyVOrjfOIwTxxmPYdZIv1PYTYfTcG+9gjr30Ci1BR9tOVOc0y3ZDy/gfRqSH4VzCde",
-	"PZst8ReYzBY63JjRPTavaRbobGE25Zk+8ZwnnrOK56yl/zbuY0ostfKVkykkd+alJd2wUeq6yUv6S8zk",
-	"72b8T6SpRtXMskhn9RqtWd6iS53cdgckEciNs4UPtFF8Up9SbY0sB/sozxFKGKWQ6IjjMSYZpKurkVaD",
-	"FHRXW61GWlVvyBwg0mZ0D4nsud4+NPrWq9K9v1Xs1Pb5uFyNwFm1fN9nxbz1jXqZ9zerEa0exFaZWB7m",
-	"hOknkQSZTE1M96rg19DINn5weWQfZKGOFnYPtw//NwAA//9JxHuZgOQAAA==",
+	"H4sIAAAAAAAC/+y9/3LbtrYv/ioYfXumSb+U7CTNPo07+w/Xdbq9T3742s7pzC19K4iERBxTAAuAltWM",
+	"Z85DnHe473Ef5TzJHSwAJEiBEqXISe7e/qeNTBI/FtYvLCx81sdBwucFZ4QpOTj6OCiwwHOiiIBfryl7",
+	"X8gT94b+U0pkImihKGeDo0H1CDE8JyP0a0YYkkRFiGEh+EIilREkiCw4kwQpjlRGJZKUzXKCqq5H6IL8",
+	"UVJBJBoXgv8HSdR4NIgGVPfxR0nEchANdA+Do3q8g2ggk4zMsR4WucPzIofnGUlueKmGkohbmpBBNFDL",
+	"Qj+RSlA2G9zfR3Zipyy9orrR9rRO75K8lPSWoLIoiEATXrIU8SnMJuFSoQVlKV+gJxevT9CLFy9ePR2h",
+	"t6VUaEKQ7iZR+RLNBMGKCKQyzJBUWCjdW9e8iB1MNBCGFungSImShGf5/PD5X4aHL4fPv796dnh0eHh0",
+	"+Ox/DqLBlIs5VoOjQYoVGSrTXvf0b6ngbB5cWe+hWVs37AKrzB913Ua/kReCp2UCvXQP7ReBWZljQdVy",
+	"dWjAZIUgkjAVIYKTrOYkpLmryKlClCmOONPcl3CRIr2OmiBoUiY3RCE+jZllxj/JCH2Qmvni8vDwRZLw",
+	"kin4JzF/KBm1v8eIcYX1QNAiI4Ig/Uh3qnviUzTOxjF7kvFSyKcRGqdj9CTFS/1vLtB4MUZPFoTcyKcj",
+	"9JoLZKmCxs+ycYTGz1P93xeL8ShmHVwy8wgTpu+zdBDpRVJE6O//12/Phq+ufzscvrr+7rcsXVx/s4bs",
+	"7/CcyAInAZGoHq3jBlZ9348XUjLFZa7WjOjcaIPV8dgHvfVOreYQZUYLWU3TJZD2cQeZZ0kxnNNEcKtm",
+	"5JpJXDrZX53GGXOaJueLXpomQpIknKVaAhIqKWdPu2ZQ6ZxtlcqLXZTKeY6VfvUNn72muSLi33FeEmn+",
+	"vTrzq4ygKTzTy5NTqdAtfICmXESwrinCZiFhXqiyTVqjKoSThBR6ORUaxmxc8FTz6BiaMp/Z9uBt1xW+",
+	"IXIUs5i9Z/nSUpmLlDKs3HgkwoJAMyQdoXHOZ2/ILcnlWMs5RlN6R1JEWDlHGCU5JUzFDOeC4HSJbhhf",
+	"yAhhlqJxjif1V5LkJFFcIIFV5oyCbozkKVpQldnRdou+Gdz6pWTlfHD020DzlCLijEmFGUijL5mWUoNo",
+	"kHCmMGVEwO/ryFfT1Uu9V/otvjP/CC/2HN/ReTlHrJxPiNA87taHI0FUKZhWkikRJEWTJRqDFh4j3RBh",
+	"KWUzvVosZmP4bIxw9fchkhxhpETJEqxIargp43lq+GBSSkqkGqF3wFSKa2u8jFlKpaIsUWgq+ByNczqn",
+	"ahyhRUaTzKyasx14RsBOwMJmWCLG0ZxgpnvXZqB71eYVUfyFcorv6NnhYTSwlIFf+idl9mdFfMoUmRGx",
+	"jvrw30uCRZKt0v8C6Iu45nlLdbv2hq5UIkXuVIQSLMmQMkmYpIreknw5Qlf6MZUo4wuEY1bQ5IaIStFi",
+	"LYESlVIz9bIglvuNVVxo0ZtrmUMYZXSWDRMMwpZTtYyZFcpS4klOkJbpPD9CtShzLSKTUi5RkWNGgPJz",
+	"LgiqVq4WcRYzzJZm6WXGy1yr0SkRZjhqWZiZCkJQkmGBE5D0pDQaRPMEnxOVUTaLWZJxDmMCTfFzk00k",
+	"0Pg8E1iSilt8s/Od4Rr5naaxpMDRhooxa7xnBv+d5X6Smg5UxqXzWtaog1tvvTs8Yc6U4HkOSmOO794Q",
+	"NlPZ4Oj5y79skGp50lIgq46/ecHZWRgrWmiHKNE9JsrOJtL8kXA2pbNSCzZnxmHL+Uy6V7kYxeyEz+d4",
+	"KIlW8oqkP6L3F6AWKTMkIHdFzlMyOJriXJKOrcGK2guQpdKOz7TCo4rMQV816PNihT5AwDPz8vPD6jEW",
+	"AusBlIz+URL7XGvl+2gg1RKWQdN00KZvQ/EGtlX2MZhBOUJrqNOXNo0eOygzxwxrNfPlCLPblizns4Cf",
+	"hCeS56Ui6MPVSWB/FrOODVqnyO2yRfth+Oz7q2f/evRCO1S7eVPyDTgSqzT5t3JCBCOKSAS+Ru1k8FuY",
+	"FkEFT80zWYmekVbLU2DFJDp+93PMtCGL0ByrRGtBNL4pJyRRORrm4xE6/aMEpT2cYEnSqidpbMqT8Q1Z",
+	"/tUY5qc/ak/cvBczXhCB4UXtVDGukCyLggvldKKzLEbDY6UEnZSwwaISkTu9z5MkjbRXGLNqw8QLorW0",
+	"IHyUktsD+PivVuHBjwgXxeimItCI8gO9in/VH04wX7PFMuTq0Kkb+91a1b7RXsfq2r5d8ZY0kxOmBPVd",
+	"pi7XH3yZh3A55BvnDq+O+Q2fIUluiaDKDpLq7U1K1iqw2isD1ovZWHfzP/R8LsgfpXbcPBecM+u0uw2/",
+	"tu4LLm6mOV8gwtKCU6Zkf6NRtd2lFE8vLt5fDKLBr8cX7xqa0XnbP5/+9OGXQTQ4e/f6vXsvsp9dr1WY",
+	"33+yvlyzY/e0Q+X9S6cxC57uxaz4+4og9WqBGVoxGRo5+XI25txubVZjCjzdn8GtN1BhJ6RyzobW6g7/",
+	"dfryh8lffng1eTksFnLy8guS6NLzcQO7OXJnPGZ4S2tmSxvQUXMiJZ5pIp5abaW1fmO7QVABTWuboJU6",
+	"KIm0WyX7LneHYtZWjSU0J2iKaU7SrfXwJRfqvd5+rs5XP0IpFQTClk4F6blq8y0VnhedIZiq1aAuho40",
+	"Q1lVguEX/PF644B3jCr1cZb2GlAyLtBftnSB7l2TwP7HOREBK3nsjhKmeigI67f04Auh/Q5thfQ38Oez",
+	"NByWgIfo7OdBQKbgGWysw9+Cw+PoCi+HWqEsoSlh6pTpLWUaDGjbmJAbjihzov0fb+ekOFKCzmZEINeg",
+	"3l8TZuZedzzhPCeYgU4gCqdYwap8I8h0cDT4/w7qSOiBJfABUPete/k+GjCu6JQmEOg+yTBjQXuvSeC/",
+	"qTfW8GqDJCN0Oi/UEtGpFU09FfhsCXzmNFygbTyvqBvqJ0TshuLTv52EhruoHrdXsaebbv/CJxAqvo8G",
+	"TVIefQyx4kWZk15LAi/eR84l3fDJBZG8FAmx24Xu4bn+u4QBuA+ipuawRi9ZtZor0pVwllLTRs8pnVRf",
+	"3EfNQYTG5P2lsUgwzBALsKBxbzPU+jasG7sMt+OeBttyupyyKR9EgwUW2uoNokGi/eIE50Gn0CxdbxJe",
+	"mtfXr/GJvzKrs6gWrlIzuJPIzSXXewNxi/Nwu0SrRdOUexE9IaPZCMWDZ/N4EKF48HIeD56GCO/2i11D",
+	"nhdYUKlHaV9Epd6Pah+k7tdbhZkWZjhimikC/4Q1+kMbNfJHcClUJojMeN5hMKrHVv2DoFjVLEOWwGzh",
+	"dMvG7HZrImeX9WzwbCbIzJDRUe+lpd6zLEi9tcxwWTFYgJ/h2dZsMCdK0KQj2g/P6sUxv230ANqUoeU3",
+	"DkewRXMIVDWY89nG1swfgtReFi1NYAWw5pyca6G1c4wGkzKdERV2y8JUb+xhV00B6Qp1gQyx1HCEHaNz",
+	"xPqYpcju/lc2/X3OZMAc1/GFwVahgsh66pcJLzbqsip35NL7BjRhwxFvecoh5hXKHBy1idXLq448rzYs",
+	"HPrxzotx73vKvzU86Dqc6FPtehM7mTPtDteiw5OCUxE+rUWl8ro2WpugU8X5zVu5Ro8pfEOY5iIjtJWU",
+	"weH7nOY5NYfYntR6TKS46rIt8Mhj17bs+1GrFTJWHHfCQwKZdOc5/a2cYzYUBKdwUpU0055CIli98oEG",
+	"7MiHs5/rQ37XFhzD2RPHCck5m2lBHPmMVpY0DfZWlG5OrZOE8w8mjUCrTK+Db6W1NY3mpznHQcNFplOa",
+	"UMKSZeiwQqrhgtBZpkiKJjkxW03dM2YpmpM513pb0Zz+aSzLylhiZgeDjus91eHoh5c2PP3Dy3/Rf4HT",
+	"xAWWqMDUGAH9Q1sEEzpYmUetujy9dRia3+ZjB1LvoK2V9tcr4bdEyFFvDU3W5V61uI0EUrHWNWg5biPT",
+	"mJUJ881bs2p7YB22TU7RyhiLrvyfFo0KPx1oTUN9aSP7BFeMZdgXU7QsRUOBRM20x6ARaXFA1MrN8wgQ",
+	"eblNfgDXaZEGazSE/3qdVr0gCZ/PCUux23N8Rv26WUWWQti++2yizwWfUrP7/hpktSFFX42UiJUV34q0",
+	"/Tl+D7xtl39l0GtZ+rLpzq7h500afvcVXa8m6mbCE5Gq22PsCL29zrGqPMaCiGEtjmAPXGoK+pWqjJcK",
+	"jb2s1HGEOCMx87JuvTRv/UXgdRR6O2atlF17PtDHc216eisebIuGpskQ/U6F4KKbgEQ/PoGToOAmTj9G",
+	"CU+JyezhE0nELRGoTk2vY+Xvf7oc/vuz4Zvh8+dhYw2nKpsVEPTp3vY7eEulpGyG3MxN7qFE31bm5Ftw",
+	"2L61JuXb4I6aqnztbL2e7e5rglO3B44GJcOlyrigf0LIesrFhKYp0QvLuHrNS2ZEn01zCjIMESSG80ug",
+	"HKyHefdMT0tLF0l7bspPbyEIr0yAoR3K6CCvCWhp3q9nFlicOt4bDIXAU+cpQHOBMKpl2Xed4cv3BWEn",
+	"cJbaspB1s5C2KCVPKCRCLiikZ2+5O+nsS29bNnS10WZ4erHXTNsWdeu5rlrb3v3tY76Vgu41W9Zwibee",
+	"q2H2f6OsY543tN7FePkB5jO/N3bL81sibeTxRHD2dz552t3lu14x9z5dru+jYyfhOjKk+8TerO3ttV6+",
+	"R7X1ajW9rV79fDpHhjSjIFh2nRLIjAsVoTlOMspIbWjMN3Zz6AZk2OUSL7QBzokiaRfbbHsu55Rmv+11",
+	"d+DXjBPCv2aw73SDeYR+Nec0PcPqYEseA7wDzsj76eDot51Cves/+tUmdTW+uX4MEF9vYsdOb/XW3fLs",
+	"EAsJA6ckRbJMEiLltMzzZV+f23Ov9hQytoPac8i4SnA1zUcowUVBUoQV0gLQM5b8N6WKt3A2JPUaXWq6",
+	"yVWa51gRlizPXx42Nlzr6LjS6pki8xBJXduvHrLtV/tve04we2Pa33/jwmjjE16affd+W6/l4uJB+ynZ",
+	"5+kpxNlnNrtoTbaVS0BCAlPp7q3gDUlYyQ3ji5ykM5Ieq01WHxKbtA6oulpgifw2etvKtdlf9TmMOQX2",
+	"D/Nt2osbQajtXZJX1rXnnm0ebp9Wrsw8jukJl+qY4XwpqexOPzs+M/EdbN8Ekte0cJ7eas9extlK1xcJ",
+	"XtvjxcnxLv3slhEFgYPQ/cR3+s9tX3ojnQWRehOxMzu773uzslRYlRtn7QT40ry9g7PtTbqnv+1Wb1dS",
+	"VA18Quqdm/d5qTp98n0L7F75abflXXUg9Z+vNxGoM43gUU8/6ulHPf1l9PTXpEYvq0kEt7yqlAEer3bU",
+	"iaK3usOWKqhIGdpnu54f4yqPiXP7iYu0OarzJNS9tz59rn6tZ0yk2kvtKSJS3/zYc1DEn1mf8McbPqtO",
+	"0jo2ie6+6nLkqS3MUniAhbbkC7yUDslphHJyS3KbM2ZPzPRr9nmt8aoglV52VAh+S1PAgCBz9N//+V/e",
+	"eZV5U6KCF2WOFUETrrIf6+ui7rlNDsiX9ZuMUG36VvexMMoONuEzM4mgauGz7q96ni2uYzW3Iv41nm39",
+	"/mrJdpPRujsz3es1jPN2qyNTf2B7PTbFCs0II3DJ0/W09wPTjk42pyytR4mwdzg8pIgtJrSHY9gdutrt",
+	"AHZX+n3i0Wvf+RVd94mvmoeQhb1evH3TO5566g636Gv3Y88tu9j+wHM3DugwXP+M7mXuozZ8MoJBn9vl",
+	"rRvkgRt2jweJX5/D7IlHl6+c85ns9GQ+7Qix8ir35C7DgB7q+NDDY9nxDNEe0nwxdbTu/p67IGeJyRG5",
+	"I0mp/MQ+Qao7c5lSRZjj97CtfUih0c2ToqtlUjTa1GRIiSJiTpnJ9qnZwsDOeMA86HQ0G6Fn8wi9nEfo",
+	"mf7Pi0P9r2yj6FZ3DneT4SZb1WLcT8W6WNzq4fYmPRs+EgdNGz6OXOH1bfcrsOrS7OG0gum96Lc9MR3W",
+	"dsDLiX953F15CUn6++NSZeeCK0DG80jcsQeC99Hz0aH2g8xHyImbtzuWKCVTykiqldzF6xP06l+f/zCK",
+	"mQeP9bskSSmoWv5ODPyEwSNlDY/7ThEmKWcRKjRzK7jItYyZaxL9n//93GRft84KbC4vZNL/bpKbQ7hQ",
+	"7vah/zqyudAfLt40wikbER0mBAsifp8TlfFU/l7BiQVwW9wjZL5BimsTYb/0k6N/G2QEpy3ku40jWUPl",
+	"7li6JgJhykFZUIkIm3KRGHBEg0gNlAnG0yudu3ql8OJNBe60wjONRHCtrOXRwYFLRx+1QM3mSdEVRddt",
+	"/R7GV2jloftpnxvG43Hie5ch//bkHF22yODpbK37ei69ESXzxRZ81lLJzclHvu0LC8EaPg2MP6TGPayf",
+	"DVE2c3viCGhtI0moyEtpkZaWkiY493COZQRbw1qPsDRmPlKguWpJ9EJUCCBUhTRA0hMo1MMJhYOKNkoo",
+	"qHUD/Fs5bjU86NrgyNk8mLgPf7Y3bF2MBA5zSsYom416BVxWd3DVeRZODXgGzs+bNmzt2SNgjFkyJ1iA",
+	"p2zxpBwu44VDg8USLUie6/8boFx496gClm6iyYKHYsFuQYlk+glcmSW5JAaj3mG/maVcYbmO2KaH67eM",
+	"UEoEva3BamuWU+ROuQXEKS4UESN0PGkEb2Nmn6AEM8aV509xRhrD2i506mAExzmfjRsg22P7xriCGESV",
+	"q+k2HDHTdHMbRffXjuFsCCuFcPc82L0AsE7Ow+zIeNrRxzuekqpBzdXaB0vLHDhk1BFJOgu4VWfnCKep",
+	"IFLuNkQv9rVVindn5Fl7Mh+uTkYPF4EO42cHfDDmnEHcQI+PzKFzxhdojtmyQj/W4rzUajIQoy5ZEOLT",
+	"7iQbLVSA3NB35JD1/IMPd1n+LV6iiRapohD8js6xIgYyu4207cZvSlYAJDpObvTmETO5IELaDL6YFVgo",
+	"inOkhRLBuCMkOVKCYIWo0roIMxMDAexzahE4MZKESeBzmeCcxKyJcw+7aAfKaQ3/98+ee4tMmfrL94NN",
+	"caxNjnuEyB2G6iuAS44WAAQ+0U48UzBrmIIlyKjhh/SBZNzEgGZ8kV3y/uwnu+Mt0x4FFDIiq3IHBjoC",
+	"KR4hkmTc19Q2OdbA5bvSBRlmaa4XE1Q8zpEBeNfsyKy+xK0SPqCsbRUGeePgF3oUD9gmjKN3mKUifiWH",
+	"ViinoSRW+OewM9BzQXIcTgVyTvoY3jMrMzZAxDhR6MmY/DF+irhAuIGs+GQ8U2T8dIQgSRcg5NsI9Y4t",
+	"KcDlk3yq5YjcFXrjdUsaaE9ahGMWkGGSp8bAz7lUToSllWHkaYF8CVKLY2bjUlwgIhU8S41Y64GAH6Ft",
+	"hi+rBZaSAHa+lhQYtl1eG/YB7KyZIuHIcE23wBbBqcw2cYDLIuN3Us1vykxxXFVPGBtweYeUP4rZBcEp",
+	"UnxmFgxU8rixumM0NIrU1SHIidKib+sXSLxE8eD7Z89jBiUFzFAidENIUZUL4BbYPx40aCRpbo6LbQEK",
+	"qiTkCLRgSPqx5O2amhktQvUpkIFW6mMAsYyFgbJFmsIKlAfJU4gGGB/NAXQLYo/cSXqEGEdkXqjl0Kxx",
+	"zMBKR2hCElxK/YFTQsZWGoVr4MFrl65X9LfDMG/amlV1UW5dnQ2fCdsiX2mgDbpZbhsAf+PBc1cx4sox",
+	"H+1AhIeMgu+qOvcXI996BG1Xz1DCjSsyyxJa1SYuydZwCO8tPkHdRBOnQJMWNvQjVO3KibmaDtuemI2r",
+	"d8emPhlJ6JSS9EcwoyuN2ZAJHH9yrXQWVJJdwA9agCy7wyC08jO7kTD6XQP2kT12yLQIgWft7ea5P84m",
+	"yMhOeQ3eWJut7SN5oYGP62GdbH+034rWWfyUrc/vvdnWrexwSN99BrHKekUJFRTk/i9hJUVpT+UepvEP",
+	"DnFivy2nVN5o5+inpSLyYZr/VVBFHqh9Az31UGtqWn+4ZTXtP9DKMqIWXNxckITQ24eiv+3kSmAm51Q9",
+	"SC/rZN6hQwVqmNnzL7uLlRGCfBpbcEwQWeZ67wWXI0aoet3C3JSSxMyLzf1RYqb0vqoq6IklMkrJwV6M",
+	"48HzF4fzeDCGyw4n5x9iBk5UwoV2aPTzl4dvqXvBLP7TYJy8J0Ajsa4zSRuAwFjZPX51CCiJ0pOV/UD4",
+	"nJZswvO/fHE470CT9NIRPDj/jve3AxJ8oCl6eqM1y8PDt7R72OGZvgx+0wYsq+nkkbjdcHNoHSh7Qa+r",
+	"ZJpAV7zgOZ8tT9PQMccxc7BSKVICT6c0QZDbbO/kWloyCBhDlUQsZkTBH1YjlSHDfqngQA/Sw7XbKmrM",
+	"j3QGpX3YrX7E2VHMhrVLNjQVc6vfR2j8zUcpkso9vT+C35cGDOvevv/Nx1SqxjupVO6dse5hhhVZ4OVq",
+	"+wiN7bOjbz7af2mfp3/T7cGTO4M+dYT6Db56/5uPGZdKN9qdeLP5WlSTAaxytY6Y4gkPbMd+pcIcuOrH",
+	"zhlrc8jIC+d0p+70QqRvjfEdT8kFmYLKB0bb9fv23gSOTd2Rq226h9C8rSndkhsbcCPob1dX5xaeXNaF",
+	"06yRaSqpUeyAC1zkCgsC+z+zq0ZPoOKjVLD3oypDB7igB7fPDmz7B7ArD1qIJlJEc7AvD1Wm94mJlrO8",
+	"juPabyJvCKM+KSpt7Ihmb68errdXgd5e7bu3Fr5E2x5htoc+2jATrb1QKx4CLObclloa7V4/gKbb3fE6",
+	"ZIjWGWHVvf8NesI4Gz6/u3vaGtX2g7nfLH7vgtiIx8YctekgzLdI2Y/tQRtVsgqPk9RJ6qj7JkjwMHJr",
+	"vNjMujMrD24sulpVbNmLQVijA4chxhKEK8B9qv5nXWeuu6KKbg+QbCEsNwKUArmu+7GK1vwBv39KBGGJ",
+	"9V+AdTo4ZoQMYhkuCEpJAacjnKGxHsMYvBP9r7/6LonPFyY1zt5KsxfB0vreWYoVjhnSTgJxJ6YMpGjo",
+	"zIc9k/kR+SG/J3pRnuq2pzTPSarbqBqtMEET0EtwO9bk2tjBOo9GezcMqiIDwLTF8HSVQQxMJlGmPghl",
+	"SmD49bRuyPNl4DAESwjQawUx1sw+Rlz44z5o0kaP2tZVhuNU9SMaW54ZH4xr7oHx2bqPHvGM7daNwGOE",
+	"UUqnsLCqKsQf2jd1Y0afNO9yPYGumusb6SlBaRg7d5QILuXQRVfNoOTTHRD8u657jdB5xTlehkyLPUpJ",
+	"pmUeMz02afzrKmZekSwLZNRRiUqGbzHNbXnqPqHELLgz+5veknlUczQKU2MPWi+cN/iL+XhlEW2j4dH0",
+	"ApU3ZcNSgnJ6C4fH2yHMn/t3nAJ0sqlWVfWcTr5+Oto2lhq+B9WrEoSnl1sbAy5uco7TqkZqt9iEBryj",
+	"Vvd2122tblywCU+XIKLn7y+vnLuM8yLDtdNs1fywUvMx83Lg0byUymmcOg4eOdKZ8JB/q/C///O/nOmI",
+	"mWtUr5/9Ytj+YgjnO6kxL7wwaX8+UrU9m6dTrRgjrcehyLS0USm4F6B3y9ICl/ASzmCx8sCxA9pv+7sf",
+	"1n/rnQhvyXbq5Na/CGXqOnaUKqxq+7p58QNQd7Ubg3ipJLV5atV2KmaOo580dTHXrup0WNjzz6cj9LMZ",
+	"iDSlD8tmdmATy0QPxCoSucscrLJBdhvvqXSYXWAswZFscdulJSd7ufOy3eK374t5IwjfPOkl7vXh6uqw",
+	"2+5alVU0Qtr7k0bsgJ1sJq6pLq53hlBRGmqA2wQGG+taYG9DlZbCnbqH9+/oUmFFk2oEMXuycHrROIyw",
+	"uZ8JXGTgsb17f1U7M5S58h5m2D8iqoz2mZCYTYlKMiiNbooG58vaAfAU+vH5WVDU9bR7x9lDocFQLF9T",
+	"dddGYe8WxECcz7FBftiGwe1XK2xn/96DuVrFGHCe73xj9LqriIJfPsI/sL0ODKemQzvEYPPqzZ8njUSQ",
+	"uk4MqZPqTEY8pLsBrtJonSXop9ir69IGSqg3blGtdvZ259QfSmiZLwvMztiUr7nlIAvMXCYs1rKfBILX",
+	"WClBJ6U9rwrn54fsAWhU3YHXQGCYqS2M+K4rV6tVOBGapAwxzHh993Ql5WU10WYrq6976W3tC6z9UqB3",
+	"xwm+ecOMPVwT2R3PHH8CtasjnvUUl2sGumaE+lE/CHxLvGAL/ZIlOlvY1oBvtY798MX0OnsggUG56wL5",
+	"OoXbvnBNrwH1pYcZoSnPc75wek0btyvIeFJiaRbGNIvmPCV5KFKXkrW4YlAyxetxhN6bQEU84DcmxAHV",
+	"RvQ/uUDxoGSSqHjgn2vwG/3D1guB5x2huI7CHz+TW5LrUQ+nOIFc9+Z23A7V+2iErpYFTXCeL/U2wPgu",
+	"sL2C+VBZD3vULw/mSiu6sGq01geuVTot2aEXt1Vc0MzDay7opjfLZ1hC8Zc1uIiYLSulW88jM1cWTHUa",
+	"s2hh511w7qnGVb1nHzvN0vlC530YPbauA4PGXXL9omzMIkjtrXXMdhSHt7vUr6FtWP/Cs37qszW5jbKg",
+	"6fszUZjmsnur8eg1PHoNj17DQ3kNlRxuwokBLbYeT9G80jOtudom7CktvtKyD4IOA63viAsDJP5ysDA2",
+	"3tEU1SqiNsW57BNSa+nG6siuCvn4ITVoNGyWHyFZ/7EQphrM3aU7dpFnsO8PJ9Cm+R4SbR2gDarPvtNT",
+	"99UbgV65tCHEsxUar08VUFjedHqyDkD1ouzydreoUgqSZtBTLvV0zeh+AvSM41Jl+pfB0njtePTvv16t",
+	"iM/ff72y+C5T3kZZGaEzq5WAUeAtq4+OG5g0BgUGYYm+NQNAcCCQwCfmbODbEQB46IFqRQVv1VwA2XT3",
+	"96BFzbYNItnmfNEcgPqne1cEz1cxIlpQiBUoyvH5WQ13647xICpuxMDeuJJRzBy3WjRdOH2GaHS1Eua7",
+	"mteq8zK5cmCmG/TAKOA+GTTm+ECOYnamEIiAwFrbQ+aOi4TbAD2eULjIOudpmROj94mylxFxokqcQ44F",
+	"uqU4Znqyei8t3ZVjAI7gQjoSVGAhtr1RzGJ2ldkLVrb4diPH4luJvvuuKCc5Tb77TlMzQvbgwCJjzDF1",
+	"uEQxK7QuNpnlOMlgz68ywcuZGbA9Mhqh01utgbRkOR4SxCVoSIRj9pMPPkTuElIoND7ICM5VNjZnATlN",
+	"iFWElkmOC5xkBD0faRVTitzD7VksFiMMj0dczA7st/LgzdnJ6bvL0+Hz0eEoU/Pcq9c66GCnQTTQVDJs",
+	"92x0ODp0uEa4oIOjwYvR4eiF3jJhlYFYHow0FwxvGF+wA66lbFih+wx9cCKb+tk+9NV2WKJPgbeKYtaK",
+	"q3vLOz6YJ8W4ko0R4AiZi+6yYjaqWQpuaCdVumcQmqo64Ae4HuNIgDsGrHYOjKSZ0F7oM7rmqLpa746G",
+	"kOEd/TW24CwTMuWCIArX7yXgI9wQZnih4iS9iRn8QtQG8DDYXIEdhRV6fnjo1I5Nm8FFkdvBHfyHrfNo",
+	"DMsms7OhZ9BzIeCyNava0PeDo9+uvQMlPVm0uQVtnGZSm5X3jlRycK3bddm2prKbSbYFwxdMgAEfxMfL",
+	"tfXmqlO7QL3m5uJAC6b23qDKCf2Jp8u9rUCgzuR907havNUH44FQacHAwp+uKSB4Hw2+7zWi6gJGo7T2",
+	"YOCFaXcrY221oFeK+j7qO/9GCfDAzM/YLc5p6nSDme2zPc3WNc4FmtuJg6rwJtUoqb2/aX1oNfv94Ys9",
+	"zemyNNV4jWt1t/zTJl1oTci4gSCU2iZpnXlLycIJJp+iOrtrynmEXI7WBIuoRnVCE/ynNhmnXs5PasL5",
+	"7i6vpV1df3x/hHvtt/nyU/jeloQ/HR4+axDQm0CoPPo+WdumupnmUdX+y70xuKc3IAWLcYVoXdrd+XgJ",
+	"Z1M6K7W8g/tpUcQ8SrRKwu+PCO+4Qo2W/RwIa0SIswHOMlmj0LBKeuD9bFLtYfc3Q2/47KGM0Apm+mc2",
+	"Qaug1IFletMJPv1ofh7NzyeZHxDHf1Lj82b4/NVXZXwC2jc3qs/pXtCEDc3buH23Sfk2wiX99a+7nfMw",
+	"KjgEFf+ZtXAQVjywbva9T9TFX1o7flE19uWUwWeX3XklNk58nSD5EmwvBEDtz55ibN7dVoqP4asHEmLT",
+	"+JeU4cYIupfPvPYowY8SHNr6fcb5W3gF9KG+8xbUItiJrVMiVo4DOiThUsmD+hjk4GP17/sD/9Dj4KP3",
+	"635jTBujaY5Vdb5XEDGsb5EA/ImD+XXwGVW/MfNAfmf0ljD/9GWEPkhS37WE3YV/vbQGqWRVsNoc4Yxn",
+	"ArMyx4KqJbwni5wqRHCSNRDnFDeHqpMyuSFKdoShKw/3RFMQDgUEnhMFJR86svDrVw5eU/a+kHU1s65q",
+	"IiufeI50/4+sb97/g2p2/T+5rM6/t5hLut0Hv9QraG8tPJBl0Iu61iRUnB3m6tGjYfhihuH7w+8/X8/v",
+	"uEKvecnSr9KpPOlWubhWuP9/C9nRGg0jcns0GgdN3FC50YgIOsvUUNI/HSy893HrvN4lMFRoojFrGI1T",
+	"reVbuKX6ayzqgrf14VoFAwK1QAyuGsIzTJmlIrRCUod70ygCUd2/K00lhquMxKzbYJlYL6g66SGY27uy",
+	"ZlJ4TtACL8GkLVHK3Qk9LER1vtvEWZjjpcm5N/gEDny1GgeAO0iun3WYuIvWcj3auE+xcQ9prjowfdca",
+	"rnXC9Wi+Hs3XV2C+Ljbpf4y8+/L2mkMDTnmjKasqvfcLo9QV57eMpJx5FeUfIpjSLu3/ReIp7UGsW31H",
+	"x8eoymNU5f+NqAr1RNgpllqs1+qWj+6fZymETlp+1Gq+a40c7r5EiqOySDHUnKX6vQKrbOBwhAZ1D4O2",
+	"yPtnUO3E5OtoUJQBdfcBukJw+8oOgLJ++s586ijzwPruvFRfWNnBCDZrOrt4j4run9HNqpiAcYWmX5O/",
+	"9dXpWqt4aK0+eunaLnCsbofOBRmgJgy9tci3DkinAuVpuplwdXYlJn0UM1ztqwBlBj3xrxLY5HgZ1ch7",
+	"1X2Fp7ZgnPsckG9i9qSKItiQhMNisoDVPri1fBqZKDZcM1gFB43ZEwfxamvYmevf9oeFffVQZ+XTGn9l",
+	"FQI4Zk0M4LDD24KHeSAz0IGv9plNQRfsU0AALtqgT4/+76P/uzkvoI0V5qnFtqAFlKNDkRu6Wl1ro65Q",
+	"+thklUIpVJN2KvDCvxzglU9GQ2TrHkce3iCUUI68asNDhAHiDpFbIpYqa95Xcbehihwz4mody1HMxj4S",
+	"opc0CgFM+H7BiJAZLYZJRpIbV9GPiAILFcWsMYsKBLE+tmnDIVImFcEpXGp5W+aKDk0pNxOalej9RQ2i",
+	"UPnx0Mrxu5/dHGsHH9pxNYptrQe/9rArf0xcgFqkthSyJqxBa4WMtKqVv7YKlAPJ/uXFz7ZgJ/wcI78Y",
+	"srmECo1pAsYMghcNzFb4tKK+Y+UR+onodcJmlHb4XEQAQ53w+RzLmM0JZjB5vyjg+4uOqLJfVW7rkLL/",
+	"8Umr2HaPkKz/+VZxaf/Dc1vOc8vPThrVtLf82JYa2/YrPntDbnf40NyUPc8EllsPdasYuf/hFqfBjUnC",
+	"jfhtB1ndRH/QuHywgmLAELj3jN4V2m0jty2n4DEm/xgV21cie9HgN1fpVJZFwUV1zYR+yXslI3RZiilO",
+	"fNB0/6oLgIdXxcFdTCpmroI3WNfGLB3epN4ioZeHzwwkhtT+g7ZUIa+r0cC6lOqQn3VgHIZhXdB2rdel",
+	"VuvbAh69X2vdeRerk6twGXDMYKKRm6kpbwx+hPYwhqb4b1XD3Zb/pT7Ev/YOImvMYwbWHA6SvdLTANac",
+	"4aIwsBP6H1hU1TrxjNTXfjO4I49TYlyq9/WcCiKcbjlyaVjm0N0vAB359bkRljdVyljM3OhNL9ovMqDU",
+	"Zq2dC2Qgcl3ygzcLzfipwAtmphwzex3dT0lL7Wi/BU6xHhDlTEauOrMgiM4YFyTVnnBV8npsy36PUckA",
+	"RaEu9KXdPlMZmE+nxmFS8Eecc2aL3CPG0QIvTZF2xU02G9Q/tVf7gSGq7AAviwCsHcISjX85bWOINzh0",
+	"XJXFNrSVUCGixmY1QWKoc58LgtMlynieyhEaQ0aETWWoQF3GTpHEDM+58e7nUDLZkR43a1Zv8A79evCf",
+	"4ij67Zh/f+0uzaNn+zV6tj4fwX9NW5/QyltXz/2zeaF+72u9H6+I+aND+uiQfk6HtFFB/x/LO00w01Mh",
+	"rJwDBnhzqs6joAqS9/SbHlxKyuFetXYEAHWHKgPMIpuu4Kov+4ZK1eleNt1IO5wEM3A4e7i8BlmpX/KM",
+	"hSTbMnPmykGDPcT5QQBb8DOfHYQA4AIMaF57PC14VMM9TgsqND0nvVaGuuX3o4U3vj8ApM5+8mwgQ80B",
+	"qUFA3lK0ATf1NRdXFvd4i7QYB5UcyIRxSM1bpsH8A6uXAD5t6GwelvNRwzxqmM0aZkX0P0XZfDQY1d2X",
+	"Cn8hCqUG59wi/BeY7ah4fiHKg03/KpRPtL43i2od6Mxie2+t6B5a17Qx6TuUTbWmjzrnUees0zkb5b9L",
+	"+xhU0U69cpKR5MYUF4UXW9Vd2rpktKJM/mba/0SZagHFV7j01cZ5YIa37FMaojvnjkrk2tkh7a+Ftw6r",
+	"1BgjL4itQ3mEEs6YCZOjKaY5SdcD8NeNlGxfU61bWgexaRYQQeaIx0R2Xa/vW982gZh/u9bq1H7zcRWA",
+	"y8XN/HS/WnnDjnpV97cBONc3YoHVVps54VAFVNJZZq4xrrvvFWrZXplZbdknWehDS7v76/v/GwAA//+L",
+	"lZU+Tv0AAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/observer/api/handlers/convert.go
+++ b/internal/observer/api/handlers/convert.go
@@ -151,3 +151,51 @@ func toTypesPlatformLogsQuery(src gen.GetPlatformLogsParams) (*types.PlatformLog
 	}
 	return dst, nil
 }
+
+// toTypesPlatformLogFilterValuesQuery maps the generated query parameters onto the
+// internal request. The record filters arrive flattened, so they are rebuilt into the
+// query they describe - including the named filter's own selections, which the adapter
+// is responsible for excluding.
+func toTypesPlatformLogFilterValuesQuery(
+	src gen.GetPlatformLogFilterValuesParams,
+) (*types.PlatformLogFilterValuesRequest, error) {
+	dst := &types.PlatformLogFilterValuesRequest{
+		Filter: string(src.Filter),
+		Query: types.PlatformLogsQueryRequest{
+			StartTime: rfc3339OrEmpty(src.StartTime),
+			EndTime:   rfc3339OrEmpty(src.EndTime),
+		},
+	}
+	if src.ClusterInstance != nil {
+		dst.Query.ClusterInstances = *src.ClusterInstance
+	}
+	if src.Namespace != nil {
+		dst.Query.Namespaces = *src.Namespace
+	}
+	if src.PodName != nil {
+		dst.Query.PodNames = *src.PodName
+	}
+	if src.ContainerName != nil {
+		dst.Query.ContainerNames = *src.ContainerName
+	}
+	if src.LogLevels != nil {
+		dst.Query.LogLevels = *src.LogLevels
+	}
+	if src.SearchPhrase != nil {
+		dst.Query.SearchPhrase = *src.SearchPhrase
+	}
+	if src.Labels != nil {
+		labels, err := ParseLabelSelector(*src.Labels)
+		if err != nil {
+			return nil, err
+		}
+		dst.Query.Labels = labels
+	}
+	if src.ValueSearch != nil {
+		dst.ValueSearch = *src.ValueSearch
+	}
+	if src.MaxValues != nil {
+		dst.MaxValues = *src.MaxValues
+	}
+	return dst, nil
+}

--- a/internal/observer/api/handlers/platformlogs.go
+++ b/internal/observer/api/handlers/platformlogs.go
@@ -76,3 +76,69 @@ func (h *Handler) platformLogsError(err error) gen.GetPlatformLogsResponseObject
 		"Failed to retrieve platform logs",
 	)
 }
+
+// --- filter values ---
+
+// GetPlatformLogFilterValues handles
+// GET /api/v1alpha1/platform-logs/filter-values.
+func (h *Handler) GetPlatformLogFilterValues(
+	ctx context.Context,
+	request gen.GetPlatformLogFilterValuesRequestObject,
+) (gen.GetPlatformLogFilterValuesResponseObject, error) {
+	req, err := toTypesPlatformLogFilterValuesQuery(request.Params)
+	if err != nil {
+		return errorResponse(http.StatusBadRequest, gen.BadRequest, "", err.Error()), nil
+	}
+
+	if err := ValidatePlatformLogFilterValuesRequest(req); err != nil {
+		h.logger.Debug("Platform log filter values request validation failed", "error", err)
+		return errorResponse(http.StatusBadRequest, gen.BadRequest, "", err.Error()), nil
+	}
+
+	if h.platformLogsService == nil {
+		h.logger.Error("Platform log filter values service is not initialized")
+		return errorResponse(
+			http.StatusInternalServerError,
+			gen.InternalServerError,
+			types.ErrorCodeV1PlatformLogFilterValuesServiceNotReady,
+			"Platform log filter values service is not initialized",
+		), nil
+	}
+
+	result, err := h.platformLogsService.QueryPlatformLogFilterValues(ctx, req)
+	if err != nil {
+		return h.platformLogFilterValuesError(err), nil
+	}
+
+	return jsonResponse(http.StatusOK, result), nil
+}
+
+// platformLogFilterValuesError maps filter values service errors onto responses.
+func (h *Handler) platformLogFilterValuesError(err error) gen.GetPlatformLogFilterValuesResponseObject {
+	switch {
+	case errors.Is(err, observerAuthz.ErrAuthzForbidden):
+		return errorResponse(http.StatusForbidden, gen.Forbidden, "", "Access denied")
+	case errors.Is(err, observerAuthz.ErrAuthzUnauthorized):
+		return errorResponse(http.StatusUnauthorized, gen.Unauthorized, "", "Unauthorized")
+	case errors.Is(err, service.ErrPlatformLogFilterValuesNotSupported):
+		h.logger.Warn("Logs adapter cannot enumerate platform log filter values")
+		return errorResponse(
+			http.StatusNotImplemented,
+			gen.NotImplemented,
+			types.ErrorCodeV1PlatformLogFilterValuesNotSupported,
+			"The configured logs adapter does not support platform log filter values",
+		)
+	}
+
+	errorCode := types.ErrorCodeV1PlatformLogsInternalGeneric
+	if errors.Is(err, service.ErrPlatformLogFilterValuesRetrieval) {
+		errorCode = types.ErrorCodeV1PlatformLogFilterValuesRetrievalFailed
+	}
+	h.logger.Error("Failed to retrieve platform log filter values", "error", err)
+	return errorResponse(
+		http.StatusInternalServerError,
+		gen.InternalServerError,
+		errorCode,
+		"Failed to retrieve platform log filter values",
+	)
+}

--- a/internal/observer/api/handlers/platformlogs_test.go
+++ b/internal/observer/api/handlers/platformlogs_test.go
@@ -358,3 +358,204 @@ func TestGetPlatformLogs_ServiceNotInitialized(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1PlatformLogsServiceNotReady)
 }
+
+// --- filter values ---
+
+// The minimum a filter values call needs: which filter, and the window it runs under.
+const filterValuesQuery = "filter=podName&" + platformLogsWindow
+
+func getFilterValues(t *testing.T, h *Handler, query string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1alpha1/platform-logs/filter-values?"+query, nil)
+	return serve(t, h, req)
+}
+
+func TestGetPlatformLogFilterValues_Success(t *testing.T) {
+	t.Parallel()
+
+	svc := servicemocks.NewMockPlatformLogsQuerier(t)
+	svc.EXPECT().QueryPlatformLogFilterValues(mock.Anything, mock.Anything).
+		Return(&types.PlatformLogFilterValuesResponse{
+			Filter: "podName",
+			Values: []types.PlatformLogFilterValue{
+				{Value: "controller-manager-abc", Count: 412},
+			},
+			TotalValues:   940,
+			TotalRelation: "gte",
+			TookMs:        4,
+		}, nil)
+
+	rr := getFilterValues(t, platformLogsHandler(t, svc), filterValuesQuery)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"filter":"podName"`)
+	assert.Contains(t, rr.Body.String(), `"value":"controller-manager-abc"`)
+	assert.Contains(t, rr.Body.String(), `"count":412`)
+	assert.Contains(t, rr.Body.String(), `"totalValues":940`)
+	assert.Contains(t, rr.Body.String(), `"totalRelation":"gte"`)
+}
+
+// The record filters arrive flattened on the query string and are rebuilt into the
+// query they describe - including the named filter's own selections, which the adapter
+// excludes rather than the observer.
+func TestGetPlatformLogFilterValues_RebuildsQuery(t *testing.T) {
+	t.Parallel()
+
+	var got *types.PlatformLogFilterValuesRequest
+	svc := servicemocks.NewMockPlatformLogsQuerier(t)
+	svc.EXPECT().QueryPlatformLogFilterValues(mock.Anything, mock.Anything).
+		Run(func(_ context.Context, req *types.PlatformLogFilterValuesRequest) { got = req }).
+		Return(&types.PlatformLogFilterValuesResponse{}, nil)
+
+	query := filterValuesQuery +
+		"&namespace=openchoreo-control-plane,cert-manager" +
+		"&podName=already-selected" +
+		"&clusterInstance=cluster1" +
+		"&containerName=manager" +
+		"&logLevels=ERROR,WARN" +
+		"&labels=openchoreo.dev%2Fplane%3Dcontrolplane" +
+		"&searchPhrase=reconcile" +
+		"&valueSearch=controller&maxValues=50"
+
+	rr := getFilterValues(t, platformLogsHandler(t, svc), query)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	require.NotNil(t, got)
+	assert.Equal(t, "podName", got.Filter)
+	assert.Equal(t, "controller", got.ValueSearch)
+	assert.Equal(t, 50, got.MaxValues)
+	assert.Equal(t, []string{"openchoreo-control-plane", "cert-manager"}, got.Query.Namespaces)
+	assert.Equal(t, []string{"cluster1"}, got.Query.ClusterInstances)
+	assert.Equal(t, []string{"manager"}, got.Query.ContainerNames)
+	assert.Equal(t, []string{"ERROR", "WARN"}, got.Query.LogLevels)
+	assert.Equal(t, map[string]string{"openchoreo.dev/plane": "controlplane"}, got.Query.Labels)
+	assert.Equal(t, "reconcile", got.Query.SearchPhrase)
+	assert.Equal(t, []string{"already-selected"}, got.Query.PodNames)
+}
+
+func TestGetPlatformLogFilterValues_DefaultsMaxValues(t *testing.T) {
+	t.Parallel()
+
+	var got *types.PlatformLogFilterValuesRequest
+	svc := servicemocks.NewMockPlatformLogsQuerier(t)
+	svc.EXPECT().QueryPlatformLogFilterValues(mock.Anything, mock.Anything).
+		Run(func(_ context.Context, req *types.PlatformLogFilterValuesRequest) { got = req }).
+		Return(&types.PlatformLogFilterValuesResponse{}, nil)
+
+	rr := getFilterValues(t, platformLogsHandler(t, svc), filterValuesQuery)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	require.NotNil(t, got)
+	assert.Equal(t, 100, got.MaxValues)
+}
+
+func TestGetPlatformLogFilterValues_BadRequests(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		query   string
+		wantErr string
+	}{
+		{name: "no filter named", query: platformLogsWindow, wantErr: ""},
+		{name: "unknown filter", query: "filter=nodeName&" + platformLogsWindow, wantErr: ""},
+		{name: "missing window", query: "filter=podName", wantErr: ""},
+		{
+			name:    "window beyond the cap",
+			query:   "filter=podName&startTime=2026-01-01T00:00:00Z&endTime=2026-06-01T00:00:00Z",
+			wantErr: "cannot exceed 30 days",
+		},
+		{
+			name:    "maxValues above the cap",
+			query:   filterValuesQuery + "&maxValues=5000",
+			wantErr: "maxValues cannot exceed",
+		},
+		{
+			name:    "malformed label selector",
+			query:   filterValuesQuery + "&labels=notaselector",
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// No service call is expected, so an unprimed mock also asserts that.
+			svc := servicemocks.NewMockPlatformLogsQuerier(t)
+			rr := getFilterValues(t, platformLogsHandler(t, svc), tt.query)
+
+			require.Equal(t, http.StatusBadRequest, rr.Code)
+			if tt.wantErr != "" {
+				assert.Contains(t, rr.Body.String(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGetPlatformLogFilterValues_ErrorMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		wantCode int
+		wantBody string
+	}{
+		{
+			name:     "adapter cannot aggregate",
+			err:      service.ErrPlatformLogFilterValuesNotSupported,
+			wantCode: http.StatusNotImplemented,
+			wantBody: types.ErrorCodeV1PlatformLogFilterValuesNotSupported,
+		},
+		{
+			name:     "retrieval failed",
+			err:      service.ErrPlatformLogFilterValuesRetrieval,
+			wantCode: http.StatusInternalServerError,
+			wantBody: types.ErrorCodeV1PlatformLogFilterValuesRetrievalFailed,
+		},
+		{
+			name:     "forbidden",
+			err:      observerAuthz.ErrAuthzForbidden,
+			wantCode: http.StatusForbidden,
+			wantBody: "Access denied",
+		},
+		{
+			name:     "unauthorized",
+			err:      observerAuthz.ErrAuthzUnauthorized,
+			wantCode: http.StatusUnauthorized,
+			wantBody: "Unauthorized",
+		},
+		{
+			name:     "unknown failure",
+			err:      errors.New("boom"),
+			wantCode: http.StatusInternalServerError,
+			wantBody: types.ErrorCodeV1PlatformLogsInternalGeneric,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc := servicemocks.NewMockPlatformLogsQuerier(t)
+			svc.EXPECT().QueryPlatformLogFilterValues(mock.Anything, mock.Anything).
+				Return(nil, tt.err)
+
+			rr := getFilterValues(t, platformLogsHandler(t, svc), filterValuesQuery)
+
+			require.Equal(t, tt.wantCode, rr.Code)
+			assert.True(t, strings.Contains(rr.Body.String(), tt.wantBody),
+				"body %q should contain %q", rr.Body.String(), tt.wantBody)
+		})
+	}
+}
+
+func TestGetPlatformLogFilterValues_ServiceNotInitialized(t *testing.T) {
+	t.Parallel()
+
+	rr := getFilterValues(t, platformLogsHandler(t, nil), filterValuesQuery)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Contains(t, rr.Body.String(), types.ErrorCodeV1PlatformLogFilterValuesServiceNotReady)
+}

--- a/internal/observer/api/handlers/response.go
+++ b/internal/observer/api/handlers/response.go
@@ -106,3 +106,7 @@ func (resp apiResponse) VisitGetRecommendationsResponse(w http.ResponseWriter) e
 func (resp apiResponse) VisitGetPlatformLogsResponse(w http.ResponseWriter) error {
 	return resp.write(w)
 }
+
+func (resp apiResponse) VisitGetPlatformLogFilterValuesResponse(w http.ResponseWriter) error {
+	return resp.write(w)
+}

--- a/internal/observer/api/handlers/spec_conformance_test.go
+++ b/internal/observer/api/handlers/spec_conformance_test.go
@@ -478,4 +478,45 @@ func TestResponsesConformToSpec(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 		assertConformsToSpec(t, req, serve(t, h, req))
 	})
+
+	// The handler returns the untyped apiResponse, so this is the only thing checking
+	// the emitted body against the declared schema. Both a populated and an empty
+	// result, since a filter with no matching values still answers 200.
+	t.Run("getPlatformLogFilterValues", func(t *testing.T) {
+		t.Parallel()
+
+		for name, resp := range map[string]*types.PlatformLogFilterValuesResponse{
+			"populated": {
+				Filter: "podName",
+				Values: []types.PlatformLogFilterValue{
+					{Value: "controller-manager-abc", Count: 412},
+				},
+				TotalValues:   940,
+				TotalRelation: "gte",
+				TookMs:        9,
+			},
+			"empty": {
+				Filter:        "podName",
+				Values:        []types.PlatformLogFilterValue{},
+				TotalRelation: "eq",
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+
+				svc := servicemocks.NewMockPlatformLogsQuerier(t)
+				svc.EXPECT().QueryPlatformLogFilterValues(mock.Anything, mock.Anything).
+					Return(resp, nil)
+
+				h := &Handler{
+					baseHandler:         baseHandler{logger: noopLogger()},
+					platformLogsService: svc,
+				}
+
+				req := httptest.NewRequest(http.MethodGet,
+					"/api/v1alpha1/platform-logs/filter-values?"+filterValuesQuery, nil)
+				assertConformsToSpec(t, req, serve(t, h, req))
+			})
+		}
+	})
 }

--- a/internal/observer/api/handlers/validations.go
+++ b/internal/observer/api/handlers/validations.go
@@ -698,3 +698,55 @@ func ValidateRecommendationQueryRequest(req *types.RecommendationQueryRequest) e
 	}
 	return nil
 }
+
+// Caps on the filter values query. maxValues is its own knob rather than reusing the
+// record limit: these are short field values, not records, and a picker with too few
+// options is worse than a slightly larger response.
+const (
+	defaultPlatformLogFilterValuesMaxValues = 100
+	maxPlatformLogFilterValuesMaxValues     = 1000
+	maxPlatformLogValueSearchLength         = 256
+)
+
+// platformLogFilterValuesFilters are the coordinates that can be listed, matching the
+// enum declared on the `filter` parameter.
+var platformLogFilterValuesFilters = map[string]bool{
+	"clusterInstance": true,
+	"namespace":       true,
+	"podName":         true,
+	"containerName":   true,
+}
+
+// ValidatePlatformLogFilterValuesRequest validates the request and applies defaults in
+// place.
+//
+// The record filters are validated exactly as the record query validates them, so a
+// query that would be rejected there is rejected here rather than reaching the adapter
+// in a shape only one of the two endpoints accepts.
+func ValidatePlatformLogFilterValuesRequest(req *types.PlatformLogFilterValuesRequest) error {
+	if !platformLogFilterValuesFilters[req.Filter] {
+		return fmt.Errorf("filter must be one of clusterInstance, namespace, podName, containerName")
+	}
+
+	// The record query carries the time window, and ValidateTimeRange caps it: an
+	// aggregation spans one index per day of that window.
+	if err := ValidatePlatformLogsQueryRequest(&req.Query); err != nil {
+		return err
+	}
+
+	if len(req.ValueSearch) > maxPlatformLogValueSearchLength {
+		return fmt.Errorf("valueSearch cannot exceed %d characters", maxPlatformLogValueSearchLength)
+	}
+
+	if req.MaxValues == 0 {
+		req.MaxValues = defaultPlatformLogFilterValuesMaxValues
+		return nil
+	}
+	if req.MaxValues < 0 {
+		return fmt.Errorf("maxValues must be a positive integer")
+	}
+	if req.MaxValues > maxPlatformLogFilterValuesMaxValues {
+		return fmt.Errorf("maxValues cannot exceed %d", maxPlatformLogFilterValuesMaxValues)
+	}
+	return nil
+}

--- a/internal/observer/api/logsadapterclientgen/client.gen.go
+++ b/internal/observer/api/logsadapterclientgen/client.gen.go
@@ -95,6 +95,20 @@ const (
 	LogsQueryRequestSortOrderDesc LogsQueryRequestSortOrder = "desc"
 )
 
+// Defines values for PlatformLogFilterValuesRequestFilter.
+const (
+	ClusterInstance PlatformLogFilterValuesRequestFilter = "clusterInstance"
+	ContainerName   PlatformLogFilterValuesRequestFilter = "containerName"
+	Namespace       PlatformLogFilterValuesRequestFilter = "namespace"
+	PodName         PlatformLogFilterValuesRequestFilter = "podName"
+)
+
+// Defines values for PlatformLogFilterValuesResponseTotalRelation.
+const (
+	Eq  PlatformLogFilterValuesResponseTotalRelation = "eq"
+	Gte PlatformLogFilterValuesResponseTotalRelation = "gte"
+)
+
 // Defines values for PlatformLogsQueryRequestLogLevels.
 const (
 	PlatformLogsQueryRequestLogLevelsDEBUG PlatformLogsQueryRequestLogLevels = "DEBUG"
@@ -468,6 +482,76 @@ type PlatformLog struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
+// PlatformLogFilterValue One value a filter takes, with how many records carry it.
+type PlatformLogFilterValue struct {
+	// Count Matching records carrying this value. May be approximate on a
+	// high-cardinality filter where the backend answers from a partial term
+	// count, so it is an ordering hint rather than a total.
+	Count int64 `json:"count"`
+
+	// Value The value, exactly as it would be sent back as a filter
+	Value string `json:"value"`
+}
+
+// PlatformLogFilterValuesRequest Which filter to list values for, and the query to list them under.
+//
+// `query` is a full `PlatformLogsQueryRequest`, in the same shape as a record
+// query - so the observer passes the query it already holds rather than
+// rebuilding it. Its `startTime` and `endTime` are required, so every call here
+// is scoped to a period.
+//
+// The other filters in `query` narrow which records the values are drawn from,
+// except the one named by `filter`, whose own selections are ignored.
+//
+// `query.limit` and `query.sortOrder` carry no meaning here: no records are
+// returned, so there is nothing to page or order. They are accepted and ignored
+// rather than rejected.
+type PlatformLogFilterValuesRequest struct {
+	// Filter The filter to list values for, named as the request field that accepts it.
+	Filter PlatformLogFilterValuesRequestFilter `json:"filter"`
+
+	// MaxValues The maximum number of values to return, ordered by `count` descending then
+	// `value` ascending, so a truncated list holds the busiest. Named to stay
+	// distinct from `query.limit`, which is a record page size and is ignored
+	// here.
+	MaxValues *int `json:"maxValues,omitempty"`
+
+	// Query A flat set of Kubernetes coordinates. Multi-value fields OR within a field; fields
+	// AND with each other. An absent field is not a filter.
+	Query PlatformLogsQueryRequest `json:"query"`
+
+	// ValueSearch Return only values containing this text, case-insensitively. Narrows the
+	// *values* returned, where `query.searchPhrase` narrows the *records* they
+	// are drawn from.
+	ValueSearch *string `json:"valueSearch,omitempty"`
+}
+
+// PlatformLogFilterValuesRequestFilter The filter to list values for, named as the request field that accepts it.
+type PlatformLogFilterValuesRequestFilter string
+
+// PlatformLogFilterValuesResponse defines model for PlatformLogFilterValuesResponse.
+type PlatformLogFilterValuesResponse struct {
+	// Filter The filter these values belong to, echoed from the request
+	Filter string `json:"filter"`
+
+	// TookMs The time taken to compute the values in milliseconds
+	TookMs int `json:"tookMs"`
+
+	// TotalRelation Whether `totalValues` is exact (`eq`) or a lower bound (`gte`).
+	TotalRelation PlatformLogFilterValuesResponseTotalRelation `json:"totalRelation"`
+
+	// TotalValues How many distinct values match, of which at most `maxValues` were returned.
+	TotalValues int64 `json:"totalValues"`
+
+	// Values Distinct values, ordered by `count` descending then `value` ascending.
+	// Records on which the field is absent are not represented: no empty-string
+	// entry, because no filter value would select one.
+	Values []PlatformLogFilterValue `json:"values"`
+}
+
+// PlatformLogFilterValuesResponseTotalRelation Whether `totalValues` is exact (`eq`) or a lower bound (`gte`).
+type PlatformLogFilterValuesResponseTotalRelation string
+
 // PlatformLogsQueryRequest A flat set of Kubernetes coordinates. Multi-value fields OR within a field; fields
 // AND with each other. An absent field is not a filter.
 type PlatformLogsQueryRequest struct {
@@ -552,6 +636,9 @@ type UpdateAlertRuleJSONRequestBody = AlertRuleRequest
 
 // HandleAlertWebhookJSONRequestBody defines body for HandleAlertWebhook for application/json ContentType.
 type HandleAlertWebhookJSONRequestBody = HandleAlertWebhookJSONBody
+
+// QueryPlatformLogFilterValuesJSONRequestBody defines body for QueryPlatformLogFilterValues for application/json ContentType.
+type QueryPlatformLogFilterValuesJSONRequestBody = PlatformLogFilterValuesRequest
 
 // QueryPlatformLogsJSONRequestBody defines body for QueryPlatformLogs for application/json ContentType.
 type QueryPlatformLogsJSONRequestBody = PlatformLogsQueryRequest
@@ -846,6 +933,11 @@ type ClientInterface interface {
 
 	HandleAlertWebhook(ctx context.Context, body HandleAlertWebhookJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// QueryPlatformLogFilterValuesWithBody request with any body
+	QueryPlatformLogFilterValuesWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	QueryPlatformLogFilterValues(ctx context.Context, body QueryPlatformLogFilterValuesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// QueryPlatformLogsWithBody request with any body
 	QueryPlatformLogsWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -989,6 +1081,30 @@ func (c *Client) HandleAlertWebhookWithBody(ctx context.Context, contentType str
 
 func (c *Client) HandleAlertWebhook(ctx context.Context, body HandleAlertWebhookJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewHandleAlertWebhookRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) QueryPlatformLogFilterValuesWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewQueryPlatformLogFilterValuesRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) QueryPlatformLogFilterValues(ctx context.Context, body QueryPlatformLogFilterValuesJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewQueryPlatformLogFilterValuesRequest(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1310,6 +1426,46 @@ func NewHandleAlertWebhookRequestWithBody(server string, contentType string, bod
 	return req, nil
 }
 
+// NewQueryPlatformLogFilterValuesRequest calls the generic QueryPlatformLogFilterValues builder with application/json body
+func NewQueryPlatformLogFilterValuesRequest(server string, body QueryPlatformLogFilterValuesJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewQueryPlatformLogFilterValuesRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewQueryPlatformLogFilterValuesRequestWithBody generates requests for QueryPlatformLogFilterValues with any type of body
+func NewQueryPlatformLogFilterValuesRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1alpha1/platform-logs/filter-values")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewQueryPlatformLogsRequest calls the generic QueryPlatformLogs builder with application/json body
 func NewQueryPlatformLogsRequest(server string, body QueryPlatformLogsJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -1450,6 +1606,11 @@ type ClientWithResponsesInterface interface {
 	HandleAlertWebhookWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*HandleAlertWebhookResp, error)
 
 	HandleAlertWebhookWithResponse(ctx context.Context, body HandleAlertWebhookJSONRequestBody, reqEditors ...RequestEditorFn) (*HandleAlertWebhookResp, error)
+
+	// QueryPlatformLogFilterValuesWithBodyWithResponse request with any body
+	QueryPlatformLogFilterValuesWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*QueryPlatformLogFilterValuesResp, error)
+
+	QueryPlatformLogFilterValuesWithResponse(ctx context.Context, body QueryPlatformLogFilterValuesJSONRequestBody, reqEditors ...RequestEditorFn) (*QueryPlatformLogFilterValuesResp, error)
 
 	// QueryPlatformLogsWithBodyWithResponse request with any body
 	QueryPlatformLogsWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*QueryPlatformLogsResp, error)
@@ -1637,6 +1798,33 @@ func (r HandleAlertWebhookResp) StatusCode() int {
 	return 0
 }
 
+type QueryPlatformLogFilterValuesResp struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *PlatformLogFilterValuesResponse
+	JSON400      *ErrorResponse
+	JSON401      *ErrorResponse
+	JSON403      *ErrorResponse
+	JSON500      *ErrorResponse
+	JSON501      *ErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r QueryPlatformLogFilterValuesResp) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r QueryPlatformLogFilterValuesResp) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type QueryPlatformLogsResp struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -1793,6 +1981,23 @@ func (c *ClientWithResponses) HandleAlertWebhookWithResponse(ctx context.Context
 		return nil, err
 	}
 	return ParseHandleAlertWebhookResp(rsp)
+}
+
+// QueryPlatformLogFilterValuesWithBodyWithResponse request with arbitrary body returning *QueryPlatformLogFilterValuesResp
+func (c *ClientWithResponses) QueryPlatformLogFilterValuesWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*QueryPlatformLogFilterValuesResp, error) {
+	rsp, err := c.QueryPlatformLogFilterValuesWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseQueryPlatformLogFilterValuesResp(rsp)
+}
+
+func (c *ClientWithResponses) QueryPlatformLogFilterValuesWithResponse(ctx context.Context, body QueryPlatformLogFilterValuesJSONRequestBody, reqEditors ...RequestEditorFn) (*QueryPlatformLogFilterValuesResp, error) {
+	rsp, err := c.QueryPlatformLogFilterValues(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseQueryPlatformLogFilterValuesResp(rsp)
 }
 
 // QueryPlatformLogsWithBodyWithResponse request with arbitrary body returning *QueryPlatformLogsResp
@@ -2158,6 +2363,67 @@ func ParseHandleAlertWebhookResp(rsp *http.Response) (*HandleAlertWebhookResp, e
 			return nil, err
 		}
 		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseQueryPlatformLogFilterValuesResp parses an HTTP response from a QueryPlatformLogFilterValuesWithResponse call
+func ParseQueryPlatformLogFilterValuesResp(rsp *http.Response) (*QueryPlatformLogFilterValuesResp, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &QueryPlatformLogFilterValuesResp{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest PlatformLogFilterValuesResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 400:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 501:
+		var dest ErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON501 = &dest
 
 	}
 

--- a/internal/observer/audit/audit_coverage_test.go
+++ b/internal/observer/audit/audit_coverage_test.go
@@ -111,9 +111,9 @@ func TestAuditCoverage(t *testing.T) {
 	// Pins the total so a spec change is forced through a deliberate update
 	// here rather than silently shifting the audited/exempted/read split.
 	//
-	// 20 = 15 public (6 GET + 9 non-GET) + 5 internal (1 GET + 4 non-GET).
+	// 21 = 16 public (7 GET + 9 non-GET) + 5 internal (1 GET + 4 non-GET).
 	t.Run("total operation count is pinned", func(t *testing.T) {
-		const wantTotal = 20
+		const wantTotal = 21
 		if len(restOperationIDs) != wantTotal {
 			t.Errorf("len(allOperationIDs) = %d, want %d", len(restOperationIDs), wantTotal)
 		}

--- a/internal/observer/audit/exemptions.go
+++ b/internal/observer/audit/exemptions.go
@@ -39,6 +39,7 @@ var RESTExemptions = map[string]string{
 	// Public spec — GET.
 	"GetComponentCosts":                 reasonRead,
 	"GetOAuthProtectedResourceMetadata": reasonRead,
+	"GetPlatformLogFilterValues":        reasonRead,
 	"GetPlatformLogs":                   reasonRead,
 	"GetRecommendations":                reasonRead,
 	"GetSpanDetailsForTrace":            reasonRead,

--- a/internal/observer/service/interfaces.go
+++ b/internal/observer/service/interfaces.go
@@ -24,6 +24,12 @@ type LogsQuerier interface {
 // PlatformLogsQuerier is the interface for querying platform logs.
 type PlatformLogsQuerier interface {
 	QueryPlatformLogs(ctx context.Context, req *types.PlatformLogsQueryRequest) (*types.PlatformLogsResponse, error)
+
+	// QueryPlatformLogFilterValues lists the values one of those filters can take.
+	QueryPlatformLogFilterValues(
+		ctx context.Context,
+		req *types.PlatformLogFilterValuesRequest,
+	) (*types.PlatformLogFilterValuesResponse, error)
 }
 
 // EventsQuerier is the interface for querying Kubernetes events.

--- a/internal/observer/service/mocks/platformlogsquerier.go
+++ b/internal/observer/service/mocks/platformlogsquerier.go
@@ -23,6 +23,65 @@ func (_m *MockPlatformLogsQuerier) EXPECT() *MockPlatformLogsQuerier_Expecter {
 	return &MockPlatformLogsQuerier_Expecter{mock: &_m.Mock}
 }
 
+// QueryPlatformLogFilterValues provides a mock function with given fields: ctx, req
+func (_m *MockPlatformLogsQuerier) QueryPlatformLogFilterValues(ctx context.Context, req *types.PlatformLogFilterValuesRequest) (*types.PlatformLogFilterValuesResponse, error) {
+	ret := _m.Called(ctx, req)
+
+	if len(ret) == 0 {
+		panic("no return value specified for QueryPlatformLogFilterValues")
+	}
+
+	var r0 *types.PlatformLogFilterValuesResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *types.PlatformLogFilterValuesRequest) (*types.PlatformLogFilterValuesResponse, error)); ok {
+		return rf(ctx, req)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *types.PlatformLogFilterValuesRequest) *types.PlatformLogFilterValuesResponse); ok {
+		r0 = rf(ctx, req)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*types.PlatformLogFilterValuesResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *types.PlatformLogFilterValuesRequest) error); ok {
+		r1 = rf(ctx, req)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockPlatformLogsQuerier_QueryPlatformLogFilterValues_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'QueryPlatformLogFilterValues'
+type MockPlatformLogsQuerier_QueryPlatformLogFilterValues_Call struct {
+	*mock.Call
+}
+
+// QueryPlatformLogFilterValues is a helper method to define mock.On call
+//   - ctx context.Context
+//   - req *types.PlatformLogFilterValuesRequest
+func (_e *MockPlatformLogsQuerier_Expecter) QueryPlatformLogFilterValues(ctx interface{}, req interface{}) *MockPlatformLogsQuerier_QueryPlatformLogFilterValues_Call {
+	return &MockPlatformLogsQuerier_QueryPlatformLogFilterValues_Call{Call: _e.mock.On("QueryPlatformLogFilterValues", ctx, req)}
+}
+
+func (_c *MockPlatformLogsQuerier_QueryPlatformLogFilterValues_Call) Run(run func(ctx context.Context, req *types.PlatformLogFilterValuesRequest)) *MockPlatformLogsQuerier_QueryPlatformLogFilterValues_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*types.PlatformLogFilterValuesRequest))
+	})
+	return _c
+}
+
+func (_c *MockPlatformLogsQuerier_QueryPlatformLogFilterValues_Call) Return(_a0 *types.PlatformLogFilterValuesResponse, _a1 error) *MockPlatformLogsQuerier_QueryPlatformLogFilterValues_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockPlatformLogsQuerier_QueryPlatformLogFilterValues_Call) RunAndReturn(run func(context.Context, *types.PlatformLogFilterValuesRequest) (*types.PlatformLogFilterValuesResponse, error)) *MockPlatformLogsQuerier_QueryPlatformLogFilterValues_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // QueryPlatformLogs provides a mock function with given fields: ctx, req
 func (_m *MockPlatformLogsQuerier) QueryPlatformLogs(ctx context.Context, req *types.PlatformLogsQueryRequest) (*types.PlatformLogsResponse, error) {
 	ret := _m.Called(ctx, req)

--- a/internal/observer/service/platform_logs.go
+++ b/internal/observer/service/platform_logs.go
@@ -88,3 +88,63 @@ func (s *PlatformLogsService) QueryPlatformLogs(
 		TookMs: result.Took,
 	}, nil
 }
+
+// --- filter values ---
+
+// ErrPlatformLogFilterValuesRetrieval wraps a failure to reach or read from the logs
+// adapter.
+var ErrPlatformLogFilterValuesRetrieval = errors.New("platform log filter values retrieval failed")
+
+// QueryPlatformLogFilterValues lists the values one coordinate filter can take.
+func (s *PlatformLogsService) QueryPlatformLogFilterValues(
+	ctx context.Context,
+	req *types.PlatformLogFilterValuesRequest,
+) (*types.PlatformLogFilterValuesResponse, error) {
+	startTime, err := time.Parse(time.RFC3339, req.Query.StartTime)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse start time: %w", err)
+	}
+	endTime, err := time.Parse(time.RFC3339, req.Query.EndTime)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse end time: %w", err)
+	}
+
+	result, err := s.adapter.GetPlatformLogFilterValues(ctx, observability.PlatformLogFilterValuesParams{
+		Query: observability.PlatformLogsParams{
+			ClusterInstances: req.Query.ClusterInstances,
+			Namespaces:       req.Query.Namespaces,
+			PodNames:         req.Query.PodNames,
+			ContainerNames:   req.Query.ContainerNames,
+			Labels:           req.Query.Labels,
+			StartTime:        startTime,
+			EndTime:          endTime,
+			SearchPhrase:     req.Query.SearchPhrase,
+			LogLevels:        req.Query.LogLevels,
+		},
+		Filter:      req.Filter,
+		ValueSearch: req.ValueSearch,
+		MaxValues:   req.MaxValues,
+	})
+	if err != nil {
+		// Passed through unwrapped so the handler can answer 501 rather than
+		// reporting a failure.
+		if errors.Is(err, ErrPlatformLogFilterValuesNotSupported) {
+			return nil, err
+		}
+		s.logger.Error("Failed to retrieve platform log filter values", "error", err)
+		return nil, fmt.Errorf("%w: %w", ErrPlatformLogFilterValuesRetrieval, err)
+	}
+
+	values := make([]types.PlatformLogFilterValue, 0, len(result.Values))
+	for _, v := range result.Values {
+		values = append(values, types.PlatformLogFilterValue{Value: v.Value, Count: v.Count})
+	}
+
+	return &types.PlatformLogFilterValuesResponse{
+		Filter:        result.Filter,
+		Values:        values,
+		TotalValues:   result.TotalValues,
+		TotalRelation: result.TotalRelation,
+		TookMs:        result.Took,
+	}, nil
+}

--- a/internal/observer/service/platform_logs_adapter.go
+++ b/internal/observer/service/platform_logs_adapter.go
@@ -120,3 +120,89 @@ func derefMap(ptr *map[string]string) map[string]string {
 	}
 	return *ptr
 }
+
+// --- filter values ---
+
+// ErrPlatformLogFilterValuesNotSupported is returned when the configured logs adapter
+// answers 501. Aggregating a field's values is work an adapter may not be able to do
+// even though it serves platform logs, so this is a distinct condition from
+// ErrPlatformLogsNotSupported and from a failure.
+var ErrPlatformLogFilterValuesNotSupported = errors.New(
+	"platform log filter values are not supported by the configured logs adapter")
+
+// GetPlatformLogFilterValues implements observability.PlatformLogsAdapter.
+func (p *LogsAdapter) GetPlatformLogFilterValues(
+	ctx context.Context,
+	params observability.PlatformLogFilterValuesParams,
+) (*observability.PlatformLogFilterValuesResult, error) {
+	client, err := logsadapterclientgen.NewClientWithResponses(
+		p.baseURL, logsadapterclientgen.WithHTTPClient(p.httpClient))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create platform log filter values client: %w", err)
+	}
+
+	// The record query goes over the wire whole, including the named filter's own
+	// selections: excluding them is the adapter's job, and sending a doctored query
+	// would leave it unable to tell "not selected" from "excluded for this call".
+	query := logsadapterclientgen.PlatformLogsQueryRequest{
+		StartTime: params.Query.StartTime,
+		EndTime:   params.Query.EndTime,
+	}
+	setIfNotEmpty(&query.ClusterInstance, params.Query.ClusterInstances)
+	setIfNotEmpty(&query.Namespace, params.Query.Namespaces)
+	setIfNotEmpty(&query.PodName, params.Query.PodNames)
+	setIfNotEmpty(&query.ContainerName, params.Query.ContainerNames)
+	if len(params.Query.Labels) > 0 {
+		labels := params.Query.Labels
+		query.Labels = &labels
+	}
+	if len(params.Query.LogLevels) > 0 {
+		levels := make([]logsadapterclientgen.PlatformLogsQueryRequestLogLevels, 0, len(params.Query.LogLevels))
+		for _, l := range params.Query.LogLevels {
+			levels = append(levels, logsadapterclientgen.PlatformLogsQueryRequestLogLevels(l))
+		}
+		query.LogLevels = &levels
+	}
+	if params.Query.SearchPhrase != "" {
+		query.SearchPhrase = &params.Query.SearchPhrase
+	}
+
+	body := logsadapterclientgen.QueryPlatformLogFilterValuesJSONRequestBody{
+		Query:  query,
+		Filter: logsadapterclientgen.PlatformLogFilterValuesRequestFilter(params.Filter),
+	}
+	if params.ValueSearch != "" {
+		body.ValueSearch = &params.ValueSearch
+	}
+	if params.MaxValues > 0 {
+		body.MaxValues = &params.MaxValues
+	}
+
+	resp, err := client.QueryPlatformLogFilterValuesWithResponse(ctx, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+
+	if resp.StatusCode() == http.StatusNotImplemented {
+		return nil, ErrPlatformLogFilterValuesNotSupported
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode(), string(resp.Body))
+	}
+	if resp.JSON200 == nil {
+		return nil, fmt.Errorf("unexpected nil response body")
+	}
+
+	values := make([]observability.PlatformLogFilterValue, 0, len(resp.JSON200.Values))
+	for _, v := range resp.JSON200.Values {
+		values = append(values, observability.PlatformLogFilterValue{Value: v.Value, Count: v.Count})
+	}
+
+	return &observability.PlatformLogFilterValuesResult{
+		Filter:        resp.JSON200.Filter,
+		Values:        values,
+		TotalValues:   resp.JSON200.TotalValues,
+		TotalRelation: string(resp.JSON200.TotalRelation),
+		Took:          resp.JSON200.TookMs,
+	}, nil
+}

--- a/internal/observer/service/platform_logs_adapter_test.go
+++ b/internal/observer/service/platform_logs_adapter_test.go
@@ -254,3 +254,160 @@ func TestLogsAdapter_GetPlatformLogs_UpstreamErrors(t *testing.T) {
 		})
 	}
 }
+
+// --- filter values ---
+
+func filterValuesParams() observability.PlatformLogFilterValuesParams {
+	return observability.PlatformLogFilterValuesParams{
+		Filter:      "podName",
+		ValueSearch: "controller",
+		MaxValues:   50,
+		Query: observability.PlatformLogsParams{
+			Namespaces:   []string{"openchoreo-control-plane"},
+			PodNames:     []string{"already-selected"},
+			Labels:       map[string]string{"openchoreo.dev/plane": "controlplane"},
+			LogLevels:    []string{"ERROR"},
+			SearchPhrase: "reconcile",
+			StartTime:    time.Date(2026, 8, 14, 16, 30, 0, 0, time.UTC),
+			EndTime:      time.Date(2026, 8, 14, 17, 30, 0, 0, time.UTC),
+		},
+	}
+}
+
+func okFilterValuesBody() map[string]any {
+	return map[string]any{
+		"filter": "podName", "values": []any{},
+		"totalValues": 0, "totalRelation": "eq", "tookMs": 1,
+	}
+}
+
+// Pins what the observer puts on the wire: the POST path from the adapter contract, and
+// the record query nested under `query` rather than flattened alongside `filter`.
+func TestLogsAdapter_GetPlatformLogFilterValues_RequestContract(t *testing.T) {
+	t.Parallel()
+
+	var gotBody map[string]any
+	var gotMethod, gotPath string
+	server := platformLogsServer(t, http.StatusOK, okFilterValuesBody(), &gotBody, &gotMethod, &gotPath)
+	defer server.Close()
+
+	_, err := newTestPlatformLogsAdapter(t, server.URL).
+		GetPlatformLogFilterValues(context.Background(), filterValuesParams())
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPost, gotMethod)
+	assert.Equal(t, "/api/v1alpha1/platform-logs/filter-values", gotPath)
+	assert.Equal(t, "podName", gotBody["filter"])
+	assert.Equal(t, "controller", gotBody["valueSearch"])
+	assert.EqualValues(t, 50, gotBody["maxValues"])
+
+	query, ok := gotBody["query"].(map[string]any)
+	require.True(t, ok, "the record query must be nested under query, got %v", gotBody)
+	assert.Equal(t, []any{"openchoreo-control-plane"}, query["namespace"])
+	assert.Equal(t, map[string]any{"openchoreo.dev/plane": "controlplane"}, query["labels"])
+	assert.Equal(t, []any{"ERROR"}, query["logLevels"])
+	assert.Equal(t, "reconcile", query["searchPhrase"])
+	assert.Equal(t, "2026-08-14T16:30:00Z", query["startTime"])
+
+	// Paging and ordering describe a page of records, of which this returns none.
+	assert.NotContains(t, query, "limit")
+	assert.NotContains(t, query, "sortOrder")
+}
+
+// The named filter's own selections are sent untouched: excluding them is the adapter's
+// job, and a doctored query would leave it unable to tell "not selected" from "excluded
+// for this call".
+func TestLogsAdapter_GetPlatformLogFilterValues_SendsNamedFilterSelections(t *testing.T) {
+	t.Parallel()
+
+	var gotBody map[string]any
+	server := platformLogsServer(t, http.StatusOK, okFilterValuesBody(), &gotBody, nil, nil)
+	defer server.Close()
+
+	_, err := newTestPlatformLogsAdapter(t, server.URL).
+		GetPlatformLogFilterValues(context.Background(), filterValuesParams())
+	require.NoError(t, err)
+
+	query := gotBody["query"].(map[string]any)
+	assert.Equal(t, []any{"already-selected"}, query["podName"])
+}
+
+func TestLogsAdapter_GetPlatformLogFilterValues_OmitsUnsetOptions(t *testing.T) {
+	t.Parallel()
+
+	var gotBody map[string]any
+	server := platformLogsServer(t, http.StatusOK, okFilterValuesBody(), &gotBody, nil, nil)
+	defer server.Close()
+
+	params := filterValuesParams()
+	params.ValueSearch = ""
+	params.MaxValues = 0
+
+	_, err := newTestPlatformLogsAdapter(t, server.URL).
+		GetPlatformLogFilterValues(context.Background(), params)
+	require.NoError(t, err)
+
+	assert.NotContains(t, gotBody, "valueSearch")
+	assert.NotContains(t, gotBody, "maxValues")
+}
+
+func TestLogsAdapter_GetPlatformLogFilterValues_MapsResponse(t *testing.T) {
+	t.Parallel()
+
+	server := platformLogsServer(t, http.StatusOK, map[string]any{
+		"filter": "podName",
+		"values": []map[string]any{
+			{"value": "controller-manager-abc", "count": 412},
+			{"value": "controller-manager-xyz", "count": 88},
+		},
+		"totalValues": 940, "totalRelation": "gte", "tookMs": 12,
+	}, nil, nil, nil)
+	defer server.Close()
+
+	result, err := newTestPlatformLogsAdapter(t, server.URL).
+		GetPlatformLogFilterValues(context.Background(), filterValuesParams())
+	require.NoError(t, err)
+
+	assert.Equal(t, "podName", result.Filter)
+	assert.Equal(t, []observability.PlatformLogFilterValue{
+		{Value: "controller-manager-abc", Count: 412},
+		{Value: "controller-manager-xyz", Count: 88},
+	}, result.Values)
+	// A truncated list says so, rather than ending silently.
+	assert.EqualValues(t, 940, result.TotalValues)
+	assert.Equal(t, "gte", result.TotalRelation)
+	assert.Equal(t, 12, result.Took)
+}
+
+// An adapter may serve platform logs and still not be able to aggregate their fields,
+// so this 501 is its own condition rather than the platform logs one.
+func TestLogsAdapter_GetPlatformLogFilterValues_NotImplemented(t *testing.T) {
+	t.Parallel()
+
+	server := platformLogsServer(t, http.StatusNotImplemented, map[string]any{
+		"title":   "notImplemented",
+		"message": "platform log filter values are not supported by this adapter",
+	}, nil, nil, nil)
+	defer server.Close()
+
+	_, err := newTestPlatformLogsAdapter(t, server.URL).
+		GetPlatformLogFilterValues(context.Background(), filterValuesParams())
+
+	require.ErrorIs(t, err, ErrPlatformLogFilterValuesNotSupported)
+	assert.NotErrorIs(t, err, ErrPlatformLogsNotSupported)
+}
+
+func TestLogsAdapter_GetPlatformLogFilterValues_UpstreamError(t *testing.T) {
+	t.Parallel()
+
+	server := platformLogsServer(t, http.StatusInternalServerError,
+		map[string]any{"title": "internalServerError"}, nil, nil, nil)
+	defer server.Close()
+
+	_, err := newTestPlatformLogsAdapter(t, server.URL).
+		GetPlatformLogFilterValues(context.Background(), filterValuesParams())
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrPlatformLogFilterValuesNotSupported)
+	assert.Contains(t, err.Error(), "500")
+}

--- a/internal/observer/service/platform_logs_authz.go
+++ b/internal/observer/service/platform_logs_authz.go
@@ -50,3 +50,22 @@ func (s *platformLogsServiceWithAuthz) QueryPlatformLogs(
 	}
 	return s.internal.QueryPlatformLogs(ctx, req)
 }
+
+// --- filter values ---
+
+func (s *platformLogsServiceWithAuthz) QueryPlatformLogFilterValues(
+	ctx context.Context,
+	req *types.PlatformLogFilterValuesRequest,
+) (*types.PlatformLogFilterValuesResponse, error) {
+	// The same action and the same cluster scope as the platform logs themselves.
+	// An empty hierarchy maps to "*", which only a cluster-scoped binding satisfies.
+	if err := observerAuthz.CheckAuthorization(
+		ctx, s.logger, s.pdp,
+		observerAuthz.ActionViewPlatformLogs,
+		observerAuthz.ResourceTypePlatform, "", authzcore.ResourceHierarchy{},
+		authzcore.Context{},
+	); err != nil {
+		return nil, err
+	}
+	return s.internal.QueryPlatformLogFilterValues(ctx, req)
+}

--- a/internal/observer/service/platform_logs_authz_test.go
+++ b/internal/observer/service/platform_logs_authz_test.go
@@ -97,3 +97,40 @@ func TestPlatformLogsAuthz_EvaluatesAtClusterScope(t *testing.T) {
 	assert.Equal(t, authzcore.ResourceHierarchy{}, captured.Resource.Hierarchy,
 		"platform logs must evaluate at cluster scope")
 }
+
+// --- filter values ---
+
+func TestPlatformLogsAuthz_FilterValues_Denied(t *testing.T) {
+	inner := mocks.NewMockPlatformLogsQuerier(t)
+
+	svc := NewPlatformLogsServiceWithAuthz(inner, mockPDPDeny(t), testLogger())
+
+	_, err := svc.QueryPlatformLogFilterValues(authedCtx(), filterValuesRequest())
+	require.ErrorIs(t, err, observerAuthz.ErrAuthzForbidden)
+	inner.AssertNotCalled(t, "QueryPlatformLogFilterValues", mock.Anything, mock.Anything)
+}
+
+// Pins that listing a filter's values is gated by the same action and the same cluster
+// scope as reading the logs. Anything weaker would let a caller enumerate every pod the
+// plane collects without being able to read one line of it.
+func TestPlatformLogsAuthz_FilterValues_MatchesPlatformLogsPermission(t *testing.T) {
+	inner := mocks.NewMockPlatformLogsQuerier(t)
+	inner.EXPECT().QueryPlatformLogFilterValues(mock.Anything, mock.Anything).
+		Return(&types.PlatformLogFilterValuesResponse{}, nil)
+
+	var captured authzcore.EvaluateRequest
+	pdp := coremocks.NewMockPDP(t)
+	pdp.EXPECT().Evaluate(mock.Anything, mock.Anything).
+		Run(func(_ context.Context, req *authzcore.EvaluateRequest) {
+			captured = *req
+		}).
+		Return(&authzcore.Decision{Decision: true}, nil).Once()
+
+	svc := NewPlatformLogsServiceWithAuthz(inner, pdp, testLogger())
+	_, err := svc.QueryPlatformLogFilterValues(authedCtx(), filterValuesRequest())
+	require.NoError(t, err)
+
+	assert.Equal(t, string(observerAuthz.ActionViewPlatformLogs), captured.Action)
+	assert.Equal(t, authzcore.ResourceHierarchy{}, captured.Resource.Hierarchy,
+		"filter values must evaluate at cluster scope, like the logs themselves")
+}

--- a/internal/observer/service/platform_logs_test.go
+++ b/internal/observer/service/platform_logs_test.go
@@ -22,6 +22,9 @@ type stubPlatformLogsAdapter struct {
 	got    observability.PlatformLogsParams
 	result *observability.PlatformLogsResult
 	err    error
+
+	gotFilterValues observability.PlatformLogFilterValuesParams
+	filterValues    *observability.PlatformLogFilterValuesResult
 }
 
 func (s *stubPlatformLogsAdapter) GetPlatformLogs(
@@ -29,6 +32,13 @@ func (s *stubPlatformLogsAdapter) GetPlatformLogs(
 ) (*observability.PlatformLogsResult, error) {
 	s.got = params
 	return s.result, s.err
+}
+
+func (s *stubPlatformLogsAdapter) GetPlatformLogFilterValues(
+	_ context.Context, params observability.PlatformLogFilterValuesParams,
+) (*observability.PlatformLogFilterValuesResult, error) {
+	s.gotFilterValues = params
+	return s.filterValues, s.err
 }
 
 func TestPlatformLogsService_QueryPlatformLogs(t *testing.T) {
@@ -112,6 +122,112 @@ func TestPlatformLogsService_InvalidTimeRange(t *testing.T) {
 		StartTime: "not-a-time",
 		EndTime:   "2026-08-14T17:30:00Z",
 	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse start time")
+}
+
+// --- filter values ---
+
+func filterValuesRequest() *types.PlatformLogFilterValuesRequest {
+	return &types.PlatformLogFilterValuesRequest{
+		Filter:      "podName",
+		ValueSearch: "controller",
+		MaxValues:   100,
+		Query: types.PlatformLogsQueryRequest{
+			Namespaces: []string{"openchoreo-control-plane"},
+			PodNames:   []string{"already-selected"},
+			Labels:     map[string]string{"openchoreo.dev/plane": "controlplane"},
+			StartTime:  "2026-08-14T16:30:00Z",
+			EndTime:    "2026-08-14T17:30:00Z",
+		},
+	}
+}
+
+func TestPlatformLogsService_FilterValues_Query(t *testing.T) {
+	t.Parallel()
+
+	adapter := &stubPlatformLogsAdapter{
+		filterValues: &observability.PlatformLogFilterValuesResult{
+			Filter: "podName",
+			Values: []observability.PlatformLogFilterValue{
+				{Value: "controller-manager-abc", Count: 412},
+				{Value: "controller-manager-xyz", Count: 88},
+			},
+			TotalValues:   2,
+			TotalRelation: "eq",
+			Took:          7,
+		},
+	}
+
+	svc := NewPlatformLogsService(adapter, testLogger())
+	resp, err := svc.QueryPlatformLogFilterValues(context.Background(), filterValuesRequest())
+	require.NoError(t, err)
+
+	assert.Equal(t, "podName", adapter.gotFilterValues.Filter)
+	assert.Equal(t, "controller", adapter.gotFilterValues.ValueSearch)
+	assert.Equal(t, 100, adapter.gotFilterValues.MaxValues)
+	assert.Equal(t, time.Date(2026, 8, 14, 16, 30, 0, 0, time.UTC), adapter.gotFilterValues.Query.StartTime)
+	assert.Equal(t, []string{"openchoreo-control-plane"}, adapter.gotFilterValues.Query.Namespaces)
+	assert.Equal(t, map[string]string{"openchoreo.dev/plane": "controlplane"}, adapter.gotFilterValues.Query.Labels)
+
+	assert.Equal(t, "podName", resp.Filter)
+	require.Len(t, resp.Values, 2)
+	assert.Equal(t, types.PlatformLogFilterValue{Value: "controller-manager-abc", Count: 412}, resp.Values[0])
+	assert.EqualValues(t, 2, resp.TotalValues)
+	assert.Equal(t, "eq", resp.TotalRelation)
+	assert.Equal(t, 7, resp.TookMs)
+}
+
+// The named filter's own selections go over the wire untouched. Excluding them is the
+// adapter's job, and doctoring the query here would leave it unable to tell "not
+// selected" from "excluded for this call".
+func TestPlatformLogsService_FilterValues_ForwardsNamedFilterSelections(t *testing.T) {
+	t.Parallel()
+
+	adapter := &stubPlatformLogsAdapter{
+		filterValues: &observability.PlatformLogFilterValuesResult{Filter: "podName", TotalRelation: "eq"},
+	}
+	svc := NewPlatformLogsService(adapter, testLogger())
+
+	_, err := svc.QueryPlatformLogFilterValues(context.Background(), filterValuesRequest())
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"already-selected"}, adapter.gotFilterValues.Query.PodNames)
+}
+
+func TestPlatformLogsService_FilterValues_NotSupportedPassesThrough(t *testing.T) {
+	t.Parallel()
+
+	adapter := &stubPlatformLogsAdapter{err: ErrPlatformLogFilterValuesNotSupported}
+	svc := NewPlatformLogsService(adapter, testLogger())
+
+	_, err := svc.QueryPlatformLogFilterValues(context.Background(), filterValuesRequest())
+
+	require.ErrorIs(t, err, ErrPlatformLogFilterValuesNotSupported)
+	assert.NotErrorIs(t, err, ErrPlatformLogFilterValuesRetrieval)
+}
+
+func TestPlatformLogsService_FilterValues_RetrievalFailureIsWrapped(t *testing.T) {
+	t.Parallel()
+
+	adapter := &stubPlatformLogsAdapter{err: errors.New("connection refused")}
+	svc := NewPlatformLogsService(adapter, testLogger())
+
+	_, err := svc.QueryPlatformLogFilterValues(context.Background(), filterValuesRequest())
+
+	require.ErrorIs(t, err, ErrPlatformLogFilterValuesRetrieval)
+	assert.Contains(t, err.Error(), "connection refused")
+}
+
+func TestPlatformLogsService_FilterValues_InvalidTimeRange(t *testing.T) {
+	t.Parallel()
+
+	svc := NewPlatformLogsService(&stubPlatformLogsAdapter{}, testLogger())
+	req := filterValuesRequest()
+	req.Query.StartTime = "not-a-time"
+
+	_, err := svc.QueryPlatformLogFilterValues(context.Background(), req)
+
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse start time")
 }

--- a/internal/observer/types/errors.go
+++ b/internal/observer/types/errors.go
@@ -50,6 +50,11 @@ const (
 	ErrorCodeV1PlatformLogsRetrievalFailed = "OBS-V1-CL-04"
 	ErrorCodeV1PlatformLogsNotSupported    = "OBS-V1-CL-05"
 
+	// Platform log filter values (v1alpha1) — same area, continuing the sequence.
+	ErrorCodeV1PlatformLogFilterValuesServiceNotReady = "OBS-V1-CL-06"
+	ErrorCodeV1PlatformLogFilterValuesRetrievalFailed = "OBS-V1-CL-07"
+	ErrorCodeV1PlatformLogFilterValuesNotSupported    = "OBS-V1-CL-08"
+
 	// Scope resolution auth failure — shared across all APIs.
 	ErrorCodeV1ScopeAuthFailed = "OBS-V1-SCOPE-AUTH-FAILED"
 )

--- a/internal/observer/types/platformlogs.go
+++ b/internal/observer/types/platformlogs.go
@@ -51,3 +51,37 @@ type PlatformLogsResponse struct {
 	Total  int           `json:"total"`
 	TookMs int           `json:"tookMs"`
 }
+
+// PlatformLogFilterValuesRequest is the parsed form of the query string on
+// GET /api/v1alpha1/platform-logs/filter-values.
+type PlatformLogFilterValuesRequest struct {
+	// Query is the record query the values are drawn from. Its own selections for
+	// Filter are ignored.
+	Query PlatformLogsQueryRequest `json:"query"`
+
+	// Filter names the coordinate to list (required)
+	Filter string `json:"filter"`
+
+	// ValueSearch narrows the values returned rather than the records (optional)
+	ValueSearch string `json:"valueSearch,omitempty"`
+
+	// MaxValues caps how many values come back (optional)
+	MaxValues int `json:"maxValues,omitempty"`
+}
+
+// PlatformLogFilterValue is one value a filter takes, with how many records carry it.
+// Matches the OpenAPI schema of the same name.
+type PlatformLogFilterValue struct {
+	Value string `json:"value"`
+	Count int64  `json:"count"`
+}
+
+// PlatformLogFilterValuesResponse is the response for
+// GET /api/v1alpha1/platform-logs/filter-values.
+type PlatformLogFilterValuesResponse struct {
+	Filter        string                   `json:"filter"`
+	Values        []PlatformLogFilterValue `json:"values"`
+	TotalValues   int64                    `json:"totalValues"`
+	TotalRelation string                   `json:"totalRelation"`
+	TookMs        int                      `json:"tookMs"`
+}

--- a/openapi/observability-logs-adapter-api.yaml
+++ b/openapi/observability-logs-adapter-api.yaml
@@ -176,6 +176,69 @@ paths:
                 errorCode: ""
                 message: "platform logs are not supported by this adapter"
 
+  /api/v1alpha1/platform-logs/filter-values:
+    post:
+      tags:
+        - Logs
+      summary: List the distinct values one platform logs filter can take
+      description: |
+        Returns the distinct values a single filter takes under a query, with a count
+        for each. Backs `GET /api/v1alpha1/platform-logs/filter-values` on the observer.
+
+        The values are those reachable under `query`'s other filters, except the one
+        named by `filter`, whose own selections are ignored - a filter that counted its
+        own selection would offer only what is already picked.
+
+        An adapter that serves platform logs but cannot aggregate answers 501.
+      operationId: queryPlatformLogFilterValues
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlatformLogFilterValuesRequest"
+      responses:
+        "200":
+          description: Filter values retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformLogFilterValuesResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "501":
+          description: Not Implemented
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                title: "notImplemented"
+                errorCode: ""
+                message: "platform log filter values are not supported by this adapter"
+
   /api/v1/events/query:
     post:
       tags:
@@ -700,6 +763,96 @@ components:
           type: integer
           description: The time taken to query the logs in milliseconds
       required: [logs, total, tookMs]
+
+    PlatformLogFilterValuesRequest:
+      type: object
+      description: |
+        Which filter to list values for, and the query to list them under.
+
+        `query` is a full `PlatformLogsQueryRequest`, in the same shape as a record
+        query - so the observer passes the query it already holds rather than
+        rebuilding it. Its `startTime` and `endTime` are required, so every call here
+        is scoped to a period.
+
+        The other filters in `query` narrow which records the values are drawn from,
+        except the one named by `filter`, whose own selections are ignored.
+
+        `query.limit` and `query.sortOrder` carry no meaning here: no records are
+        returned, so there is nothing to page or order. They are accepted and ignored
+        rather than rejected.
+      required: [query, filter]
+      properties:
+        query:
+          $ref: "#/components/schemas/PlatformLogsQueryRequest"
+        filter:
+          type: string
+          description: |
+            The filter to list values for, named as the request field that accepts it.
+          enum: [clusterInstance, namespace, podName, containerName]
+        valueSearch:
+          type: string
+          maxLength: 256
+          description: |
+            Return only values containing this text, case-insensitively. Narrows the
+            *values* returned, where `query.searchPhrase` narrows the *records* they
+            are drawn from.
+        maxValues:
+          type: integer
+          default: 100
+          minimum: 1
+          maximum: 1000
+          description: |
+            The maximum number of values to return, ordered by `count` descending then
+            `value` ascending, so a truncated list holds the busiest. Named to stay
+            distinct from `query.limit`, which is a record page size and is ignored
+            here.
+
+    PlatformLogFilterValue:
+      type: object
+      description: One value a filter takes, with how many records carry it.
+      required: [value, count]
+      properties:
+        value:
+          type: string
+          description: The value, exactly as it would be sent back as a filter
+        count:
+          type: integer
+          format: int64
+          minimum: 1
+          description: |
+            Matching records carrying this value. May be approximate on a
+            high-cardinality filter where the backend answers from a partial term
+            count, so it is an ordering hint rather than a total.
+
+    PlatformLogFilterValuesResponse:
+      type: object
+      required: [filter, values, totalValues, totalRelation, tookMs]
+      properties:
+        filter:
+          type: string
+          description: The filter these values belong to, echoed from the request
+        values:
+          type: array
+          description: |
+            Distinct values, ordered by `count` descending then `value` ascending.
+            Records on which the field is absent are not represented: no empty-string
+            entry, because no filter value would select one.
+          items:
+            $ref: "#/components/schemas/PlatformLogFilterValue"
+        totalValues:
+          type: integer
+          format: int64
+          minimum: 0
+          description: |
+            How many distinct values match, of which at most `maxValues` were returned.
+        totalRelation:
+          type: string
+          enum: [eq, gte]
+          description: |
+            Whether `totalValues` is exact (`eq`) or a lower bound (`gte`).
+        tookMs:
+          type: integer
+          description: The time taken to compute the values in milliseconds
 
     # Request schema for events
     EventsQueryRequest:

--- a/openapi/observer-api.yaml
+++ b/openapi/observer-api.yaml
@@ -460,6 +460,84 @@ paths:
                 errorCode: ""
                 message: "platform logs are not supported by this adapter"
 
+  /api/v1alpha1/platform-logs/filter-values:
+    get:
+      tags:
+        - Logs
+      summary: List the distinct values one platform logs filter can take
+      description: |
+        Returns the distinct values one filter takes across the platform logs matching a
+        query, with a count for each - what a filter picker is populated from, rather
+        than only the values that happen to appear in the page a client has loaded.
+
+        One filter per request: each costs an aggregation, so a client asks for the
+        picker it has open. The query narrows which records the values are drawn from,
+        except for the named filter's own selections, which are ignored - counting
+        `podName` under a selected pod would offer that pod alone, with no way back to
+        the others.
+
+        Takes the same query parameters as `GET /api/v1alpha1/platform-logs`, so a
+        client sends the query string it already holds. `limit` and `sortOrder` are not
+        among them: no records are returned.
+      operationId: getPlatformLogFilterValues
+      parameters:
+        - $ref: "#/components/parameters/PlatformLogFilterValuesFilter"
+        - $ref: "#/components/parameters/PlatformLogsStartTime"
+        - $ref: "#/components/parameters/PlatformLogsEndTime"
+        - $ref: "#/components/parameters/PlatformLogsClusterInstance"
+        - $ref: "#/components/parameters/PlatformLogsNamespace"
+        - $ref: "#/components/parameters/PlatformLogsPodName"
+        - $ref: "#/components/parameters/PlatformLogsContainerName"
+        - $ref: "#/components/parameters/PlatformLogsLabels"
+        - $ref: "#/components/parameters/PlatformLogsLogLevels"
+        - $ref: "#/components/parameters/PlatformLogsSearchPhrase"
+        - $ref: "#/components/parameters/PlatformLogFilterValuesValueSearch"
+        - $ref: "#/components/parameters/PlatformLogFilterValuesMaxValues"
+      responses:
+        "200":
+          description: Filter values retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformLogFilterValuesResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "501":
+          description: |
+            Not Implemented. Surfaced when the logs adapter backing this observer
+            cannot enumerate filter values, which it may not be able to do even
+            though it serves platform logs.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              example:
+                title: "notImplemented"
+                errorCode: ""
+                message: "platform log filter values are not supported by this adapter"
+
   # Runtime topology endpoint (for cell diagram with runtime observability)
   /api/v1alpha1/metrics/runtime-topology:
     post:
@@ -1037,6 +1115,50 @@ components:
         type: string
         enum: [asc, desc]
         default: desc
+    PlatformLogFilterValuesFilter:
+      name: filter
+      in: query
+      required: true
+      description: |
+        The filter to list values for, named as the query parameter that accepts it -
+        `podName` lists the values that filter takes.
+
+        Only the coordinate filters are listed. `logLevels` is a fixed enum a client
+        already knows, and `labels` is a selector rather than a field with values.
+      schema:
+        type: string
+        enum: [clusterInstance, namespace, podName, containerName]
+        example: podName
+    PlatformLogFilterValuesValueSearch:
+      name: valueSearch
+      in: query
+      required: false
+      description: |
+        Return only values containing this text, case-insensitively. This is how a
+        picker narrows as its user types, and it is what makes a high-cardinality
+        filter usable at all: `podName` on a busy plane has more distinct values than
+        any list should offer, and typing three characters cuts it to something
+        choosable.
+
+        Distinct from `searchPhrase`, which narrows the *records* considered. This
+        narrows the *values* returned from those records.
+      schema:
+        type: string
+        maxLength: 256
+        example: controller
+    PlatformLogFilterValuesMaxValues:
+      name: maxValues
+      in: query
+      required: false
+      description: |
+        The maximum number of values to return, ordered by `count` descending then
+        `value` ascending - so a truncated list holds the busiest. Named to stay
+        distinct from `limit`, which is a record page size and has no meaning here.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 1000
+        default: 100
 
   schemas:
     # Request schemas for logs
@@ -1258,6 +1380,73 @@ components:
           format: int64
           minimum: 0
           description: The time taken to query the logs in milliseconds.
+
+    PlatformLogFilterValue:
+      type: object
+      description: One value a filter takes, with how many records carry it.
+      required:
+        - value
+        - count
+      properties:
+        value:
+          type: string
+          description: The value, exactly as it would be sent back as a filter.
+          example: controller-manager-7f58b689b5-pwsb5
+        count:
+          type: integer
+          format: int64
+          minimum: 1
+          description: |
+            Matching records carrying this value, within the queried window. May be
+            approximate on a high-cardinality filter where the backend answers from a
+            partial term count, so treat it as an ordering hint and a sense of scale
+            rather than a total.
+          example: 412
+
+    PlatformLogFilterValuesResponse:
+      type: object
+      required:
+        - filter
+        - values
+        - totalValues
+        - totalRelation
+        - tookMs
+      properties:
+        filter:
+          type: string
+          description: |
+            The filter these values belong to, echoed from the request so a client
+            handling several pickers can match a response to the one that asked.
+          example: podName
+        values:
+          type: array
+          description: |
+            The distinct values, ordered by `count` descending then `value` ascending.
+            Records on which the field is absent are not represented: no empty-string
+            entry, because no filter value would select one.
+          items:
+            $ref: "#/components/schemas/PlatformLogFilterValue"
+        totalValues:
+          type: integer
+          format: int64
+          minimum: 0
+          description: |
+            How many distinct values match, of which at most `maxValues` were returned.
+            Read together with `totalRelation` - this is what lets a picker say "412
+            more values, keep typing to narrow" rather than silently ending its list.
+        totalRelation:
+          type: string
+          enum: [eq, gte]
+          description: |
+            Whether `totalValues` is exact (`eq`) or a lower bound (`gte`). Counting
+            distinct values exactly is itself an expensive aggregation on a
+            high-cardinality field, and most backends answer approximately, so a
+            capped or estimated count is labelled rather than passed off as exact.
+        tookMs:
+          type: integer
+          format: int64
+          minimum: 0
+          description: The time taken to compute the values in milliseconds.
 
     # Request schema for events
     EventsQueryRequest:

--- a/pkg/observability/logs.go
+++ b/pkg/observability/logs.go
@@ -138,9 +138,50 @@ type LogsAdapter interface {
 		params WorkflowLogsParams) (*WorkflowLogsResult, error)
 }
 
+// PlatformLogFilterValuesParams asks what values one filter takes under a query.
+type PlatformLogFilterValuesParams struct {
+	// Query is the record query the values are drawn from. Its own selections for
+	// Filter are ignored - a filter that counted its own selection would offer only
+	// what is already picked.
+	Query PlatformLogsParams `json:"query"`
+	// Filter names the coordinate to list, as the query parameter that accepts it.
+	Filter string `json:"filter"`
+	// ValueSearch narrows the values returned, where Query.SearchPhrase narrows the
+	// records they are drawn from.
+	ValueSearch string `json:"valueSearch"`
+	MaxValues   int    `json:"maxValues"`
+}
+
+// PlatformLogFilterValue is one value a filter takes, with how many records carry it.
+// The count may be approximate on a high-cardinality filter, so it orders a list rather
+// than totalling it.
+type PlatformLogFilterValue struct {
+	Value string `json:"value"`
+	Count int64  `json:"count"`
+}
+
+// PlatformLogFilterValuesResult is the result of a filter values query.
+type PlatformLogFilterValuesResult struct {
+	Filter string                   `json:"filter"`
+	Values []PlatformLogFilterValue `json:"values"`
+	// TotalValues is how many distinct values match, of which at most MaxValues were
+	// returned. TotalRelation says whether it is exact ("eq") or a lower bound ("gte").
+	TotalValues   int64  `json:"totalValues"`
+	TotalRelation string `json:"totalRelation"`
+	Took          int    `json:"took"`
+}
+
 // PlatformLogsAdapter defines the interface for fetching platform logs
 type PlatformLogsAdapter interface {
 	// GetPlatformLogs retrieves logs by raw Kubernetes coordinates, with no
 	// project/component/environment correlation.
 	GetPlatformLogs(ctx context.Context, params PlatformLogsParams) (*PlatformLogsResult, error)
+
+	// GetPlatformLogFilterValues retrieves the distinct values one filter takes.
+	// Separately declinable from GetPlatformLogs: an adapter may serve the records
+	// without being able to aggregate them, and says so with a 501 rather than by
+	// implementing a narrower interface.
+	GetPlatformLogFilterValues(
+		ctx context.Context, params PlatformLogFilterValuesParams,
+	) (*PlatformLogFilterValuesResult, error)
 }


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits format: type(scope): subject
Scope is optional and subject must start with a lowercase letter.

Examples:
  feat(api): add endpoint for listing components
  fix(controller): handle nil pointer in reconciler
  docs: update contributor guide
  chore(deps): bump sigs.k8s.io/controller-runtime

See: docs/contributors/github_workflow.md#pr-title-convention
-->

## Purpose
This pull request adds support for querying available filter values for platform logs in the API client, enabling clients to dynamically fetch distinct values for log filters (such as cluster instance, namespace, pod name, etc.) along with their counts. This is useful for building filter pickers in UIs and for improving the user experience when searching logs. The changes include new API client methods, response types, and associated model definitions.

The most important changes are:

**API Client Enhancements:**

* Added a new method `GetPlatformLogFilterValues` to the `ClientInterface` and `ClientWithResponsesInterface` interfaces, along with its implementation, to support fetching available filter values for platform logs. [[1]](diffhunk://#diff-3e934c2452d32c2099dc8fb62b368e308482dd9b0987e54085d2de51d00706d8R139-R141) [[2]](diffhunk://#diff-3e934c2452d32c2099dc8fb62b368e308482dd9b0987e54085d2de51d00706d8R375-R386) [[3]](diffhunk://#diff-3e934c2452d32c2099dc8fb62b368e308482dd9b0987e54085d2de51d00706d8R1654-R1656) [[4]](diffhunk://#diff-3e934c2452d32c2099dc8fb62b368e308482dd9b0987e54085d2de51d00706d8R2252-R2260)
* Implemented request builder `NewGetPlatformLogFilterValuesRequest` to construct requests with all relevant query parameters for filter value retrieval.
* Added response parsing logic and a new response type `GetPlatformLogFilterValuesResp` to handle and unmarshal the API response. [[1]](diffhunk://#diff-3e934c2452d32c2099dc8fb62b368e308482dd9b0987e54085d2de51d00706d8R1964-R1990) [[2]](diffhunk://#diff-3e934c2452d32c2099dc8fb62b368e308482dd9b0987e54085d2de51d00706d8R2935-R2995)

**Model and Enum Additions:**

* Introduced new model types: `PlatformLogFilterValue`, `PlatformLogFilterValuesResponse`, and related enums for filter fields and log levels, to represent the structure of filter value responses. [[1]](diffhunk://#diff-cda6e80fbcdcf346fd2407d98f6f472ea83cbe6d75a79a5bab7da4017ddb0673R777-R820) [[2]](diffhunk://#diff-cda6e80fbcdcf346fd2407d98f6f472ea83cbe6d75a79a5bab7da4017ddb0673R98-R103) [[3]](diffhunk://#diff-cda6e80fbcdcf346fd2407d98f6f472ea83cbe6d75a79a5bab7da4017ddb0673R136-R143) [[4]](diffhunk://#diff-cda6e80fbcdcf346fd2407d98f6f472ea83cbe6d75a79a5bab7da4017ddb0673R164-R179) [[5]](diffhunk://#diff-cda6e80fbcdcf346fd2407d98f6f472ea83cbe6d75a79a5bab7da4017ddb0673R1204-R1212)

**Enum Refactoring:**

* Refactored some existing enums to use more descriptive constant names, improving code clarity and maintainability.

These changes collectively enable clients to query and display filter value options for platform logs, supporting more interactive and responsive log searching interfaces.

## Approach
- Introduced new endpoint `POST /api/v1alpha1/platform-logs/filter-values` to list distinct values for a specified log filter.
- Implemented `QueryPlatformLogFilterValues` method in `PlatformLogsService` to handle the new functionality.
- Added necessary types and error handling for filter values retrieval.
- Updated OpenAPI specifications to include the new endpoint and its request/response schemas.
- Enhanced authorization checks for accessing filter values in `platformLogsServiceWithAuthz`.
- Added unit tests to ensure correct behavior of the new filter values functionality.


## Related Issues
Epic: https://github.com/openchoreo/openchoreo/issues/4089
Task: https://github.com/openchoreo/openchoreo/issues/4556

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
<!-- Tick the box below if AI generated code or content in this PR. Simple autocomplete or asking AI to explain code doesn't count. See docs/contributors/AI-POLICY.md -->
- [x] This PR includes AI-generated code or content

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
