### PR TITLE
fix(api): adopt stateless MCP HTTP with go-sdk v1.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/knadh/koanf/providers/file v1.2.1
 	github.com/knadh/koanf/providers/structs v1.0.0
 	github.com/knadh/koanf/v2 v2.3.5
-	github.com/modelcontextprotocol/go-sdk v1.4.1
+	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/oapi-codegen/runtime v1.6.0
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
@@ -64,7 +64,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
-	github.com/google/jsonschema-go v0.4.2 // indirect
+	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
-github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 h1:EwtI+Al+DeppwYX2oXJCETMO23COyaKGP6fHVpkpWpg=
 github.com/google/pprof v0.0.0-20260402051712-545e8a4df936/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -208,8 +208,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
 github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
-github.com/modelcontextprotocol/go-sdk v1.4.1 h1:M4x9GyIPj+HoIlHNGpK2hq5o3BFhC+78PkEaldQRphc=
-github.com/modelcontextprotocol/go-sdk v1.4.1/go.mod h1:Bo/mS87hPQqHSRkMv4dQq1XCu6zv4INdXnFZabkNU6s=
+github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
+github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/internal/observer/mcp/server.go
+++ b/internal/observer/mcp/server.go
@@ -17,7 +17,7 @@ func NewHTTPServer(handler *MCPHandler) http.Handler {
 
 	return mcpsdk.NewStreamableHTTPHandler(func(r *http.Request) *mcpsdk.Server {
 		return server
-	}, nil)
+	}, &mcpsdk.StreamableHTTPOptions{Stateless: true})
 }
 
 // NewServer creates the MCP server with every observer tool registered.

--- a/internal/observer/mcp/server_test.go
+++ b/internal/observer/mcp/server_test.go
@@ -1059,12 +1059,14 @@ func TestToolErrorHandling(t *testing.T) {
 
 	mockHandler.resetAll()
 
-	_, err := clientSession.CallTool(ctx, &mcpsdk.CallToolParams{
+	result, err := clientSession.CallTool(ctx, &mcpsdk.CallToolParams{
 		Name:      testSpec.name,
 		Arguments: map[string]any{}, // Empty - missing required params
 	})
 
-	require.Error(t, err, "Expected error for tool %q with missing required parameters", testSpec.name)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.IsError, "Expected tool error for %q with missing required parameters", testSpec.name)
 }
 
 // TestMinimalParameterSets verifies that tools work with only required parameters.

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -16,8 +16,8 @@ import (
 	"github.com/openchoreo/openchoreo/pkg/mcp/tools"
 )
 
-// HTTP query parameter names recognized by the MCP HTTP handler. Both are
-// optional and read once per session-creation request.
+// HTTP query parameter names recognized by the MCP HTTP handler. These are
+// optional and read on every HTTP request.
 const (
 	// QueryParamToolsets narrows the toolsets visible via tools/list to a
 	// comma-separated subset (e.g. ?toolsets=namespace,component,pe). Unknown
@@ -42,10 +42,10 @@ const (
 
 // NewHTTPServer creates an MCP HTTP handler backed by a single shared server.
 //
-// All configured toolsets are registered up front. Per-session narrowing
-// happens via query parameters parsed from the initialize request:
+// All configured toolsets are registered up front. Per-request narrowing
+// happens via query parameters parsed from each HTTP request:
 //   - ?toolsets=ns1,ns2              — only show tools from those toolsets in tools/list
-//   - ?filterByAuthz=false           — disable MCP-layer authz filtering for the session
+//   - ?filterByAuthz=false           — disable MCP-layer authz filtering for the request
 //   - ?includeDeprecatedTools=true   — list the deprecated cluster-prefixed alias tools
 //     (hidden by default as of v1.2; they remain callable and are removed in v1.3)
 //
@@ -99,8 +99,8 @@ func NewHTTPServer(
 
 	streamable := mcp.NewStreamableHTTPHandler(func(r *http.Request) *mcp.Server {
 		return server
-	}, nil)
-	return withSessionQueryParams(streamable), nil
+	}, &mcp.StreamableHTTPOptions{Stateless: true})
+	return withRequestQueryParams(streamable), nil
 }
 
 // NewSTDIO creates an MCP server for STDIO transport (local CLI usage).
@@ -116,18 +116,11 @@ func NewSTDIO(toolsets *tools.Toolsets) *mcp.Server {
 	return server
 }
 
-// withSessionQueryParams returns an http.Handler that extracts the optional
-// MCP session-scoping query parameters (toolsets, filterByAuthz,
-// includeDeprecatedTools) from the request URL and stores them on the request
-// context. The MCP SDK propagates
-// the initialize request's context into the long-lived session, so the values
-// set here become the per-session scope used by the tool-filter middleware.
-//
-// Subsequent requests in a stateful session do not re-read these params — the
-// session is bound to the values supplied at session creation. In stateless
-// mode the params are honored on every request because each request creates a
-// fresh session.
-func withSessionQueryParams(next http.Handler) http.Handler {
+// withRequestQueryParams reads toolsets, filterByAuthz, and includeDeprecatedTools
+// from each HTTP request and passes them to the MCP middleware through its
+// context. Stateless requests must supply their own scope; no previous
+// request's query parameters are retained.
+func withRequestQueryParams(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
 		ctx := r.Context()

--- a/pkg/mcp/server_stateless_test.go
+++ b/pkg/mcp/server_stateless_test.go
@@ -1,0 +1,224 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	authzcore "github.com/openchoreo/openchoreo/internal/authz/core"
+	observermcp "github.com/openchoreo/openchoreo/internal/observer/mcp"
+	"github.com/openchoreo/openchoreo/internal/server/middleware/auth"
+	"github.com/openchoreo/openchoreo/pkg/mcp/mcpaudit"
+	"github.com/openchoreo/openchoreo/pkg/mcp/tools"
+)
+
+// Exercise the production HTTP handlers and SDK, including context propagation.
+// These requests deliberately carry no session ID or shared client state.
+func statelessRPC(t *testing.T, h http.Handler, query, version, body string) map[string]json.RawMessage {
+	t.Helper()
+	var message struct {
+		Method string         `json:"method"`
+		Params map[string]any `json:"params"`
+	}
+	if err := json.Unmarshal([]byte(body), &message); err != nil {
+		t.Fatal(err)
+	}
+	if version == "2026-07-28" {
+		message.Params["_meta"] = map[string]any{
+			"io.modelcontextprotocol/protocolVersion":    version,
+			"io.modelcontextprotocol/clientCapabilities": map[string]any{},
+			"io.modelcontextprotocol/clientInfo":         map[string]any{"name": "test", "version": "1"},
+		}
+		encoded, err := json.Marshal(map[string]any{
+			"jsonrpc": "2.0", "id": 1, "method": message.Method, "params": message.Params,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		body = string(encoded)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/mcp"+query, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("MCP-Protocol-Version", version)
+	if version == "2026-07-28" {
+		req.Header.Set("Mcp-Method", message.Method)
+		if name, ok := message.Params["name"].(string); ok {
+			req.Header.Set("Mcp-Name", name)
+		}
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("HTTP %d: %s", w.Code, w.Body.String())
+	}
+	if id := w.Header().Get("Mcp-Session-Id"); id != "" {
+		t.Fatalf("unexpected session ID: %q", id)
+	}
+	payload := w.Body.String()
+	if strings.HasPrefix(w.Header().Get("Content-Type"), "text/event-stream") {
+		payload = ""
+		for line := range strings.SplitSeq(w.Body.String(), "\n") {
+			if strings.HasPrefix(line, "data: ") {
+				payload = strings.TrimPrefix(line, "data: ")
+			}
+		}
+	}
+	var response map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(payload), &response); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, w.Body.String())
+	}
+	return response
+}
+
+func TestHTTPServersStatelessProtocols(t *testing.T) {
+	api := newTestMCPHandler(t, &tools.Toolsets{ProjectToolset: &fakeProjectToolset{}}, nil,
+		mcpaudit.MiddlewareOptions{Emitter: newAuditTestEmitter(t, io.Discard)})
+	for name, handler := range map[string]http.Handler{
+		"api":      api,
+		"observer": observermcp.NewHTTPServer(nil),
+	} {
+		t.Run(name, func(t *testing.T) {
+			discover := statelessRPC(t, handler, "", "2026-07-28",
+				`{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{}}`)
+			var discovery struct {
+				SupportedVersions []string `json:"supportedVersions"`
+			}
+			if err := json.Unmarshal(discover["result"], &discovery); err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Contains(discovery.SupportedVersions, "2026-07-28") {
+				t.Fatalf("new protocol not advertised: %s", discover)
+			}
+			for _, version := range []string{"2025-03-26", "2025-06-18", "2025-11-25", "2026-07-28"} {
+				t.Run(version, func(t *testing.T) {
+					// Listing must work without first initializing a server-side session.
+					response := statelessRPC(t, handler, "", version,
+						`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`)
+					if response["error"] != nil || response["result"] == nil {
+						t.Fatalf("tools/list failed: %s", response)
+					}
+				})
+			}
+			// Legacy clients still initialize and receive their negotiated version.
+			response := statelessRPC(t, handler, "", "2025-06-18",
+				`{"jsonrpc":"2.0","id":2,"method":"initialize","params":`+
+					`{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"legacy","version":"1"}}}`)
+			var result struct {
+				ProtocolVersion string `json:"protocolVersion"`
+			}
+			if err := json.Unmarshal(response["result"], &result); err != nil {
+				t.Fatal(err)
+			}
+			if result.ProtocolVersion != "2025-06-18" {
+				t.Fatalf("negotiated version = %q", result.ProtocolVersion)
+			}
+		})
+	}
+}
+
+type statelessToolset struct{ tools.AllToolsetsHandler }
+
+func TestHTTPServerFiltersEveryRequest(t *testing.T) {
+	all := tools.NewToolsets(&statelessToolset{}, map[tools.ToolsetType]bool{
+		tools.ToolsetProject: true, tools.ToolsetPE: true,
+	})
+	handler := newTestMCPHandler(t, all, &fakeAuditPDP{profile: denyAllAuditProfile()},
+		mcpaudit.MiddlewareOptions{Emitter: newAuditTestEmitter(t, io.Discard)})
+	for _, version := range []string{"2025-06-18", "2026-07-28"} {
+		t.Run(version, func(t *testing.T) {
+			for _, tc := range []struct {
+				query                            string
+				project, environment, deprecated bool
+			}{
+				{"?filterByAuthz=false&includeDeprecatedTools=true", true, true, true},
+				{"?filterByAuthz=false&toolsets=project", true, false, false},
+				{"?filterByAuthz=false&toolsets=pe", false, true, false},
+				{"?filterByAuthz=false", true, true, false},
+				{"?filterByAuthz=true", false, false, false},
+				{"", false, false, false},
+			} {
+				response := statelessRPC(t, handler, tc.query, version,
+					`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`)
+				var result struct {
+					Tools []struct {
+						Name string `json:"name"`
+					} `json:"tools"`
+				}
+				if response["error"] != nil {
+					t.Fatalf("list: %s", response["error"])
+				}
+				if err := json.Unmarshal(response["result"], &result); err != nil {
+					t.Fatal(err)
+				}
+				var project, environment, deprecated bool
+				for _, tool := range result.Tools {
+					project = project || tool.Name == "create_project"
+					environment = environment || tool.Name == "create_environment"
+					deprecated = deprecated || tools.IsDeprecatedTool(tool.Name)
+				}
+				if project != tc.project || environment != tc.environment || deprecated != tc.deprecated {
+					t.Fatalf("%s: project/environment/deprecated = %v/%v/%v, want %v/%v/%v",
+						tc.query, project, environment, deprecated, tc.project, tc.environment, tc.deprecated)
+				}
+			}
+		})
+	}
+}
+
+func TestHTTPServerCallAuthorizationEveryRequest(t *testing.T) {
+	handler := newTestMCPHandler(t, &tools.Toolsets{ProjectToolset: &fakeProjectToolset{}},
+		&fakeAuditPDP{profile: denyAllAuditProfile()},
+		mcpaudit.MiddlewareOptions{Emitter: newAuditTestEmitter(t, io.Discard)})
+	for _, query := range []string{"?filterByAuthz=false", "", "?filterByAuthz=false", "?filterByAuthz=true"} {
+		response := statelessRPC(t, handler, query, "2026-07-28",
+			`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":`+
+				`{"name":"create_project","arguments":{"namespace_name":"test","name":"example"}}}`)
+		denied := response["error"] != nil
+		if denied != (query != "?filterByAuthz=false") {
+			t.Fatalf("%s: unexpected authorization result: %s", query, response)
+		}
+		if !denied {
+			var result struct {
+				IsError bool `json:"isError"`
+			}
+			if err := json.Unmarshal(response["result"], &result); err != nil {
+				t.Fatal(err)
+			}
+			if result.IsError {
+				t.Fatalf("tool failed: %s", response)
+			}
+		}
+	}
+}
+
+func TestHTTPServerSubjectDoesNotPersist(t *testing.T) {
+	handler, err := NewHTTPServer(slog.Default(), &tools.Toolsets{ProjectToolset: &fakeProjectToolset{}},
+		&fakeAuditPDP{profile: allowAllAuditProfile(authzcore.ActionCreateProject)},
+		mcpaudit.MiddlewareOptions{Emitter: newAuditTestEmitter(t, io.Discard)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, authenticated := range []bool{true, false, true} {
+		requestHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if authenticated {
+				r = r.WithContext(auth.SetSubjectContext(r.Context(), &auth.SubjectContext{ID: "test-user", Type: "user"}))
+			}
+			handler.ServeHTTP(w, r)
+		})
+		response := statelessRPC(t, requestHandler, "", "2026-07-28",
+			`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":`+
+				`{"name":"create_project","arguments":{"namespace_name":"test","name":"example"}}}`)
+		if (response["error"] == nil) != authenticated {
+			t.Fatalf("authenticated=%v: %s", authenticated, response)
+		}
+	}
+}

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // captureHandler is a tiny http.Handler that records the request context it
-// observed, so tests can assert that withSessionQueryParams populated it
+// observed, so tests can assert that withRequestQueryParams populated it
 // correctly.
 type captureHandler struct {
 	requestedToolsets map[tools.ToolsetType]bool
@@ -27,7 +27,7 @@ func (h *captureHandler) ServeHTTP(_ http.ResponseWriter, r *http.Request) {
 	h.filterByAuthz, h.hasFilter = tools.FilterByAuthzFromContext(r.Context())
 }
 
-func TestWithSessionQueryParamsParsesToolsets(t *testing.T) {
+func TestWithRequestQueryParamsParsesToolsets(t *testing.T) {
 	tests := []struct {
 		name string
 		url  string
@@ -65,7 +65,7 @@ func TestWithSessionQueryParamsParsesToolsets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cap := &captureHandler{}
-			h := withSessionQueryParams(cap)
+			h := withRequestQueryParams(cap)
 
 			req := httptest.NewRequest(http.MethodPost, tt.url, http.NoBody)
 			h.ServeHTTP(httptest.NewRecorder(), req)
@@ -80,7 +80,7 @@ func TestWithSessionQueryParamsParsesToolsets(t *testing.T) {
 	}
 }
 
-func TestWithSessionQueryParamsAbsentToolsets(t *testing.T) {
+func TestWithRequestQueryParamsAbsentToolsets(t *testing.T) {
 	tests := []struct {
 		name string
 		url  string
@@ -93,7 +93,7 @@ func TestWithSessionQueryParamsAbsentToolsets(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cap := &captureHandler{}
-			h := withSessionQueryParams(cap)
+			h := withRequestQueryParams(cap)
 			req := httptest.NewRequest(http.MethodPost, tt.url, http.NoBody)
 			h.ServeHTTP(httptest.NewRecorder(), req)
 			if cap.hasRequested {
@@ -103,7 +103,7 @@ func TestWithSessionQueryParamsAbsentToolsets(t *testing.T) {
 	}
 }
 
-func TestWithSessionQueryParamsParsesFilterByAuthz(t *testing.T) {
+func TestWithRequestQueryParamsParsesFilterByAuthz(t *testing.T) {
 	tests := []struct {
 		name      string
 		url       string
@@ -122,7 +122,7 @@ func TestWithSessionQueryParamsParsesFilterByAuthz(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cap := &captureHandler{}
-			h := withSessionQueryParams(cap)
+			h := withRequestQueryParams(cap)
 			req := httptest.NewRequest(http.MethodPost, tt.url, http.NoBody)
 			h.ServeHTTP(httptest.NewRecorder(), req)
 			if cap.hasFilter != tt.wantSet {
@@ -135,9 +135,9 @@ func TestWithSessionQueryParamsParsesFilterByAuthz(t *testing.T) {
 	}
 }
 
-func TestWithSessionQueryParamsCombined(t *testing.T) {
+func TestWithRequestQueryParamsCombined(t *testing.T) {
 	cap := &captureHandler{}
-	h := withSessionQueryParams(cap)
+	h := withRequestQueryParams(cap)
 	req := httptest.NewRequest(
 		http.MethodPost,
 		"/mcp?toolsets=namespace,component,pe&filterByAuthz=false",

--- a/pkg/mcp/tools/filter.go
+++ b/pkg/mcp/tools/filter.go
@@ -42,7 +42,7 @@ var (
 // tools/list and tools/call results along two independent axes:
 //
 //  1. Toolset narrowing — when the client requested a specific subset of
-//     toolsets via ?toolsets= on the initialize request, tools/list returns
+//     toolsets via ?toolsets= on the current request, tools/list returns
 //     only tools whose registered toolsets intersect the requested set. This
 //     filter is purely a tools/list visibility helper; tools/call is not
 //     gated by it (clients that bypass tools/list can still call any
@@ -87,7 +87,7 @@ func NewToolFilterMiddleware(
 }
 
 // filterListTools calls the next handler, then narrows the returned tool list
-// by the per-session toolset request and (when enabled) the user's authz
+// by the per-request toolset request and (when enabled) the user's authz
 // capabilities.
 func filterListTools(
 	ctx context.Context,
@@ -155,7 +155,7 @@ func filterListTools(
 
 // filterCallTool checks whether the user is permitted to call the requested tool
 // before forwarding to the next handler. Authz checks are skipped when the
-// per-session filterByAuthz flag is false or no PDP is configured; the service
+// per-request filterByAuthz flag is false or no PDP is configured; the service
 // layer enforces authz independently in those cases.
 func filterCallTool(
 	ctx context.Context,
@@ -218,7 +218,7 @@ func filterCallTool(
 
 // authzFilteringActive reports whether MCP-layer authz filtering should be
 // applied for this request. It is active only when a PDP is configured and the
-// per-session filterByAuthz flag has not been explicitly set to false.
+// per-request filterByAuthz flag has not been explicitly set to false.
 func authzFilteringActive(ctx context.Context, pdp authzcore.PDP) bool {
 	if pdp == nil {
 		return false

--- a/pkg/mcp/tools/integration_test.go
+++ b/pkg/mcp/tools/integration_test.go
@@ -119,14 +119,17 @@ func TestToolErrorHandling(t *testing.T) {
 	mockHandler.calls = make(map[string][]interface{})
 
 	// Try calling the tool with missing required parameter
-	_, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+	result, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
 		Name:      testSpec.name,
 		Arguments: map[string]any{}, // Empty arguments - missing required params
 	})
 
-	// We expect an error for missing required parameters
-	if err == nil {
-		t.Errorf("Expected error for tool %q with missing required parameters, got nil", testSpec.name)
+	// The SDK reports input validation failures as tool errors, not protocol errors.
+	if err != nil {
+		t.Fatalf("CallTool protocol error: %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Errorf("Expected tool error for %q with missing required parameters", testSpec.name)
 	}
 
 	// Verify the handler was NOT called (validation should fail before reaching handler)

--- a/pkg/mcp/tools/scoped_test.go
+++ b/pkg/mcp/tools/scoped_test.go
@@ -152,14 +152,20 @@ func TestScopedToolNamespaceRequiredForNamespaceScope(t *testing.T) {
 }
 
 func TestScopedToolInvalidScope(t *testing.T) {
-	cs, _ := setupScopedTestServer(t, context.Background(), nil)
-	// The `scope` argument is constrained by an enum in the input schema, so an
-	// out-of-range value is rejected at the protocol layer before the handler runs.
-	if _, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+	cs, mock := setupScopedTestServer(t, context.Background(), nil)
+	// The SDK rejects an out-of-range scope as a tool error before the handler runs.
+	result, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
 		Name:      "list_component_types",
 		Arguments: map[string]any{"scope": "galaxy"},
-	}); err == nil {
-		t.Errorf("expected an error for an invalid scope value")
+	})
+	if err != nil {
+		t.Fatalf("CallTool protocol error: %v", err)
+	}
+	if result == nil || !result.IsError {
+		t.Errorf("expected a tool error for an invalid scope value")
+	}
+	if len(mock.calls) != 0 {
+		t.Errorf("handler called with invalid scope: %v", mock.calls)
 	}
 }
 

--- a/pkg/mcp/tools/types.go
+++ b/pkg/mcp/tools/types.go
@@ -29,11 +29,11 @@ const (
 // the client requested via the ?toolsets= query param.
 type requestedToolsetsCtxKey struct{}
 
-// filterByAuthzCtxKey is the context key used to carry the per-session
+// filterByAuthzCtxKey is the context key used to carry the per-request
 // filterByAuthz flag from the ?filterByAuthz= query param.
 type filterByAuthzCtxKey struct{}
 
-// includeDeprecatedToolsCtxKey is the context key used to carry the per-session
+// includeDeprecatedToolsCtxKey is the context key used to carry the per-request
 // includeDeprecatedTools flag from the ?includeDeprecatedTools= query param.
 type includeDeprecatedToolsCtxKey struct{}
 
@@ -48,21 +48,21 @@ func WithRequestedToolsets(ctx context.Context, requested map[ToolsetType]bool) 
 }
 
 // RequestedToolsetsFromContext returns the set of toolsets the client requested
-// for this session, if any. The second return value reports whether the client
+// for this request, if any. The second return value reports whether the client
 // supplied any narrowing.
 func RequestedToolsetsFromContext(ctx context.Context) (map[ToolsetType]bool, bool) {
 	v, ok := ctx.Value(requestedToolsetsCtxKey{}).(map[ToolsetType]bool)
 	return v, ok && len(v) > 0
 }
 
-// WithFilterByAuthz returns a copy of ctx carrying the per-session decision of
+// WithFilterByAuthz returns a copy of ctx carrying the per-request decision of
 // whether to apply MCP-layer authz filtering. The default (no value in ctx) is
 // true.
 func WithFilterByAuthz(ctx context.Context, filter bool) context.Context {
 	return context.WithValue(ctx, filterByAuthzCtxKey{}, filter)
 }
 
-// FilterByAuthzFromContext returns the per-session filterByAuthz flag if the
+// FilterByAuthzFromContext returns the per-request filterByAuthz flag if the
 // client explicitly supplied one. The second return value reports whether a
 // value was set; callers should default to true when not set.
 func FilterByAuthzFromContext(ctx context.Context) (bool, bool) {
@@ -70,7 +70,7 @@ func FilterByAuthzFromContext(ctx context.Context) (bool, bool) {
 	return v, ok
 }
 
-// WithIncludeDeprecatedTools returns a copy of ctx carrying the per-session
+// WithIncludeDeprecatedTools returns a copy of ctx carrying the per-request
 // decision of whether tools/list should include deprecated compatibility-alias
 // tools. The default (no value in ctx) is false as of v1.2: deprecated aliases
 // are hidden from tools/list, though they remain callable and still return a
@@ -83,7 +83,7 @@ func WithIncludeDeprecatedTools(ctx context.Context, include bool) context.Conte
 }
 
 // IncludeDeprecatedToolsFromContext reports whether tools/list should include
-// the deprecated compatibility-alias tools for this session. Defaults to false
+// the deprecated compatibility-alias tools for this request. Defaults to false
 // when the client did not set the flag.
 func IncludeDeprecatedToolsFromContext(ctx context.Context) bool {
 	v, ok := ctx.Value(includeDeprecatedToolsCtxKey{}).(bool)


### PR DESCRIPTION
## Purpose

Both MCP HTTP servers currently use stateful sessions with go-sdk v1.4.1. Upgrade to v1.7.0 and enable stateless HTTP so they support MCP 2026-07-28 while retaining legacy protocol flows.

## Approach

- Enable Stateless on both the API and Observer HTTP handlers.
- Keep toolsets, filterByAuthz, and includeDeprecatedTools scoped to each request; rename the query wrapper and update session-oriented comments.
- Add HTTP regression coverage for discovery, supported protocol versions, legacy initialization, absence of session IDs, per-request filtering and authorization, and authenticated-context isolation.
- Adapt validation tests to the SDK's tool-error response contract, retaining checks that invalid arguments do not invoke handlers.

## Related Issues

Fixes #4466.

## Checklist

- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (not applicable)
- [ ] Added backport label (not requested)
- [x] This PR includes AI-generated code or content

## Remarks

Validation on Windows with Go 1.26.8:

- `go test ./pkg/mcp/... ./internal/observer/mcp/...`: passed all four packages.
- `golangci-lint run ./pkg/mcp/... ./internal/observer/mcp/...` (v2.8.0): 0 issues.
- Changed-file license headers, final newlines, and `git diff --cached --check`: passed.
- Linux amd64 cross-builds of `cmd/openchoreo-api` and `cmd/observer`: passed; no live Linux/Kubernetes deployment tested.
- Repository-wide Go tests excluding e2e, with a 60-second per-package timeout: 178 packages passed; 42 failed. All 42 failing packages and the same failing test-name set reproduced on the unmodified upstream baseline. Failures include platform/path/permission/line-ending assumptions and unavailable or timed-out Kubernetes test infrastructure. The full suite is not green on this Windows environment and should run in Linux CI.
