### PR TITLE
feat(api): register portal-assistant:invoke and add chart roles validation test (#4683)

### DIFF
--- a/internal/authz/core/actions.go
+++ b/internal/authz/core/actions.go
@@ -298,6 +298,9 @@ const (
 
 	// Delivery insights (DORA metrics) actions
 	ActionViewDeliveryInsights = "deliveryinsights:view"
+
+	// PortalAssistant actions
+	ActionInvokePortalAssistant = "portal-assistant:invoke"
 )
 
 // Action represents a system action with metadata
@@ -575,6 +578,9 @@ var systemActions = []Action{
 
 	// Platform logs observability
 	{Name: ActionViewPlatformLogs, LowestScope: ScopeCluster, IsInternal: false},
+
+	// Portal assistant
+	{Name: ActionInvokePortalAssistant, LowestScope: ScopeCluster, IsInternal: false},
 }
 
 // AllActions returns all system-defined actions

--- a/internal/authz/core/actions_test.go
+++ b/internal/authz/core/actions_test.go
@@ -225,3 +225,23 @@ func TestActionViewDeliveryInsightsRegistered(t *testing.T) {
 	require.False(t, found.IsInternal,
 		"%s is granted to roles, so it must not be internal-only", ActionViewDeliveryInsights)
 }
+
+// TestActionInvokePortalAssistantRegistered pins the Portal Assistant invoke action and its
+// metadata. It is invoked at cluster scope for chat and warmup endpoints.
+func TestActionInvokePortalAssistantRegistered(t *testing.T) {
+	var found *Action
+	for i := range PublicActions() {
+		if PublicActions()[i].Name == ActionInvokePortalAssistant {
+			found = &PublicActions()[i]
+			break
+		}
+	}
+
+	require.NotNil(t, found, "%s must be registered as a public action", ActionInvokePortalAssistant)
+	require.Equal(t, "portal-assistant:invoke", ActionInvokePortalAssistant,
+		"the action name is referenced by role grants in values.yaml and portal-assistant auth, and must not drift")
+	require.Equal(t, ScopeCluster, found.LowestScope,
+		"portal-assistant is invoked at cluster scope")
+	require.False(t, found.IsInternal,
+		"%s is granted to roles, so it must not be internal-only", ActionInvokePortalAssistant)
+}

--- a/internal/authz/core/chart_roles_test.go
+++ b/internal/authz/core/chart_roles_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 The OpenChoreo Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package core
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+type chartValues struct {
+	OpenchoreoAPI struct {
+		Config struct {
+			Security struct {
+				Authorization struct {
+					Bootstrap struct {
+						Roles []struct {
+							Name    string   `yaml:"name"`
+							Actions []string `yaml:"actions"`
+						} `yaml:"roles"`
+					} `yaml:"bootstrap"`
+				} `yaml:"authorization"`
+			} `yaml:"security"`
+		} `yaml:"config"`
+	} `yaml:"openchoreoApi"`
+}
+
+func TestBootstrapRoles_ActionValidity(t *testing.T) {
+	valuesPath := filepath.Join("..", "..", "..", "install", "helm", "openchoreo-control-plane", "values.yaml")
+	data, err := os.ReadFile(valuesPath)
+	require.NoError(t, err, "failed to read control plane values.yaml")
+
+	var values chartValues
+	err = yaml.Unmarshal(data, &values)
+	require.NoError(t, err, "failed to parse control plane values.yaml")
+
+	roles := values.OpenchoreoAPI.Config.Security.Authorization.Bootstrap.Roles
+	require.NotEmpty(t, roles, "bootstrap.roles in values.yaml must not be empty")
+
+	validActions := make(map[string]bool)
+	for _, a := range ConcretePublicActions() {
+		validActions[a.Name] = true
+	}
+
+	for _, role := range roles {
+		t.Run(role.Name, func(t *testing.T) {
+			require.NotEmpty(t, role.Actions, "role %s must have actions", role.Name)
+			for _, action := range role.Actions {
+				if action == "*" {
+					continue
+				}
+				require.Truef(t, validActions[action],
+					"role %q grants action %q which is not registered in core.ConcretePublicActions()",
+					role.Name, action)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Purpose
Resolves openchoreo/openchoreo#4683 (codebase portion).

During the authorization audit in #4683, `portal-assistant:invoke` was found to be granted to `platform-engineer` and `developer` roles in Helm chart values (`install/helm/openchoreo-control-plane/values.yaml`), and actively enforced by `AuthRuntime` in `agents/portal-assistant/src/auth.py` and `agent_routes.py`. However, it was missing from the registry in `internal/authz/core/actions.go`.

This PR formally registers `ActionInvokePortalAssistant` and introduces an automated drift-guard test to prevent future divergence between Helm bootstrap roles and the core action registry.

## Approach
1. Registered `ActionInvokePortalAssistant = "portal-assistant:invoke"` in `internal/authz/core/actions.go` with lowest scope `ScopeCluster` and `IsInternal: false`.
2. Added `internal/authz/core/chart_roles_test.go` (`TestBootstrapRoles_ActionValidity`) which parses `install/helm/openchoreo-control-plane/values.yaml` and validates that every action granted across all bootstrap roles exists in `core.ConcretePublicActions()`.

## Related Issues
- openchoreo/openchoreo#4683
- Docs PR: openchoreo/openchoreo.github.io#857

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [ ] Added `backport/<release-branch>` label if this should be backported (e.g., `backport/release-v1.0`)
- [ ] This PR includes AI-generated code or content

## Remarks
Documentation updates bringing the 165 actions and 11 default roles up to date are submitted in companion PR: https://github.com/openchoreo/openchoreo.github.io/pull/857